### PR TITLE
Scrolling demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+### Added
+- Hardware scrolling, wired live end-to-end. Declare a scrolling region by wrapping
+  any region in `engine::ScrollRegion<Inner, MapW, MapH>` inside a `DisplayLayout`,
+  bind a game-held `engine::TileMap` as its source with `Game::scroll_map(map)`, and
+  drive it with `Game::scroll.move()` / `Game::scroll.set()`. The frame service splits
+  the position into fine (HSCROL/VSCROL) and coarse (per-line LMS) scroll, clamps at the
+  map edges, and keeps the tile viewport (`Game::tiles`) in sync automatically.
+- Scroll validation demo building to `atari_scroll_test.xex` — a 64×32 tilemap scrolled
+  under a fixed HUD. Builds independently of `atari_hw_test`.
+- Backend ANTIC scroll geometry: `DL_HSCROLL` / `DL_VSCROLL`, `scroll_margin`,
+  `scroll_fetch_width`, and `fine_scroll_range` (`platform/atari/antic.h`), plus a
+  per-line-LMS scroll-aware display-program builder with `patch_scroll`
+  (`platform/atari/display_list.h`).
+
+### Changed
+- `ScrollManager` reworked into a portable fine/coarse split: it owns the position and
+  the fine-register writes (via `Platform::hal`) and exposes `coarse_col()` /
+  `coarse_row()`; the backend display program owns all load-address patching. The
+  per-axis fine-scroll inversion and the fetch width are supplied by the backend through
+  display traits, so the generic scroll layer names no ANTIC specifics (Dependency Rule 2).
+
 ## [0.1.0] - 2026-05-31
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,15 @@ if(EDGE_BUILD_DEMO)
     # the build stays -Os and no -g/DWARF is added.
     target_link_options(atari_hw_test PRIVATE
         "LINKER:--Map=$<TARGET_FILE_DIR:atari_hw_test>/atari_hw_test.map")
+
+    # Scroll validation demo — separate, independent .xex (no charset header).
+    add_executable(atari_scroll_test demo/atari_scroll_test.cpp)
+    target_compile_options(atari_scroll_test PRIVATE
+        -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra)
+    target_include_directories(atari_scroll_test PRIVATE ${CMAKE_SOURCE_DIR})
+    set_target_properties(atari_scroll_test PROPERTIES OUTPUT_NAME "atari_scroll_test.xex")
+    target_link_options(atari_scroll_test PRIVATE
+        "LINKER:--Map=$<TARGET_FILE_DIR:atari_scroll_test>/atari_scroll_test.map")
     return()
 endif()
 
@@ -104,6 +113,27 @@ if(MOS_ATARI8_CXX)
         COMMENT "Building Atari XEX demo (atari_hw_test.xex)"
         VERBATIM)
     add_custom_target(atari_hw_test DEPENDS ${HW_TEST_XEX})
+
+    # ── Scroll validation demo (atari_scroll_test.xex) ──────────────────
+    # Same mos-atari8-dos toolchain, built explicitly and independently of the
+    # hw_test demo and the mos-sim test suite:
+    #
+    #   cmake --build build --target atari_scroll_test   # -> build/atari_scroll_test.xex
+    set(SCROLL_TEST_XEX ${CMAKE_BINARY_DIR}/atari_scroll_test.xex)
+    set(SCROLL_TEST_MAP ${CMAKE_BINARY_DIR}/atari_scroll_test.map)
+    add_custom_command(
+        OUTPUT ${SCROLL_TEST_XEX}
+        COMMAND ${MOS_ATARI8_CXX}
+                -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra
+                -I${CMAKE_SOURCE_DIR}
+                ${CMAKE_SOURCE_DIR}/demo/atari_scroll_test.cpp
+                -o ${SCROLL_TEST_XEX}
+                -Wl,--Map=${SCROLL_TEST_MAP}
+        DEPENDS ${CMAKE_SOURCE_DIR}/demo/atari_scroll_test.cpp
+        BYPRODUCTS ${SCROLL_TEST_MAP}
+        COMMENT "Building Atari XEX demo (atari_scroll_test.xex)"
+        VERBATIM)
+    add_custom_target(atari_scroll_test DEPENDS ${SCROLL_TEST_XEX})
 else()
-    message(STATUS "mos-atari8-dos-clang++ not found; 'atari_hw_test' demo target unavailable")
+    message(STATUS "mos-atari8-dos-clang++ not found; 'atari_hw_test'/'atari_scroll_test' demo targets unavailable")
 endif()

--- a/demo/README.md
+++ b/demo/README.md
@@ -61,3 +61,42 @@ The one backend seam worth calling out is the deferred-frame ISR install:
 trampoline that preserves the llvm-mos zero-page registers and exits via
 `JMP XITVBV` — without it, `Game::run()` would crash on real hardware (it is never
 exercised under `mos-sim`, which has no NMI).
+
+# Scroll validation demo (`atari_scroll_test.xex`)
+
+A second, independent demo that exercises the hardware scroll subsystem and the
+Tile infrastructure: a fixed two-row HUD over a 22-row window onto a 64×32
+`engine::TileMap`, scrolled with the joystick. The game loop only calls
+`Game::scroll.move()`; the engine splits the position into fine (HSCROL/VSCROL)
+and coarse (per-line LMS) scroll each frame. It uses the default OS font, so —
+unlike `atari_hw_test` — it has no charset/asset dependency.
+
+## Build
+
+```sh
+cmake --build build --target atari_scroll_test          # -> build/atari_scroll_test.xex
+```
+
+Or with the dedicated Atari toolchain configure (`EDGE_BUILD_DEMO=ON`, as above),
+or manually:
+
+```sh
+mos-atari8-dos-clang++ -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra \
+    -I. demo/atari_scroll_test.cpp -o atari_scroll_test.xex
+```
+
+## What to look for
+
+| Observation | Proves |
+|---|---|
+| Push right/left → field scrolls right/left; up/down likewise | fine + coarse scroll, correct directions |
+| `*` origin marker sits at the field's top-left at scroll (0,0) | map-to-screen alignment (HSCROLL margin handled) |
+| Column ruler reads `00 01 02 …` across, row ruler `00 01 02 …` down | per-line LMS addressing, no tearing |
+| Tile boundaries stay seamless through a fine→coarse step | fine/coarse handoff |
+| Scrolling stops cleanly at every map edge | edge clamping (to the fetch width) |
+| HUD (`X` / `Y` / frame) stays fixed while the field scrolls | mixed scroll + non-scroll layout |
+
+The `#` left-margin column is intentionally **not** visible — it lives in the
+left border (the HSCROLL fetch margin). See the ANTIC scroll quirks captured in
+the engine memory / [`engine/scroll.h`](../engine/scroll.h) and ADR-027 in
+[`docs/DECISIONS.md`](../docs/DECISIONS.md).

--- a/demo/atari_scroll_test.cpp
+++ b/demo/atari_scroll_test.cpp
@@ -48,6 +48,13 @@ using Platform = atari::Platform<
 static constexpr u16 kMapW = 64;
 static constexpr u16 kMapH = 32;
 
+// Horizontal scroll margin: enabling HSCROLL makes ANTIC fetch a wider line
+// (Mode 2: 48 bytes vs 40), so the displayed window sits this many columns into
+// the fetched data and the leftmost columns fall in the left border. Reserving
+// these columns as off-screen margin puts logical column 0 at the visible edge.
+// (= scroll_margin(MODE_2) / 2.)
+static constexpr u16 kMargin = 4;
+
 struct ScrollScreen {
     // Region 0: a fixed 2-row Mode-2 HUD. Region 1: a 22-row Mode-2 window that
     // scrolls over the 64x32 map. ANTIC renders the regions top-to-bottom, so the
@@ -72,19 +79,33 @@ static engine::TileMap<kMapW, kMapH> g_map;
 // ASCII -> ANTIC internal screen code, for direct tile writes.
 static inline u8 g(char c) { return M::ascii_to_internal(c); }
 
-// Fill the map with a coordinate grid (left ruler = row number, every 4th column
-// = column-number marker, checkerboard elsewhere).
+// Fill the map with a coordinate grid, offset right by kMargin so logical column
+// 0 sits at the visible left edge once the HSCROLL margin is accounted for:
+//   physical cols 0..kMargin-1 : '#' left margin (lives in the border)
+//   logical (c-kMargin), rows 0-1 : 2-digit COLUMN ruler (tens / ones)
+//   logical col 0-1 (cols kMargin, kMargin+1) : 2-digit ROW ruler
+//   logical (0,0)              : a '*' origin marker
+//   elsewhere                 : '.' texture
+// At scroll (0,0) the field's top-left cell should now be '*', the top two rows
+// read 00 01 02 ... across, and the left two columns 00 01 02 ... down.
 static void fill_map() {
     for (u16 r = 0; r < kMapH; ++r) {
         for (u16 c = 0; c < kMapW; ++c) {
             u8 t;
-            if (c == 0)            t = g(static_cast<char>('0' + (r / 10)));  // row tens
-            else if (c == 1)       t = g(static_cast<char>('0' + (r % 10)));  // row ones
-            else if ((c & 3) == 0) t = g(static_cast<char>('0' + (c % 10)));  // column marker
-            else                   t = g(((r + c) & 1) ? '.' : ':');          // texture
+            if (c < kMargin) {
+                t = g('#');                                     // left margin / border
+            } else {
+                const u16 lc = static_cast<u16>(c - kMargin);   // logical column
+                if (r == 0)       t = g(static_cast<char>('0' + (lc / 10) % 10));  // col tens
+                else if (r == 1)  t = g(static_cast<char>('0' + (lc % 10)));       // col ones
+                else if (lc == 0) t = g(static_cast<char>('0' + (r / 10) % 10));   // row tens
+                else if (lc == 1) t = g(static_cast<char>('0' + (r % 10)));        // row ones
+                else              t = g('.');                                      // texture
+            }
             g_map.set_tile(c, r, t);
         }
     }
+    g_map.set_tile(kMargin, 0, g('*'));   // logical origin (0,0)
 }
 
 // ── Game state ────────────────────────────────────────────────────────────

--- a/demo/atari_scroll_test.cpp
+++ b/demo/atari_scroll_test.cpp
@@ -1,0 +1,137 @@
+// demo/atari_scroll_test.cpp — Edge engine ANTIC hardware-scroll validation demo.
+//
+// A minimal Atari program that exercises the engine's hardware scroll path and
+// the Tile infrastructure, producing a loadable .xex (build with the
+// mos-atari8-dos target; see CMakeLists.txt). It is the scroll counterpart to
+// atari_hw_test.cpp and is meant to be run on Altirra / Fujisan as a visual
+// confirmation that per-line-LMS scrolling works on real silicon:
+//
+//   Top 2 rows : fixed HUD — live scroll X, Y and a frame counter (does NOT
+//                scroll, so the coordinates stay readable).
+//   Below      : a 22-row Mode-2 window onto a 64x32 tilemap. Joystick scrolls
+//                the window through the map; the engine splits the position into
+//                fine (HSCROL/VSCROL) and coarse (per-line LMS) automatically.
+//
+// The map is an engine::TileMap<64,32> in RAM (a tile index is the ANTIC screen
+// code in Mode 2, so the map serves directly as scroll screen memory). It is
+// filled with a coordinate grid so any scroll glitch is obvious: the left two
+// columns are the row number, every 4th column carries a column-number marker,
+// and the rest is a checkerboard texture.
+//
+// ── Pure engine API ──────────────────────────────────────────────────────
+//
+// Every hardware interaction goes through engine::Core / Platform::hal — no
+// poke()s, no inline assembly, no magic addresses. The game loop only calls
+// Game::scroll.move(); the engine's frame service writes the fine-scroll
+// registers and repoints the display-list LMS each frame. This file is meant to
+// read as example game code.
+
+#include <stdint.h>
+
+#include <engine/platform/atari/platform.h>
+#include <engine/core.h>
+
+using engine::u8;
+using engine::u16;
+namespace M = atari;
+
+// ── Platform + game configuration ────────────────────────────────────────
+
+using Platform = atari::Platform<
+    atari::Machine::XL,
+    atari::RAM::Baseline,
+    atari::Graphics::Baseline,
+    atari::Sound::Mono,
+    atari::TV::NTSC>;
+
+// Map geometry (cells). The scroll region's MapW/MapH must match g_map.
+static constexpr u16 kMapW = 64;
+static constexpr u16 kMapH = 32;
+
+struct ScrollScreen {
+    // Region 0: a fixed 2-row Mode-2 HUD. Region 1: a 22-row Mode-2 window that
+    // scrolls over the 64x32 map. ANTIC renders the regions top-to-bottom, so the
+    // HUD simply omits the scroll bits and stays put while the field below moves.
+    using display = engine::DisplayLayout<
+        engine::TextRegion<M::Mode::MODE_2, 2>,
+        engine::ScrollRegion<engine::TextRegion<M::Mode::MODE_2, 22>, kMapW, kMapH>>;
+};
+
+struct GameConfig {
+    using screens = engine::ScreenSet<ScrollScreen>;
+    static constexpr u8 max_sprites    = 1;
+    static constexpr u8 sound_channels = 1;
+};
+
+using Game = engine::Core<Platform, GameConfig>;
+
+// ── The scroll map (RAM-resident; ANTIC reads it via DMA) ─────────────────
+
+static engine::TileMap<kMapW, kMapH> g_map;
+
+// ASCII -> ANTIC internal screen code, for direct tile writes.
+static inline u8 g(char c) { return M::ascii_to_internal(c); }
+
+// Fill the map with a coordinate grid (left ruler = row number, every 4th column
+// = column-number marker, checkerboard elsewhere).
+static void fill_map() {
+    for (u16 r = 0; r < kMapH; ++r) {
+        for (u16 c = 0; c < kMapW; ++c) {
+            u8 t;
+            if (c == 0)            t = g(static_cast<char>('0' + (r / 10)));  // row tens
+            else if (c == 1)       t = g(static_cast<char>('0' + (r % 10)));  // row ones
+            else if ((c & 3) == 0) t = g(static_cast<char>('0' + (c % 10)));  // column marker
+            else                   t = g(((r + c) & 1) ? '.' : ':');          // texture
+            g_map.set_tile(c, r, t);
+        }
+    }
+}
+
+// ── Game state ────────────────────────────────────────────────────────────
+
+static u16 g_frame = 0;
+
+// ── Per-frame logic (runs once per VBI via Game::run) ────────────────────
+
+static void frame_step(const engine::Input& in) {
+    // Joystick scrolls the window. X is in fine (color-clock) units, Y in
+    // scanlines; the engine clamps at the map edges and handles fine<->coarse.
+    if (in.left())  Game::scroll.move(-1, 0);
+    if (in.right()) Game::scroll.move(1, 0);
+    if (in.up())    Game::scroll.move(0, -1);
+    if (in.down())  Game::scroll.move(0, 1);
+
+    ++g_frame;
+
+    // HUD: live scroll position + frame counter (region 0, the fixed rows).
+    Game::print_num(2,  1, Game::scroll.x(), 3);
+    Game::print_num(9,  1, Game::scroll.y(), 3);
+    Game::print_num(15, 1, g_frame, 5);
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────
+
+int main() {
+    // Builds the display list (the scroll region gets one LMS per visible line),
+    // programs the OS shadows, arms the dispatcher, and installs the VBI service.
+    // No charset is loaded, so the default OS font renders the grid + HUD.
+    Game::init();
+
+    // Playfield colours via the OS shadows (field map: 0-3 = COLPF0-3, 4 = COLBK).
+    Platform::hal::set_color_pf(4, 0x90);   // COLBK  : dark blue background
+    Platform::hal::set_color_pf(2, 0x90);   // COLPF2 : text background
+    Platform::hal::set_color_pf(1, 0x0E);   // COLPF1 : text luminance (white)
+
+    // Fill the map, then bind it as the scroll source and start scrolling.
+    fill_map();
+    Game::scroll_map(g_map);
+
+    // Static HUD labels (written once into the fixed top region).
+    Game::print(0, 0, "EDGE SCROLL TEST");
+    Game::print(0, 1, "X:");
+    Game::print(7, 1, "Y:");
+    Game::print(13, 1, "F:");
+
+    // One callback per frame, forever.
+    Game::run(frame_step);
+}

--- a/engine/core.h
+++ b/engine/core.h
@@ -193,8 +193,31 @@ public:
     static auto& region() { return screen.template region<S, N>(); }
 
     // ── Screen transition ──
+    // Deactivate scroll on every transition; a scroll screen re-arms it via
+    // scroll_map() once the game has bound its map buffer.
     template <typename S, typename Cb>
-    static void set_screen(Cb cb) { screen.template set_screen<S>(cb); }
+    static void set_screen(Cb cb) {
+        scroll.deactivate();
+        screen.template set_screen<S>(cb);
+    }
+
+    // ── Scroll map binding ──
+    //
+    // Bind a game-held map (an engine::TileMap, or any value exposing `tiles[]`
+    // and a `width` constant) as screen S's scroll source and start scrolling.
+    // Call after init(). The map's width/height must match the screen's scroll
+    // region (checked at compile time). The frame service then drives the fine
+    // registers and the per-line LMS from Game::scroll's position every frame.
+    template <typename Map, typename S = InitialScreen>
+    static void scroll_map(Map& m) {
+        using Layout = typename S::display;
+        static constexpr u8 idx = Layout::scroll_region_index();
+        static_assert(Layout::region_map_width[idx] == Map::width,
+                      "scroll map width does not match the screen's scroll region");
+        static_assert(Layout::region_map_height[idx] == Map::height,
+                      "scroll map height does not match the screen's scroll region");
+        screen.template bind_scroll_map<S>(scroll, &m.tiles[0], Map::width);
+    }
 
     // ── Game loop forwarders (loop.h) ──
     template <typename Cb>
@@ -217,6 +240,12 @@ public:
         u8 joy[kPorts];
         for (u8 p = 0; p < kPorts; ++p) joy[p] = Platform::hal::read_joystick(p);
         input.update(joy, Platform::hal::read_keyboard());
+
+        // 1b. Scroll: write the fine registers and repoint the scroll-region LMS
+        //     for the current viewport, and keep the tile viewport coherent. No-op
+        //     unless a scroll map is bound (Dependency: screen owns the LMS bytes).
+        screen.apply_scroll(scroll);
+        tiles.set_viewport(scroll.x(), scroll.y());
 
         // 2. Sound envelopes.
         sound.tick();

--- a/engine/core.h
+++ b/engine/core.h
@@ -207,7 +207,8 @@ public:
     // and a `width` constant) as screen S's scroll source and start scrolling.
     // Call after init(). The map's width/height must match the screen's scroll
     // region (checked at compile time). The frame service then drives the fine
-    // registers and the per-line LMS from Game::scroll's position every frame.
+    // registers and the scroll-region load addresses from Game::scroll's position
+    // every frame.
     template <typename Map, typename S = InitialScreen>
     static void scroll_map(Map& m) {
         using Layout = typename S::display;
@@ -241,9 +242,10 @@ public:
         for (u8 p = 0; p < kPorts; ++p) joy[p] = Platform::hal::read_joystick(p);
         input.update(joy, Platform::hal::read_keyboard());
 
-        // 1b. Scroll: write the fine registers and repoint the scroll-region LMS
-        //     for the current viewport, and keep the tile viewport coherent. No-op
-        //     unless a scroll map is bound (Dependency: screen owns the LMS bytes).
+        // 1b. Scroll: write the fine registers and repoint the scroll-region load
+        //     addresses for the current viewport, and keep the tile viewport
+        //     coherent. No-op unless a scroll map is bound (the screen owns the
+        //     display-program bytes).
         screen.apply_scroll(scroll);
         tiles.set_viewport(scroll.x(), scroll.y());
 

--- a/engine/display.h
+++ b/engine/display.h
@@ -195,8 +195,9 @@ struct BitmapRegion {
 // hardware-scrolling region over a `MapW`×`MapH` map. The inner region supplies
 // the mode, the visible height, and the view type (so a scroll region draws with
 // the same view as its non-scroll counterpart); the wrapper adds the map geometry
-// and the `is_scroll` flag the display-list builder reads to emit one LMS per
-// visible line (with the HSCROLL/VSCROLL bits) striding by `map_width`.
+// and the `is_scroll` flag the backend display-program builder reads to give each
+// visible line its own load address (with the fine-scroll enable) striding by
+// `map_width`.
 //
 // `ram_bytes` is 0: a scroll region's pixels live in the game-held map buffer the
 // engine binds at scroll_map() time, not in the shared screen buffer, so it costs

--- a/engine/display.h
+++ b/engine/display.h
@@ -162,9 +162,13 @@ struct TextRegion {
     static constexpr mode_type mode           = M;
     static constexpr u8        height         = Height;   // text rows
     static constexpr bool      is_text        = true;
+    static constexpr bool      is_scroll      = false;
     static constexpr u8        bytes_per_line =
         engine::display::traits<mode_type>::bytes_per_line(M);
     static constexpr u16       ram_bytes      = static_cast<u16>(Height) * bytes_per_line;
+    // For a non-scroll region the "map" is exactly the on-screen region.
+    static constexpr u16       map_width      = bytes_per_line;
+    static constexpr u16       map_height     = Height;
 
     using view = TextRegionView<M, Height>;
 };
@@ -175,11 +179,43 @@ struct BitmapRegion {
     static constexpr mode_type mode           = M;
     static constexpr u8        height         = Height;   // scanlines / mode-lines
     static constexpr bool      is_text        = false;
+    static constexpr bool      is_scroll      = false;
     static constexpr u8        bytes_per_line =
         engine::display::traits<mode_type>::bytes_per_line(M);
     static constexpr u16       ram_bytes      = static_cast<u16>(Height) * bytes_per_line;
+    static constexpr u16       map_width      = bytes_per_line;
+    static constexpr u16       map_height     = Height;
 
     using view = BitmapRegionView<M, Height>;
+};
+
+// ── ScrollRegion ──────────────────────────────────────────────────────
+//
+// A mode-agnostic wrapper that turns any TextRegion / BitmapRegion into a
+// hardware-scrolling region over a `MapW`×`MapH` map. The inner region supplies
+// the mode, the visible height, and the view type (so a scroll region draws with
+// the same view as its non-scroll counterpart); the wrapper adds the map geometry
+// and the `is_scroll` flag the display-list builder reads to emit one LMS per
+// visible line (with the HSCROLL/VSCROLL bits) striding by `map_width`.
+//
+// `ram_bytes` is 0: a scroll region's pixels live in the game-held map buffer the
+// engine binds at scroll_map() time, not in the shared screen buffer, so it costs
+// nothing there and contributes nothing to the following regions' offsets. MapW/
+// MapH are in the inner region's native units (text: columns/rows; bitmap:
+// bytes-per-line/scanlines).
+template <typename Inner, u16 MapW, u16 MapH>
+struct ScrollRegion {
+    using mode_type = typename Inner::mode_type;
+    static constexpr mode_type mode           = Inner::mode;
+    static constexpr u8        height         = Inner::height;   // visible rows / lines
+    static constexpr bool      is_text        = Inner::is_text;
+    static constexpr bool      is_scroll      = true;
+    static constexpr u8        bytes_per_line = Inner::bytes_per_line;
+    static constexpr u16       ram_bytes      = 0;               // backed by the map buffer
+    static constexpr u16       map_width      = MapW;
+    static constexpr u16       map_height     = MapH;
+
+    using view = typename Inner::view;
 };
 
 // ── Pack indexing helper ──────────────────────────────────────────────
@@ -223,6 +259,20 @@ struct DisplayLayout {
     static constexpr u8  region_bytes_per_line[region_count] =
         { Regions::bytes_per_line... };
     static constexpr bool region_is_text[region_count]       = { Regions::is_text... };
+    // Scroll metadata (non-scroll regions report is_scroll=false, map == region).
+    static constexpr bool region_is_scroll[region_count]     = { Regions::is_scroll... };
+    static constexpr u16 region_map_width[region_count]      = { Regions::map_width... };
+    static constexpr u16 region_map_height[region_count]     = { Regions::map_height... };
+
+    // True if any region in this layout scrolls.
+    static constexpr bool has_scroll = (Regions::is_scroll || ... || false);
+
+    // Index of the first scrolling region, or region_count if none.
+    static constexpr u8 scroll_region_index() {
+        for (u8 i = 0; i < region_count; ++i)
+            if (region_is_scroll[i]) return i;
+        return region_count;
+    }
 
     // Byte offset of region n into the shared screen buffer.
     static constexpr u16 offset(u8 n) {

--- a/engine/display_traits.h
+++ b/engine/display_traits.h
@@ -19,6 +19,8 @@
 //   static constexpr u8   scanlines_per_line(ModeT); // mode-line height
 //   static constexpr u8   mode_opcode(ModeT);        // backend display-program byte
 //   static constexpr u8   to_screen_code(char);      // ASCII -> screen tile code
+//   static constexpr u8   fine_scroll_range(ModeT);  // horizontal fine-scroll modulus
+//                                                    //   (only used by scroll-active screens)
 //
 // Depends only on types.h.
 

--- a/engine/display_traits.h
+++ b/engine/display_traits.h
@@ -20,7 +20,8 @@
 //   static constexpr u8   mode_opcode(ModeT);        // backend display-program byte
 //   static constexpr u8   to_screen_code(char);      // ASCII -> screen tile code
 //   static constexpr u8   fine_scroll_range(ModeT);  // horizontal fine-scroll modulus
-//                                                    //   (only used by scroll-active screens)
+//   static constexpr u8   scroll_fetch_width(ModeT); // bytes fetched per scrolled line
+//                                                    //   (both only used by scroll-active screens)
 //
 // Depends only on types.h.
 

--- a/engine/display_traits.h
+++ b/engine/display_traits.h
@@ -20,8 +20,10 @@
 //   static constexpr u8   mode_opcode(ModeT);        // backend display-program byte
 //   static constexpr u8   to_screen_code(char);      // ASCII -> screen tile code
 //   static constexpr u8   fine_scroll_range(ModeT);  // horizontal fine-scroll modulus
-//   static constexpr u8   scroll_fetch_width(ModeT); // bytes fetched per scrolled line
-//                                                    //   (both only used by scroll-active screens)
+//   static constexpr u8   scroll_fetch_width(ModeT); // cells fetched per scrolled line
+//   static constexpr bool fine_scroll_inverts_x(ModeT); // fine X register opposes coarse
+//   static constexpr bool fine_scroll_inverts_y(ModeT); // fine Y register opposes coarse
+//                                                    //   (these four only used by scroll-active screens)
 //
 // Depends only on types.h.
 

--- a/engine/platform/atari/antic.h
+++ b/engine/platform/atari/antic.h
@@ -54,10 +54,12 @@ enum class Mode : u8 {
 // A display list is a byte program ANTIC's DMA executes: blank-line counts,
 // mode-line bytes (optionally with an LMS load-address prefix and/or a DLI
 // trigger), and a terminating jump. See DECISIONS.md ADR-026.
-inline constexpr u8 DL_LMS = 0x40;   // mode byte | DL_LMS => 2 address bytes follow
-inline constexpr u8 DL_DLI = 0x80;   // mode byte | DL_DLI => fire a DLI on this line
-inline constexpr u8 DL_JMP = 0x01;   // jump (2 address bytes follow)
-inline constexpr u8 DL_JVB = 0x41;   // jump + wait for vertical blank (loops the DL)
+inline constexpr u8 DL_LMS     = 0x40;   // mode byte | DL_LMS => 2 address bytes follow
+inline constexpr u8 DL_DLI     = 0x80;   // mode byte | DL_DLI => fire a DLI on this line
+inline constexpr u8 DL_HSCROLL = 0x10;   // mode byte | DL_HSCROLL => horizontal fine scroll on this line
+inline constexpr u8 DL_VSCROLL = 0x20;   // mode byte | DL_VSCROLL => vertical fine scroll on this line
+inline constexpr u8 DL_JMP     = 0x01;   // jump (2 address bytes follow)
+inline constexpr u8 DL_JVB     = 0x41;   // jump + wait for vertical blank (loops the DL)
 
 // Blank-line instruction for `n` blank scanlines (1..8). Encoded as (n-1)<<4.
 constexpr u8 dl_blank(u8 n) { return static_cast<u8>((n - 1) << 4); }
@@ -126,6 +128,47 @@ constexpr u8 scanlines_per_line(Mode m) {
 
 // The display-list mode-line instruction byte for this mode (no LMS/DLI bits).
 constexpr u8 dl_mode_byte(Mode m) { return static_cast<u8>(m); }
+
+// ── Hardware scrolling geometry ──────────────────────────────────────
+//
+// When a mode line has DL_HSCROLL set, ANTIC fetches the *next wider* playfield
+// so there is off-screen content to slide in: a normal-width 40-column text line
+// fetches 48 bytes instead of 40. `scroll_margin` is those extra bytes; a scroll
+// map's row stride must be at least `scroll_fetch_width` so every fetched byte
+// is real map data.
+constexpr u8 scroll_margin(Mode m) {
+    switch (m) {
+        case Mode::MODE_2: case Mode::MODE_3:
+        case Mode::MODE_4: case Mode::MODE_5:
+            return 8;                        // 40-col text: 40 -> 48
+        case Mode::MODE_6: case Mode::MODE_7:
+            return 4;                        // 20-col text: 20 -> 24
+        default:
+            return 8;
+    }
+}
+
+constexpr u8 scroll_fetch_width(Mode m) {
+    return static_cast<u8>(bytes_per_line(m) + scroll_margin(m));
+}
+
+// Fine-scroll modulus: the number of HSCROL color-clock positions that span one
+// character cell, i.e. how far HSCROL advances before a one-byte coarse step.
+// The normal playfield is 160 color clocks wide, so a 40-column cell is 4 color
+// clocks and a 20-column cell is 8. (Vertical fine scroll uses scanlines_per_line
+// as its modulus instead.) THIS is the value to verify against real hardware if a
+// fine->coarse handoff ever jumps — see demo/atari_scroll_test.cpp.
+constexpr u8 fine_scroll_range(Mode m) {
+    switch (m) {
+        case Mode::MODE_2: case Mode::MODE_3:
+        case Mode::MODE_4: case Mode::MODE_5:
+            return 4;                        // 160 color clocks / 40 cells
+        case Mode::MODE_6: case Mode::MODE_7:
+            return 8;                        // 160 color clocks / 20 cells
+        default:
+            return 4;
+    }
+}
 
 // ── Player/Missile memory layout ──────────────────────────────────────
 //

--- a/engine/platform/atari/display_list.h
+++ b/engine/platform/atari/display_list.h
@@ -33,12 +33,15 @@ namespace detail {
 
 // Base display-list length for `Layout` assuming one LMS per region (no 4K
 // crossings): 3 blank-line instructions + per region (1 mode/LMS byte + 2 LMS
-// address bytes + height-1 mode bytes) + a 3-byte JVB.
+// address bytes + height-1 mode bytes) + a 3-byte JVB. A scroll region instead
+// emits one LMS (3 bytes) per visible line, so it contributes 3*height.
 template <typename Layout>
 constexpr u16 display_list_base_size() {
     u16 s = 3 + 3;
     for (u8 i = 0; i < Layout::region_count; ++i) {
-        s += static_cast<u16>(Layout::region_height[i]) + 2;
+        s += Layout::region_is_scroll[i]
+                 ? static_cast<u16>(3 * Layout::region_height[i])
+                 : static_cast<u16>(Layout::region_height[i]) + 2;
     }
     return s;
 }
@@ -61,14 +64,28 @@ constexpr u16 display_list_capacity() {
     return s;
 }
 
-// Worst-case total LMS count: one per region plus its potential crossings.
+// Worst-case total LMS count: a scroll region emits one LMS per visible line; a
+// normal region emits one plus its potential 4K crossings.
 template <typename Layout>
 constexpr u16 max_lms_count() {
     u16 n = 0;
     for (u8 i = 0; i < Layout::region_count; ++i) {
-        n += static_cast<u16>(1 + lms_crossings_max(Layout::region_ram[i]));
+        n += Layout::region_is_scroll[i]
+                 ? static_cast<u16>(Layout::region_height[i])
+                 : static_cast<u16>(1 + lms_crossings_max(Layout::region_ram[i]));
     }
     return n;
+}
+
+// Total scroll LMS (one per visible line of every scroll region). Sized at least
+// 1 so DisplayProgram::scroll_lms_pos[] is never a zero-length array.
+template <typename Layout>
+constexpr u16 max_scroll_lms_count() {
+    u16 n = 0;
+    for (u8 i = 0; i < Layout::region_count; ++i) {
+        if (Layout::region_is_scroll[i]) n += Layout::region_height[i];
+    }
+    return n < 1 ? 1 : n;
 }
 
 } // namespace detail
@@ -92,6 +109,7 @@ struct DisplayProgram {
     static constexpr u8  region_count = Layout::region_count;
     static constexpr u16 capacity     = detail::display_list_capacity<Layout>();
     static constexpr u16 max_lms      = detail::max_lms_count<Layout>();
+    static constexpr u16 max_scroll_lms = detail::max_scroll_lms_count<Layout>();
 
     u8  bytes[capacity]              = {};
     u16 size                         = 0;   // bytes actually used by build()
@@ -99,12 +117,18 @@ struct DisplayProgram {
     u16 lms_count                    = 0;
     u16 lms_pos[max_lms]             = {};   // low-byte index of every LMS
     u16 region_lms_pos[region_count] = {};   // low-byte index of each region's first LMS
+    // Low-byte index of every scroll-region LMS, in visible-line (top-to-bottom)
+    // order, so patch_scroll() can repoint each line independently. The generic
+    // ScrollManager never sees these — it only supplies coarse col/row.
+    u16 scroll_lms_pos[max_scroll_lms] = {};
+    u16 scroll_lms_count               = 0;
 
     // Build the display list for screen memory based at `screen_base`, with the
     // list itself residing at `dl_base` (used by the JVB to loop the list).
     constexpr void build(u16 screen_base, u16 dl_base) {
         u16 p   = 0;
         lms_count = 0;
+        scroll_lms_count = 0;
 
         // Three 8-blank-line instructions (24 scanlines) to centre vertically.
         bytes[p++] = dl_blank(8);
@@ -113,6 +137,26 @@ struct DisplayProgram {
 
         for (u8 r = 0; r < region_count; ++r) {
             const u8  mode = Layout::region_mode_byte[r];
+
+            if (Layout::region_is_scroll[r]) {
+                // Scroll region: every visible line gets its own LMS (with the
+                // HSCROLL/VSCROLL bits) striding by the map width, so a map wider
+                // than the fetch width stays row-aligned and 4K crossings are moot
+                // (each line reloads the full address anyway). The addresses here
+                // are placeholders against `screen_base`; scroll_map() repoints
+                // them at the bound map via patch_scroll().
+                const u8  op     = static_cast<u8>(mode | DL_LMS | DL_HSCROLL | DL_VSCROLL);
+                const u16 stride = Layout::region_map_width[r];
+                u16 line_start   = static_cast<u16>(screen_base + Layout::offset(r));
+                for (u8 i = 0; i < Layout::region_height[r]; ++i) {
+                    const u16 pos = emit_load(p, op, line_start);
+                    scroll_lms_pos[scroll_lms_count++] = pos;
+                    if (i == 0) region_lms_pos[r] = pos;
+                    line_start = static_cast<u16>(line_start + stride);
+                }
+                continue;
+            }
+
             const u8  bpl  = Layout::region_bytes_per_line[r];
             u16 line_start = static_cast<u16>(screen_base + Layout::offset(r));
 
@@ -140,16 +184,33 @@ struct DisplayProgram {
         size = p;
     }
 
+    // Repoint every scroll-region LMS at the bound map for a coarse (col, row)
+    // offset: visible line i loads `map_base + (coarse_row + i)*map_width +
+    // coarse_col`. This is the ONLY place the ANTIC LMS bytes are rewritten at run
+    // time; the generic ScrollManager supplies only the coarse offsets (it never
+    // touches the display list). A no-op for layouts with no scroll region.
+    void patch_scroll(u16 map_base, u16 map_width, u16 coarse_col, u16 coarse_row) {
+        for (u16 i = 0; i < scroll_lms_count; ++i) {
+            const u16 a = static_cast<u16>(
+                map_base + static_cast<u16>(coarse_row + i) * map_width + coarse_col);
+            bytes[scroll_lms_pos[i]]     = lo(a);
+            bytes[scroll_lms_pos[i] + 1] = hi(a);
+        }
+    }
+
 private:
-    // Emit `mode | LMS` + the 2-byte address `a`; record and return the low-byte
-    // position. `p` is advanced past the 3 emitted bytes.
-    constexpr u16 emit_lms(u16& p, u8 mode, u16 a) {
-        bytes[p++] = static_cast<u8>(mode | DL_LMS);
+    // Emit display-list opcode `op` + the 2-byte address `a`; record and return
+    // the low-byte position. `p` is advanced past the 3 emitted bytes.
+    constexpr u16 emit_load(u16& p, u8 op, u16 a) {
+        bytes[p++] = op;
         const u16 pos = p;
         bytes[p++] = lo(a);
         bytes[p++] = hi(a);
         lms_pos[lms_count++] = pos;
         return pos;
+    }
+    constexpr u16 emit_lms(u16& p, u8 mode, u16 a) {
+        return emit_load(p, static_cast<u8>(mode | DL_LMS), a);
     }
     static constexpr u8 lo(u16 a) { return static_cast<u8>(a & 0xFF); }
     static constexpr u8 hi(u16 a) { return static_cast<u8>(a >> 8); }

--- a/engine/platform/atari/display_traits.h
+++ b/engine/platform/atari/display_traits.h
@@ -40,6 +40,11 @@ struct traits<atari::Mode> {
     static constexpr engine::u8 scroll_fetch_width(atari::Mode m) {
         return atari::scroll_fetch_width(m);
     }
+    // ANTIC register conventions: raising HSCROL moves the picture opposite to the
+    // LMS (coarse) pointer, so horizontal fine scroll inverts; VSCROL moves it the
+    // same way as the LMS pointer, so vertical does not. (See platform/atari/antic.h.)
+    static constexpr bool fine_scroll_inverts_x(atari::Mode) { return true; }
+    static constexpr bool fine_scroll_inverts_y(atari::Mode) { return false; }
     static constexpr engine::u8 to_screen_code(char c) {
         return atari::ascii_to_internal(c);
     }

--- a/engine/platform/atari/display_traits.h
+++ b/engine/platform/atari/display_traits.h
@@ -34,6 +34,9 @@ struct traits<atari::Mode> {
     static constexpr engine::u8 mode_opcode(atari::Mode m) {
         return atari::dl_mode_byte(m);
     }
+    static constexpr engine::u8 fine_scroll_range(atari::Mode m) {
+        return atari::fine_scroll_range(m);
+    }
     static constexpr engine::u8 to_screen_code(char c) {
         return atari::ascii_to_internal(c);
     }

--- a/engine/platform/atari/display_traits.h
+++ b/engine/platform/atari/display_traits.h
@@ -37,6 +37,9 @@ struct traits<atari::Mode> {
     static constexpr engine::u8 fine_scroll_range(atari::Mode m) {
         return atari::fine_scroll_range(m);
     }
+    static constexpr engine::u8 scroll_fetch_width(atari::Mode m) {
+        return atari::scroll_fetch_width(m);
+    }
     static constexpr engine::u8 to_screen_code(char c) {
         return atari::ascii_to_internal(c);
     }

--- a/engine/screen.h
+++ b/engine/screen.h
@@ -198,7 +198,7 @@ public:
         constexpr ModeT mode = Region::mode;
         using tr = engine::display::traits<ModeT>;
         scroll.activate(Layout::region_map_width[idx], Layout::region_map_height[idx],
-                        Layout::region_height[idx], tr::bytes_per_line(mode),
+                        Layout::region_height[idx], tr::scroll_fetch_width(mode),
                         tr::scanlines_per_line(mode), tr::fine_scroll_range(mode));
     }
 

--- a/engine/screen.h
+++ b/engine/screen.h
@@ -140,7 +140,8 @@ public:
         // One display program per screen, in BSS (not on the 256-byte 6502
         // stack). The hardware reads it directly, so it is built at its own
         // resident address. program_for<S>() returns that one persistent instance
-        // so bind_scroll_map()/apply_scroll() patch the same list ANTIC executes.
+        // so bind_scroll_map()/apply_scroll() patch the same program the display
+        // hardware executes.
         auto& dl = program_for<S>();
         dl.build(addr(screen_buffer_), addr(&dl.bytes[0]));
 
@@ -170,9 +171,9 @@ public:
     // ── Scroll binding ────────────────────────────────────────────────
     //
     // Bind a game-held map buffer to screen S's scroll region: point every
-    // scroll-region LMS at the map (initial coarse 0,0), rebind the region view to
-    // the map, and activate the ScrollManager with the geometry from the layout +
-    // the mode's display traits. Call after set_screen<S>() (init() builds the
+    // scroll-region load address at the map (initial coarse 0,0), rebind the region
+    // view to the map, and activate the ScrollManager with the geometry from the
+    // layout + the mode's display traits. Call after set_screen<S>() (init() builds the
     // initial screen). `map_width` is the map's row stride in the region's native
     // units; it must match the layout's scroll-region map width.
     template <typename S, typename ScrollT>
@@ -189,7 +190,7 @@ public:
         scroll_bound_     = true;
 
         // Point the scroll region's view at the map so region-view writes land in
-        // the map buffer, and set the initial (unscrolled) LMS addresses.
+        // the map buffer, and set the initial (unscrolled) load addresses.
         views_.template for_screen<S>().template get<idx>().ptr = map_base;
         dl.patch_scroll(scroll_map_base_, scroll_map_width_, 0, 0);
 
@@ -199,12 +200,14 @@ public:
         using tr = engine::display::traits<ModeT>;
         scroll.activate(Layout::region_map_width[idx], Layout::region_map_height[idx],
                         Layout::region_height[idx], tr::scroll_fetch_width(mode),
-                        tr::scanlines_per_line(mode), tr::fine_scroll_range(mode));
+                        tr::scanlines_per_line(mode), tr::fine_scroll_range(mode),
+                        tr::fine_scroll_inverts_x(mode), tr::fine_scroll_inverts_y(mode));
     }
 
     // Per-frame scroll update (called from the frame service). Writes the fine
-    // registers and repoints the scroll LMS for the current coarse offset. No-op
-    // unless a map is bound and the ScrollManager is active and not suspended.
+    // registers and repoints the scroll-region load addresses for the current coarse
+    // offset. No-op unless a map is bound and the ScrollManager is active and not
+    // suspended.
     template <typename ScrollT>
     void apply_scroll(ScrollT& scroll) {
         if (!scroll_bound_ || !scroll.active() || scroll.suspended()) return;
@@ -242,7 +245,7 @@ private:
     }
 
     // The one persistent display program for screen S (a function-local static so
-    // it has a stable resident address ANTIC can read). set_screen, bind_scroll_map,
+    // it has a stable resident address the display hardware can read). set_screen, bind_scroll_map,
     // and patch_thunk all reach the same instance through here.
     template <typename S>
     static auto& program_for() {

--- a/engine/screen.h
+++ b/engine/screen.h
@@ -137,12 +137,11 @@ public:
     // callback.
     template <typename S, typename Cb>
     void set_screen(Cb cb) {
-        using Layout = typename S::display;
-
         // One display program per screen, in BSS (not on the 256-byte 6502
         // stack). The hardware reads it directly, so it is built at its own
-        // resident address. The builder type comes from the backend.
-        static typename Platform::template display_program<Layout> dl;
+        // resident address. program_for<S>() returns that one persistent instance
+        // so bind_scroll_map()/apply_scroll() patch the same list ANTIC executes.
+        auto& dl = program_for<S>();
         dl.build(addr(screen_buffer_), addr(&dl.bytes[0]));
 
         // Rebind this screen's region views to their buffer slices.
@@ -156,12 +155,62 @@ public:
         active_dl_      = dl.bytes;
         active_dl_size_ = dl.size;
 
+        // A fresh screen is not scroll-bound until bind_scroll_map(); apply_scroll
+        // is a no-op until then (and the caller deactivates the ScrollManager).
+        scroll_bound_ = false;
+
         // TODO (later subsystems): clear screen buffer, rebuild the raster-hook
-        // chain, enable/disable sprites + scroll per screen flags, generate the
+        // chain, enable/disable sprites per screen flags, generate the
         // row-address table when use_row_table. See ARCHITECTURE.md set_screen
         // steps 3-11.
 
         cb();
+    }
+
+    // ── Scroll binding ────────────────────────────────────────────────
+    //
+    // Bind a game-held map buffer to screen S's scroll region: point every
+    // scroll-region LMS at the map (initial coarse 0,0), rebind the region view to
+    // the map, and activate the ScrollManager with the geometry from the layout +
+    // the mode's display traits. Call after set_screen<S>() (init() builds the
+    // initial screen). `map_width` is the map's row stride in the region's native
+    // units; it must match the layout's scroll-region map width.
+    template <typename S, typename ScrollT>
+    void bind_scroll_map(ScrollT& scroll, u8* map_base, u16 map_width) {
+        using Layout = typename S::display;
+        static_assert(Layout::has_scroll, "screen S has no scroll region");
+        constexpr u8 idx = Layout::scroll_region_index();
+
+        auto& dl = program_for<S>();
+        scroll_prog_      = &dl;
+        scroll_patch_     = &patch_thunk<S>;
+        scroll_map_base_  = addr(map_base);
+        scroll_map_width_ = map_width;
+        scroll_bound_     = true;
+
+        // Point the scroll region's view at the map so region-view writes land in
+        // the map buffer, and set the initial (unscrolled) LMS addresses.
+        views_.template for_screen<S>().template get<idx>().ptr = map_base;
+        dl.patch_scroll(scroll_map_base_, scroll_map_width_, 0, 0);
+
+        using Region = typename Layout::template region_at<idx>;
+        using ModeT  = typename Region::mode_type;
+        constexpr ModeT mode = Region::mode;
+        using tr = engine::display::traits<ModeT>;
+        scroll.activate(Layout::region_map_width[idx], Layout::region_map_height[idx],
+                        Layout::region_height[idx], tr::bytes_per_line(mode),
+                        tr::scanlines_per_line(mode), tr::fine_scroll_range(mode));
+    }
+
+    // Per-frame scroll update (called from the frame service). Writes the fine
+    // registers and repoints the scroll LMS for the current coarse offset. No-op
+    // unless a map is bound and the ScrollManager is active and not suspended.
+    template <typename ScrollT>
+    void apply_scroll(ScrollT& scroll) {
+        if (!scroll_bound_ || !scroll.active() || scroll.suspended()) return;
+        scroll.write_fine();
+        scroll_patch_(scroll_prog_, scroll_map_base_, scroll_map_width_,
+                      scroll.coarse_col(), scroll.coarse_row());
     }
 
     // Typed region view for region N of screen S (compile-time type safety:
@@ -192,11 +241,37 @@ private:
         return static_cast<u16>(reinterpret_cast<uintptr_t>(p));
     }
 
+    // The one persistent display program for screen S (a function-local static so
+    // it has a stable resident address ANTIC can read). set_screen, bind_scroll_map,
+    // and patch_thunk all reach the same instance through here.
+    template <typename S>
+    static auto& program_for() {
+        static typename Platform::template display_program<typename S::display> dl;
+        return dl;
+    }
+
+    // Type-erasing trampoline so apply_scroll can call the backend display
+    // program's patch_scroll without the ScreenManager naming the per-screen
+    // program type at the call site.
+    template <typename S>
+    static void patch_thunk(void* p, u16 base, u16 width, u16 col, u16 row) {
+        using DP = typename Platform::template display_program<typename S::display>;
+        static_cast<DP*>(p)->patch_scroll(base, width, col, row);
+    }
+
     u8 screen_buffer_[buffer_size] = {};
     typename detail::screen_views_of<screens>::type views_;
 
     u8*       active_dl_      = nullptr;   // last built list (points into a static)
     u16       active_dl_size_ = 0;
+
+    // Scroll binding (type-erased: the active program type is captured in
+    // scroll_patch_ at bind time so apply_scroll names no per-screen type).
+    void*  scroll_prog_      = nullptr;
+    void (*scroll_patch_)(void*, u16, u16, u16, u16) = nullptr;
+    u16    scroll_map_base_  = 0;
+    u16    scroll_map_width_ = 0;
+    bool   scroll_bound_     = false;
 };
 
 } // namespace engine

--- a/engine/scroll.h
+++ b/engine/scroll.h
@@ -85,16 +85,28 @@ public:
     // Write the sub-cell remainder to the fine-scroll registers. The caller gates
     // this on active()/suspended(); kept register-only so this header stays off
     // the display list entirely.
+    //
+    // Hardware direction (ANTIC): the two fine registers are NOT symmetric.
+    // Raising HSCROL pushes the picture RIGHT — opposite to the way the LMS (coarse)
+    // pointer moves it horizontally — so the raw remainder would make horizontal
+    // fine creep against coarse and snap at each cell boundary; we invert it (and
+    // coarse_col absorbs it with a one-cell step) so fine and coarse advance
+    // together. Raising VSCROL pushes the picture UP, which is the SAME direction
+    // the LMS pointer moves it vertically, so vertical needs no inversion.
     void write_fine() const {
-        Platform::hal::set_fine_scroll_x(static_cast<u8>(scroll_x_ % fsr_));
+        Platform::hal::set_fine_scroll_x(invert(static_cast<u8>(scroll_x_ % fsr_), fsr_));
         Platform::hal::set_fine_scroll_y(static_cast<u8>(scroll_y_ % splpl_));
     }
 
     // ── Coarse scroll (whole cells), clamped to the map edges ─────────
-    // Horizontal stops so the visible window's right edge never passes the map's;
-    // vertical likewise at the bottom.
+    // The horizontal fine remainder is inverted (write_fine), so its cell is
+    // advanced by one to keep the total displacement monotonic; the vertical
+    // remainder is not, so coarse_row is the plain quotient. Horizontal stops so the
+    // visible window's right edge never passes the map's; vertical likewise at the
+    // bottom.
     u16 coarse_col() const {
-        const u16 c = static_cast<u16>(scroll_x_ / fsr_);
+        u16 c = static_cast<u16>(scroll_x_ / fsr_);
+        if (scroll_x_ % fsr_) ++c;
         const u16 max_c = map_width_ > bpl_ ? static_cast<u16>(map_width_ - bpl_) : 0;
         return c > max_c ? max_c : c;
     }
@@ -106,6 +118,11 @@ public:
     }
 
 private:
+    // Invert a sub-cell remainder for a fine register that scrolls opposite to the
+    // coarse pointer: 0 stays 0, otherwise `cell - r` (so the register counts down
+    // as coarse, bumped by one cell, counts up). See write_fine().
+    static u8 invert(u8 r, u8 cell) { return r ? static_cast<u8>(cell - r) : 0; }
+
     static u16 add_clamped(u16 base, i16 delta) {
         if (delta < 0) {
             const u16 mag = static_cast<u16>(-delta);

--- a/engine/scroll.h
+++ b/engine/scroll.h
@@ -3,22 +3,24 @@
 
 // scroll.h — the portable scroll subsystem.
 //
-// `ScrollManager<Platform>` tracks a pixel-space viewport position into a
-// tilemap and pushes it to the display in two parts (docs/API_DESIGN.md "Scroll",
-// docs/ARCHITECTURE.md "Scroll"):
+// `ScrollManager<Platform>` tracks a viewport position into a map and splits it
+// into the two parts ANTIC-class hardware scrolls in (docs/API_DESIGN.md
+// "Scroll", docs/ARCHITECTURE.md "Scroll"):
 //
-//   * fine scroll — the sub-cell remainder, applied through the HAL's
-//     Platform::hal::set_fine_scroll_x / set_fine_scroll_y.
-//   * coarse scroll — whole-cell movement, applied by patching the display
-//     program's load address so the display fetches from a shifted point in the
-//     map (see the backend display-program builder).
+//   * fine scroll — the sub-cell remainder, written straight to the fine-scroll
+//     registers through Platform::hal::set_fine_scroll_x / set_fine_scroll_y.
+//   * coarse scroll — whole-cell movement, exposed as coarse_col()/coarse_row()
+//     for the backend to turn into display-program load addresses.
 //
-// Mode-dependent geometry (cell width in fine units, cell height in scanlines,
-// line width in bytes) is not known to this layer. The screen manager owns the
-// active layout/mode and supplies the geometry through activate() when a
-// scroll-active screen is selected; deactivate() clears it. This keeps the
-// subsystem off any platform header, reaching hardware only through Platform::hal
-// (Dependency Rule 2).
+// IMPORTANT (Dependency Rule 2): this is the generic layer. It knows NOTHING of
+// the backend display-list byte encoding — no LMS layout, no opcode bits, no
+// pointer into the list. It owns only the position, the fine/coarse split, and
+// the fine-register writes (via the HAL). The coordinator (engine/screen.h) reads
+// coarse_col()/coarse_row() and hands them to the backend's patch routine, which
+// is the sole owner of the LMS bytes.
+//
+// Mode-dependent geometry is supplied by the screen manager through activate()
+// when a scroll-active screen is bound; deactivate() clears it.
 //
 // Depends on types.h only.
 
@@ -30,7 +32,8 @@ template <typename Platform>
 class ScrollManager {
 public:
     // ── Position ──────────────────────────────────────────────────────
-    // Absolute viewport position in the tilemap (fine units / scanlines).
+    // Absolute viewport position in the map (horizontal in fine units, vertical
+    // in scanlines).
     void set(u16 x, u16 y) { scroll_x_ = x; scroll_y_ = y; }
 
     // Relative scroll. Signed deltas are applied into the unsigned position
@@ -49,55 +52,57 @@ public:
     void suspend() { suspended_ = true;  }
     void resume()  { suspended_ = false; }
 
+    bool active()    const { return active_; }
+    bool suspended() const { return suspended_; }
+
     // ── Activation (driven by the screen manager, not the user) ────────
-    // Called at set_screen time for a scroll-active screen. The geometry comes
-    // from the active mode (the display traits the screen manager owns):
-    //   bytes_per_line     — display width of one mode line, in bytes.
-    //   scanlines_per_line — height of one mode line, in scanlines.
-    //   fine_scroll_range  — fine units per cell column (fine-scroll wrap point).
-    void activate(u8 bytes_per_line, u8 scanlines_per_line, u8 fine_scroll_range) {
-        bpl_    = bytes_per_line;
-        splpl_  = scanlines_per_line;
-        fsr_    = fine_scroll_range;
-        active_ = true;
+    // Called when a scroll-active screen is bound. Geometry comes from the active
+    // mode (display traits) and the scroll region's map:
+    //   map_width / map_height — full map size in the region's native units
+    //                            (text: columns/rows). Bounds coarse scrolling.
+    //   visible_lines          — on-screen mode lines of the scroll region.
+    //   bytes_per_line         — display width of one mode line, in bytes.
+    //   scanlines_per_line     — mode-line height; the vertical fine modulus.
+    //   fine_scroll_range      — fine units per cell; the horizontal fine modulus.
+    void activate(u16 map_width, u16 map_height, u8 visible_lines,
+                  u8 bytes_per_line, u8 scanlines_per_line, u8 fine_scroll_range) {
+        map_width_     = map_width;
+        map_height_    = map_height;
+        visible_lines_ = visible_lines;
+        bpl_           = bytes_per_line;
+        splpl_         = scanlines_per_line;
+        fsr_           = fine_scroll_range;
+        active_        = true;
     }
 
     void deactivate() {
         active_ = false;
-        bpl_ = splpl_ = fsr_ = 0;
+        map_width_ = map_height_ = 0;
+        visible_lines_ = bpl_ = splpl_ = fsr_ = 0;
     }
 
-    // ── Apply to hardware ─────────────────────────────────────────────
-    // Push the current position to the display: write the fine-scroll registers
-    // and patch the display program's load address for the coarse offset. Called
-    // during the frame service (or at set_screen). `load_pos` is the low-byte index
-    // of the load address to patch (the backend builder's region_lms_pos[0]).
-    // `screen_base` is the tilemap origin; `map_width_bytes` is its full row stride.
-    //
-    // No-op while suspended or inactive (geometry is then unset).
-    void apply(u8* display_list, u16 load_pos, u8* screen_base, u16 map_width_bytes) {
-        if (suspended_ || !active_) return;
+    // ── Fine scroll → hardware ────────────────────────────────────────
+    // Write the sub-cell remainder to the fine-scroll registers. The caller gates
+    // this on active()/suspended(); kept register-only so this header stays off
+    // the display list entirely.
+    void write_fine() const {
+        Platform::hal::set_fine_scroll_x(static_cast<u8>(scroll_x_ % fsr_));
+        Platform::hal::set_fine_scroll_y(static_cast<u8>(scroll_y_ % splpl_));
+    }
 
-        const u8 fine_x = static_cast<u8>(scroll_x_ % fsr_);
-        const u8 fine_y = static_cast<u8>(scroll_y_ % splpl_);
-        Platform::hal::set_fine_scroll_x(fine_x);
-        Platform::hal::set_fine_scroll_y(fine_y);
-
-        u16 coarse_col = static_cast<u16>(scroll_x_ / fsr_);
-        const u16 coarse_row = static_cast<u16>(scroll_y_ / splpl_);
-
-        // Keep the visible window inside the map's right edge.
-        if (map_width_bytes > bpl_) {
-            const u16 max_col = static_cast<u16>(map_width_bytes - bpl_);
-            if (coarse_col > max_col) coarse_col = max_col;
-        } else {
-            coarse_col = 0;
-        }
-
-        const u16 load_addr = static_cast<u16>(addr(screen_base)
-                        + coarse_row * map_width_bytes + coarse_col);
-        display_list[load_pos]     = lo(load_addr);
-        display_list[load_pos + 1] = hi(load_addr);
+    // ── Coarse scroll (whole cells), clamped to the map edges ─────────
+    // Horizontal stops so the visible window's right edge never passes the map's;
+    // vertical likewise at the bottom.
+    u16 coarse_col() const {
+        const u16 c = static_cast<u16>(scroll_x_ / fsr_);
+        const u16 max_c = map_width_ > bpl_ ? static_cast<u16>(map_width_ - bpl_) : 0;
+        return c > max_c ? max_c : c;
+    }
+    u16 coarse_row() const {
+        const u16 r = static_cast<u16>(scroll_y_ / splpl_);
+        const u16 max_r =
+            map_height_ > visible_lines_ ? static_cast<u16>(map_height_ - visible_lines_) : 0;
+        return r > max_r ? max_r : r;
     }
 
 private:
@@ -109,19 +114,16 @@ private:
         return static_cast<u16>(base + static_cast<u16>(delta));
     }
 
-    static u16 addr(const void* p) {
-        return static_cast<u16>(reinterpret_cast<uintptr_t>(p));
-    }
-    static u8 lo(u16 a) { return static_cast<u8>(a & 0xFF); }
-    static u8 hi(u16 a) { return static_cast<u8>(a >> 8); }
-
-    u16  scroll_x_  = 0;
-    u16  scroll_y_  = 0;
-    bool suspended_ = false;
-    bool active_    = false;
-    u8   bpl_       = 0;   // bytes_per_line     — scroll-region line width
-    u8   splpl_     = 0;   // scanlines_per_line — vertical fine modulus / row divisor
-    u8   fsr_       = 0;   // fine_scroll_range  — horizontal fine modulus / col divisor
+    u16  scroll_x_      = 0;
+    u16  scroll_y_      = 0;
+    bool suspended_     = false;
+    bool active_        = false;
+    u16  map_width_     = 0;   // full map row width  (native units) — coarse-col bound
+    u16  map_height_    = 0;   // full map height     (native units) — coarse-row bound
+    u8   visible_lines_ = 0;   // on-screen scroll mode lines
+    u8   bpl_           = 0;   // bytes_per_line     — scroll-region display width
+    u8   splpl_         = 0;   // scanlines_per_line — vertical fine modulus / row divisor
+    u8   fsr_           = 0;   // fine_scroll_range  — horizontal fine modulus / col divisor
 };
 
 } // namespace engine

--- a/engine/scroll.h
+++ b/engine/scroll.h
@@ -4,8 +4,8 @@
 // scroll.h — the portable scroll subsystem.
 //
 // `ScrollManager<Platform>` tracks a viewport position into a map and splits it
-// into the two parts ANTIC-class hardware scrolls in (docs/API_DESIGN.md
-// "Scroll", docs/ARCHITECTURE.md "Scroll"):
+// into the two parts hardware scrolling uses (docs/API_DESIGN.md "Scroll",
+// docs/ARCHITECTURE.md "Scroll"):
 //
 //   * fine scroll — the sub-cell remainder, written straight to the fine-scroll
 //     registers through Platform::hal::set_fine_scroll_x / set_fine_scroll_y.
@@ -13,14 +13,17 @@
 //     for the backend to turn into display-program load addresses.
 //
 // IMPORTANT (Dependency Rule 2): this is the generic layer. It knows NOTHING of
-// the backend display-list byte encoding — no LMS layout, no opcode bits, no
-// pointer into the list. It owns only the position, the fine/coarse split, and
-// the fine-register writes (via the HAL). The coordinator (engine/screen.h) reads
-// coarse_col()/coarse_row() and hands them to the backend's patch routine, which
-// is the sole owner of the LMS bytes.
+// the backend display-program byte encoding — no load-address layout, no opcode
+// bits, no pointer into the program. It owns only the position, the fine/coarse
+// split, and the fine-register writes (via the HAL). The coordinator
+// (engine/screen.h) reads coarse_col()/coarse_row() and hands them to the
+// backend's patch routine, which is the sole owner of the display-program bytes.
 //
-// Mode-dependent geometry is supplied by the screen manager through activate()
-// when a scroll-active screen is bound; deactivate() clears it.
+// Geometry and hardware conventions are supplied by the screen manager through
+// activate() when a scroll-active screen is bound; deactivate() clears them. In
+// particular, whether a fine-scroll register scrolls the picture *opposite* to
+// the coarse pointer is a backend property passed in (invert_x/invert_y) rather
+// than assumed here.
 //
 // Depends on types.h only.
 
@@ -56,26 +59,33 @@ public:
     bool suspended() const { return suspended_; }
 
     // ── Activation (driven by the screen manager, not the user) ────────
-    // Called when a scroll-active screen is bound. Geometry comes from the active
-    // mode (display traits) and the scroll region's map:
+    // Called when a scroll-active screen is bound. Geometry and conventions come
+    // from the active mode (display traits) and the scroll region's map:
     //   map_width / map_height — full map size in the region's native units
     //                            (text: columns/rows). Bounds coarse scrolling.
     //   visible_lines          — on-screen mode lines of the scroll region.
-    //   fetch_width            — bytes ANTIC fetches per scrolled line, in the
-    //                            region's native units. With horizontal scrolling
-    //                            ANTIC reads WIDER than the display (Mode 2: 48 vs
-    //                            40), so the right-edge clamp uses this, not the
-    //                            display width, to stay inside the map.
+    //   fetch_width            — cells the hardware fetches per scrolled line, in
+    //                            the region's native units. Scroll hardware can
+    //                            fetch wider than it displays, so the right-edge
+    //                            clamp uses this, not the display width, to stay
+    //                            inside the map.
     //   scanlines_per_line     — mode-line height; the vertical fine modulus.
     //   fine_scroll_range      — fine units per cell; the horizontal fine modulus.
+    //   invert_x / invert_y    — true when that axis's fine-scroll register moves
+    //                            the picture OPPOSITE to the coarse pointer, so the
+    //                            remainder must be inverted (and the cell carried)
+    //                            to keep fine and coarse advancing together.
     void activate(u16 map_width, u16 map_height, u8 visible_lines,
-                  u8 fetch_width, u8 scanlines_per_line, u8 fine_scroll_range) {
+                  u8 fetch_width, u8 scanlines_per_line, u8 fine_scroll_range,
+                  bool invert_x, bool invert_y) {
         map_width_     = map_width;
         map_height_    = map_height;
         visible_lines_ = visible_lines;
         fetch_         = fetch_width;
         splpl_         = scanlines_per_line;
         fsr_           = fine_scroll_range;
+        invert_x_      = invert_x;
+        invert_y_      = invert_y;
         active_        = true;
     }
 
@@ -83,41 +93,42 @@ public:
         active_ = false;
         map_width_ = map_height_ = 0;
         visible_lines_ = fetch_ = splpl_ = fsr_ = 0;
+        invert_x_ = invert_y_ = false;
     }
 
     // ── Fine scroll → hardware ────────────────────────────────────────
     // Write the sub-cell remainder to the fine-scroll registers. The caller gates
     // this on active()/suspended(); kept register-only so this header stays off
-    // the display list entirely.
+    // the display program entirely.
     //
-    // Hardware direction (ANTIC): the two fine registers are NOT symmetric.
-    // Raising HSCROL pushes the picture RIGHT — opposite to the way the LMS (coarse)
-    // pointer moves it horizontally — so the raw remainder would make horizontal
-    // fine creep against coarse and snap at each cell boundary; we invert it (and
-    // coarse_col absorbs it with a one-cell step) so fine and coarse advance
-    // together. Raising VSCROL pushes the picture UP, which is the SAME direction
-    // the LMS pointer moves it vertically, so vertical needs no inversion.
+    // On an axis whose register scrolls opposite to the coarse pointer (invert_*),
+    // the raw remainder would make fine creep against coarse and snap at each cell
+    // boundary, so it is inverted (and coarse_col/coarse_row carry one cell) to
+    // keep the two advancing together. Whether each axis inverts is a backend fact
+    // passed to activate(), not assumed here.
     void write_fine() const {
-        Platform::hal::set_fine_scroll_x(invert(static_cast<u8>(scroll_x_ % fsr_), fsr_));
-        Platform::hal::set_fine_scroll_y(static_cast<u8>(scroll_y_ % splpl_));
+        const u8 rx = static_cast<u8>(scroll_x_ % fsr_);
+        const u8 ry = static_cast<u8>(scroll_y_ % splpl_);
+        Platform::hal::set_fine_scroll_x(invert_x_ ? invert(rx, fsr_)   : rx);
+        Platform::hal::set_fine_scroll_y(invert_y_ ? invert(ry, splpl_) : ry);
     }
 
     // ── Coarse scroll (whole cells), clamped to the map edges ─────────
-    // The horizontal fine remainder is inverted (write_fine), so its cell is
-    // advanced by one to keep the total displacement monotonic; the vertical
-    // remainder is not, so coarse_row is the plain quotient. Horizontal stops so the
-    // visible window's right edge never passes the map's; vertical likewise at the
-    // bottom.
+    // When an axis's fine remainder is inverted (write_fine), its cell is advanced
+    // by one to keep the total displacement monotonic; otherwise the coarse value
+    // is the plain quotient. Horizontal stops so the visible window's right edge
+    // never passes the map's; vertical likewise at the bottom.
     u16 coarse_col() const {
         u16 c = static_cast<u16>(scroll_x_ / fsr_);
-        if (scroll_x_ % fsr_) ++c;
-        // Clamp to the FETCH width: ANTIC reads `fetch_` bytes per scrolled line,
-        // so the last in-map coarse column is map_width - fetch_, not - display.
+        if (invert_x_ && (scroll_x_ % fsr_)) ++c;
+        // Clamp to the FETCH width: the hardware reads `fetch_` cells per scrolled
+        // line, so the last in-map coarse column is map_width - fetch_, not - display.
         const u16 max_c = map_width_ > fetch_ ? static_cast<u16>(map_width_ - fetch_) : 0;
         return c > max_c ? max_c : c;
     }
     u16 coarse_row() const {
-        const u16 r = static_cast<u16>(scroll_y_ / splpl_);
+        u16 r = static_cast<u16>(scroll_y_ / splpl_);
+        if (invert_y_ && (scroll_y_ % splpl_)) ++r;
         const u16 max_r =
             map_height_ > visible_lines_ ? static_cast<u16>(map_height_ - visible_lines_) : 0;
         return r > max_r ? max_r : r;
@@ -144,9 +155,11 @@ private:
     u16  map_width_     = 0;   // full map row width  (native units) — coarse-col bound
     u16  map_height_    = 0;   // full map height     (native units) — coarse-row bound
     u8   visible_lines_ = 0;   // on-screen scroll mode lines
-    u8   fetch_         = 0;   // fetch_width        — bytes ANTIC reads per scrolled line
+    u8   fetch_         = 0;   // fetch_width        — cells fetched per scrolled line
     u8   splpl_         = 0;   // scanlines_per_line — vertical fine modulus / row divisor
     u8   fsr_           = 0;   // fine_scroll_range  — horizontal fine modulus / col divisor
+    bool invert_x_      = false; // fine X register opposes the coarse pointer
+    bool invert_y_      = false; // fine Y register opposes the coarse pointer
 };
 
 } // namespace engine

--- a/engine/scroll.h
+++ b/engine/scroll.h
@@ -61,15 +61,19 @@ public:
     //   map_width / map_height — full map size in the region's native units
     //                            (text: columns/rows). Bounds coarse scrolling.
     //   visible_lines          — on-screen mode lines of the scroll region.
-    //   bytes_per_line         — display width of one mode line, in bytes.
+    //   fetch_width            — bytes ANTIC fetches per scrolled line, in the
+    //                            region's native units. With horizontal scrolling
+    //                            ANTIC reads WIDER than the display (Mode 2: 48 vs
+    //                            40), so the right-edge clamp uses this, not the
+    //                            display width, to stay inside the map.
     //   scanlines_per_line     — mode-line height; the vertical fine modulus.
     //   fine_scroll_range      — fine units per cell; the horizontal fine modulus.
     void activate(u16 map_width, u16 map_height, u8 visible_lines,
-                  u8 bytes_per_line, u8 scanlines_per_line, u8 fine_scroll_range) {
+                  u8 fetch_width, u8 scanlines_per_line, u8 fine_scroll_range) {
         map_width_     = map_width;
         map_height_    = map_height;
         visible_lines_ = visible_lines;
-        bpl_           = bytes_per_line;
+        fetch_         = fetch_width;
         splpl_         = scanlines_per_line;
         fsr_           = fine_scroll_range;
         active_        = true;
@@ -78,7 +82,7 @@ public:
     void deactivate() {
         active_ = false;
         map_width_ = map_height_ = 0;
-        visible_lines_ = bpl_ = splpl_ = fsr_ = 0;
+        visible_lines_ = fetch_ = splpl_ = fsr_ = 0;
     }
 
     // ── Fine scroll → hardware ────────────────────────────────────────
@@ -107,7 +111,9 @@ public:
     u16 coarse_col() const {
         u16 c = static_cast<u16>(scroll_x_ / fsr_);
         if (scroll_x_ % fsr_) ++c;
-        const u16 max_c = map_width_ > bpl_ ? static_cast<u16>(map_width_ - bpl_) : 0;
+        // Clamp to the FETCH width: ANTIC reads `fetch_` bytes per scrolled line,
+        // so the last in-map coarse column is map_width - fetch_, not - display.
+        const u16 max_c = map_width_ > fetch_ ? static_cast<u16>(map_width_ - fetch_) : 0;
         return c > max_c ? max_c : c;
     }
     u16 coarse_row() const {
@@ -138,7 +144,7 @@ private:
     u16  map_width_     = 0;   // full map row width  (native units) — coarse-col bound
     u16  map_height_    = 0;   // full map height     (native units) — coarse-row bound
     u8   visible_lines_ = 0;   // on-screen scroll mode lines
-    u8   bpl_           = 0;   // bytes_per_line     — scroll-region display width
+    u8   fetch_         = 0;   // fetch_width        — bytes ANTIC reads per scrolled line
     u8   splpl_         = 0;   // scanlines_per_line — vertical fine modulus / row divisor
     u8   fsr_           = 0;   // fine_scroll_range  — horizontal fine modulus / col divisor
 };

--- a/tests/backends/atari/CMakeLists.txt
+++ b/tests/backends/atari/CMakeLists.txt
@@ -4,5 +4,6 @@
 
 add_engine_test(test_platform)
 add_engine_test(test_atari_display)
+add_engine_test(test_atari_scroll)
 add_engine_test(test_atari_interrupt)
 add_engine_test(test_atari_core)

--- a/tests/backends/atari/test_atari_core.cpp
+++ b/tests/backends/atari/test_atari_core.cpp
@@ -81,6 +81,8 @@ struct MockHal {
     static u8   coll_missile_player(u8)   { return 0; }
     static void clear_collisions() {}
     static void suppress_idle_dim() {}
+    static void set_fine_scroll_x(u8) {}
+    static void set_fine_scroll_y(u8) {}
     static void install_frame_isr(void (*)()) {}
 
     static void reset() { sdmctl = 0; gractl = 0; }

--- a/tests/backends/atari/test_atari_scroll.cpp
+++ b/tests/backends/atari/test_atari_scroll.cpp
@@ -1,0 +1,202 @@
+// test_atari_scroll.cpp — Atari-backend tests for hardware scrolling.
+//
+// Built for the llvm-mos `mos-sim` platform and run under `mos-sim`; main()'s
+// return value becomes the process exit code (0 = pass) for CTest.
+//
+// The portable split math lives in tests/generic/test_scroll.cpp. Here we test
+// the ANTIC-specific half: that atari::DisplayProgram emits one LMS per visible
+// scroll line (with the HSCROLL/VSCROLL bits) striding by the map width, that
+// patch_scroll() rewrites those addresses for a coarse offset, and that
+// ScreenManager::apply_scroll() drives it end-to-end (including suspend gating)
+// while a non-scroll region in the same layout still emits a single LMS.
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include <engine/display.h>
+#include <engine/screen.h>
+#include <engine/scroll.h>
+#include <engine/platform/atari/platform.h>
+#include <engine/platform/atari/registers.h>
+
+using engine::u8;
+using engine::u16;
+
+using engine::DisplayLayout;
+using engine::TextRegion;
+using engine::ScrollRegion;
+using engine::ScreenSet;
+using engine::ScreenManager;
+using engine::ScrollManager;
+
+namespace M = atari;
+
+// ── Mock platform ─────────────────────────────────────────────────────
+
+struct MockHal {
+    static const u8* last_program;
+    static u8        sdmctl;
+    static u8        hscrol;
+    static u8        vscrol;
+    static unsigned  fine_writes;
+
+    static void display_dma_disable() { sdmctl &= M::dmactl::PM_DMA_MASK; }
+    static void display_dma_enable(u8 mode_bits = M::dmactl::PLAYFIELD_NORMAL) {
+        sdmctl = static_cast<u8>((sdmctl & M::dmactl::PM_DMA_MASK) |
+                                 M::dmactl::DL_ENABLE | mode_bits);
+    }
+    static void set_display_program(const u8* p) { last_program = p; }
+    static void set_fine_scroll_x(u8 v) { hscrol = v; ++fine_writes; }
+    static void set_fine_scroll_y(u8 v) { vscrol = v; ++fine_writes; }
+};
+const u8* MockHal::last_program = nullptr;
+u8        MockHal::sdmctl       = 0;
+u8        MockHal::hscrol       = 0;
+u8        MockHal::vscrol       = 0;
+unsigned  MockHal::fine_writes  = 0;
+
+struct MockPlatform {
+    using hal = MockHal;
+    template <typename Layout>
+    using display_program = atari::DisplayProgram<Layout>;
+};
+
+// ── Test screen: a 2-row HUD over a 22-row window into a 64x32 map ──────
+
+static constexpr u16 MAP_W = 64;
+static constexpr u16 MAP_H = 32;
+static constexpr u8  VIS   = 22;
+
+struct ScrollScreen {
+    using display = DisplayLayout<
+        TextRegion<M::Mode::MODE_2, 2>,
+        ScrollRegion<TextRegion<M::Mode::MODE_2, VIS>, MAP_W, MAP_H>>;
+};
+
+struct GameConfig {
+    using screens = ScreenSet<ScrollScreen>;
+};
+
+using Layout = ScrollScreen::display;
+
+// Scroll-line opcode: Mode 2 | LMS | HSCROLL | VSCROLL.
+static constexpr u8 SCROLL_OP =
+    static_cast<u8>(0x02 | M::DL_LMS | M::DL_HSCROLL | M::DL_VSCROLL);
+
+// ── Runtime harness ────────────────────────────────────────────────────
+
+static unsigned g_failures = 0;
+
+#define CHECK(cond)                                                        \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);         \
+            ++g_failures;                                                  \
+        }                                                                  \
+    } while (0)
+
+static u16 addr_of(const void* p) {
+    return static_cast<u16>(reinterpret_cast<uintptr_t>(p));
+}
+static u16 read16(const u8* b, u16 i) {
+    return static_cast<u16>(b[i]) | (static_cast<u16>(b[i + 1]) << 8);
+}
+
+// ── Compile-time layout metadata ───────────────────────────────────────
+
+static_assert(Layout::has_scroll, "layout must report a scroll region");
+static_assert(Layout::scroll_region_index() == 1, "scroll region is index 1");
+static_assert(Layout::region_map_width[1] == MAP_W, "map width recorded");
+static_assert(Layout::region_map_height[1] == MAP_H, "map height recorded");
+static_assert(!Layout::region_is_scroll[0], "HUD region is not scroll");
+
+// ── DisplayProgram emits one LMS per visible scroll line ───────────────
+
+static atari::DisplayProgram<Layout> g_dl;   // ~80 bytes -> static, not stack
+
+static void test_scroll_build() {
+    g_dl.build(0x4000, 0x4000);
+
+    // 22 scroll LMS + 1 for the HUD region = 23 total (no 4K crossing here).
+    CHECK(g_dl.scroll_lms_count == VIS);
+    CHECK(g_dl.lms_count == VIS + 1);
+
+    // Every scroll line carries LMS | HSCROLL | VSCROLL.
+    for (u16 i = 0; i < g_dl.scroll_lms_count; ++i) {
+        const u16 pos = g_dl.scroll_lms_pos[i];
+        CHECK(g_dl.bytes[pos - 1] == SCROLL_OP);
+    }
+    // The scroll region's first LMS is recorded as its region LMS.
+    CHECK(g_dl.region_lms_pos[1] == g_dl.scroll_lms_pos[0]);
+
+    // The HUD region (index 0) still emits a single plain LMS (Mode 2 | LMS).
+    CHECK(g_dl.bytes[g_dl.region_lms_pos[0] - 1] == (0x02 | M::DL_LMS));
+}
+
+// ── patch_scroll repoints each line by the map-width stride ────────────
+
+static void test_patch_scroll() {
+    g_dl.build(0x4000, 0x4000);
+    g_dl.patch_scroll(0x8000, MAP_W, /*col*/ 3, /*row*/ 2);
+
+    for (u16 i = 0; i < g_dl.scroll_lms_count; ++i) {
+        const u16 expect = static_cast<u16>(0x8000 + (2 + i) * MAP_W + 3);
+        CHECK(read16(g_dl.bytes, g_dl.scroll_lms_pos[i]) == expect);
+    }
+}
+
+// ── ScreenManager.apply_scroll drives the live list + suspend gating ───
+
+static ScreenManager<MockPlatform, GameConfig> g_sm;
+static u8 g_map[MAP_W * MAP_H];
+
+// First scroll-line load address in the live display list (the first opcode that
+// has the scroll bits set), or 0 if none found.
+static u16 first_scroll_addr() {
+    const u8* dl = g_sm.active_dl();
+    const u16 sz = g_sm.active_dl_size();
+    for (u16 k = 0; k + 2 < sz; ++k)
+        if (dl[k] == SCROLL_OP) return read16(dl, k + 1);
+    return 0;
+}
+
+static void test_apply_scroll() {
+    g_sm.set_screen<ScrollScreen>([]() {});
+
+    ScrollManager<MockPlatform> scroll;
+    g_sm.bind_scroll_map<ScrollScreen>(scroll, g_map, MAP_W);
+
+    const u16 map = addr_of(g_map);
+    CHECK(scroll.active());
+    CHECK(first_scroll_addr() == map);             // bound at coarse (0,0)
+
+    // Scroll to (20,17): hscrol 0, vscrol 1, coarse col 5, row 2.
+    scroll.set(20, 17);
+    MockHal::fine_writes = 0;
+    g_sm.apply_scroll(scroll);
+    CHECK(MockHal::hscrol == 0);
+    CHECK(MockHal::vscrol == 1);
+    CHECK(MockHal::fine_writes == 2);
+    CHECK(first_scroll_addr() == static_cast<u16>(map + 2 * MAP_W + 5));
+
+    // Suspended: apply_scroll writes nothing and leaves the list unchanged.
+    scroll.suspend();
+    scroll.set(40, 33);
+    MockHal::fine_writes = 0;
+    g_sm.apply_scroll(scroll);
+    CHECK(MockHal::fine_writes == 0);
+    CHECK(first_scroll_addr() == static_cast<u16>(map + 2 * MAP_W + 5));
+}
+
+int main() {
+    test_scroll_build();
+    test_patch_scroll();
+    test_apply_scroll();
+
+    if (g_failures == 0) {
+        printf("ALL TESTS PASSED\n");
+    } else {
+        printf("%u FAILURES\n", g_failures);
+    }
+    return g_failures != 0;
+}

--- a/tests/backends/atari/test_atari_scroll.cpp
+++ b/tests/backends/atari/test_atari_scroll.cpp
@@ -170,7 +170,9 @@ static void test_apply_scroll() {
     CHECK(scroll.active());
     CHECK(first_scroll_addr() == map);             // bound at coarse (0,0)
 
-    // Scroll to (20,17): hscrol 0, vscrol 1, coarse col 5, row 2.
+    // Scroll to (20,17). Horizontal fine is inverted and absorbs into its cell;
+    // vertical fine is raw. hscrol 0 (20%4==0), vscrol 1 (17%8), coarse col 5,
+    // coarse row 2 (17/8).
     scroll.set(20, 17);
     MockHal::fine_writes = 0;
     g_sm.apply_scroll(scroll);

--- a/tests/generic/test_core.cpp
+++ b/tests/generic/test_core.cpp
@@ -106,6 +106,11 @@ struct MockHal {
     static void set_color_pf(u8, u8) {}
     static void suppress_idle_dim() { ++idle_dim_suppressions; }
 
+    // Fine-scroll registers (frame_service instantiates apply_scroll; it is a
+    // runtime no-op here since no scroll map is bound).
+    static void set_fine_scroll_x(u8) {}
+    static void set_fine_scroll_y(u8) {}
+
     // Frame-service install.
     static void install_frame_isr(void (*h)()) { frame_handler = h; }
 

--- a/tests/generic/test_scroll.cpp
+++ b/tests/generic/test_scroll.cpp
@@ -1,12 +1,14 @@
-// test_scroll.cpp — unit tests for engine/scroll.h.
+// test_scroll.cpp — unit tests for engine/scroll.h (the portable ScrollManager).
 //
 // Built for the llvm-mos `mos-sim` platform and run under `mos-sim`; main()'s
 // return value becomes the process exit code (0 = pass) for CTest.
 //
-// Everything here is platform-independent: the fine/coarse split, the LMS
-// display-list patch, and the suspend/activate gating are driven through a MOCK
-// HAL so no real ANTIC is touched. The live ANTIC scroll registers in the Atari
-// HAL (and the hardware scroll direction) are verified separately on Fujisan.
+// ScrollManager is now purely portable: it owns the position, the fine/coarse
+// split, and the fine-register writes (through a MOCK HAL). It knows NOTHING of
+// the display-list bytes — that patching lives in the backend DisplayProgram and
+// is covered by tests/backends/atari/test_atari_scroll.cpp. So these tests check
+// the split math (coarse_col/coarse_row with edge clamps), the fine-register
+// writes, and the active/suspend flags only.
 
 #include <stdint.h>
 #include <stdio.h>
@@ -19,8 +21,7 @@ using engine::ScrollManager;
 
 // ── Mock platform ─────────────────────────────────────────────────────
 //
-// Records the last fine-scroll values written and how many writes occurred
-// (so suspend/inactive can be checked by write count).
+// Records the last fine-scroll values written and how many writes occurred.
 struct MockHal {
     static u8       hscrol;
     static u8       vscrol;
@@ -56,88 +57,82 @@ static unsigned g_failures = 0;
         }                                                                  \
     } while (0)
 
-static u16 read16(const u8* b, u16 i) {
-    return static_cast<u16>(b[i]) | (static_cast<u16>(b[i + 1]) << 8);
-}
-
-// ── Shared test geometry ───────────────────────────────────────────────
+// ── Shared test geometry (a Mode-2 scroll region over a 64x32 map) ──────
 //
-// A minimal display list holding one LMS instruction (Mode 4 | LMS, then its
-// 2-byte address) initialised to point at the tilemap origin. The low byte of
-// the address sits at index 1, so lms_pos == 1.
-static constexpr u16 SCREEN_BASE = 0x4000;   // tilemap origin (address value)
-static constexpr u16 MAP_WIDTH   = 64;       // full row stride, > bytes_per_line
-static constexpr u16 LMS_POS     = 1;
+//   bytes_per_line = 40, scanlines_per_line = 8, fine_scroll_range = 4.
+//   map 64 wide x 32 tall, 22 visible lines.
+static constexpr u16 MAP_W   = 64;
+static constexpr u16 MAP_H   = 32;
+static constexpr u8  VIS     = 22;
+static constexpr u8  BPL     = 40;
+static constexpr u8  SPLPL   = 8;
+static constexpr u8  FSR     = 4;
 
-// Geometry the screen manager would pass for a Mode-4 scroll region:
-//   bytes_per_line = 40, scanlines_per_line = 8, fine_scroll_range = 16.
-static constexpr u8 BPL   = 40;
-static constexpr u8 SPLPL = 8;
-static constexpr u8 FSR   = 16;
-
-static u8* screen_base() { return reinterpret_cast<u8*>(SCREEN_BASE); }
-
-static void init_dl(u8* dl) {
-    dl[0] = static_cast<u8>(0x04 | 0x40);     // Mode 4 | DL_LMS
-    dl[1] = static_cast<u8>(SCREEN_BASE & 0xFF);
-    dl[2] = static_cast<u8>(SCREEN_BASE >> 8);
+static void activate(ScrollManager<MockPlatform>& sm) {
+    sm.activate(MAP_W, MAP_H, VIS, BPL, SPLPL, FSR);
 }
 
-// ── Zero scroll: registers cleared, LMS unchanged ──────────────────────
+// ── Zero scroll: registers cleared, coarse 0 ───────────────────────────
 
 static void test_zero() {
-    u8 dl[3];
-    init_dl(dl);
     MockHal::reset();
-
     ScrollManager<MockPlatform> sm;
-    sm.activate(BPL, SPLPL, FSR);
+    activate(sm);
     sm.set(0, 0);
-    sm.apply(dl, LMS_POS, screen_base(), MAP_WIDTH);
+    sm.write_fine();
 
     CHECK(MockHal::hscrol == 0);
     CHECK(MockHal::vscrol == 0);
-    CHECK(read16(dl, LMS_POS) == SCREEN_BASE);   // coarse 0 -> base, unchanged
+    CHECK(sm.coarse_col() == 0);
+    CHECK(sm.coarse_row() == 0);
 }
 
 // ── Small scroll: fine only, no coarse step ────────────────────────────
 
 static void test_fine_only() {
-    u8 dl[3];
-    init_dl(dl);
     MockHal::reset();
-
     ScrollManager<MockPlatform> sm;
-    sm.activate(BPL, SPLPL, FSR);
+    activate(sm);
     sm.set(3, 5);
-    sm.apply(dl, LMS_POS, screen_base(), MAP_WIDTH);
+    sm.write_fine();
 
-    CHECK(MockHal::hscrol == 3);                 // 3 % 16
-    CHECK(MockHal::vscrol == 5);                 // 5 % 8
-    CHECK(read16(dl, LMS_POS) == SCREEN_BASE);   // 3/16 == 0, 5/8 == 0
+    CHECK(MockHal::hscrol == 3);        // 3 % 4
+    CHECK(MockHal::vscrol == 5);        // 5 % 8
+    CHECK(sm.coarse_col() == 0);        // 3 / 4
+    CHECK(sm.coarse_row() == 0);        // 5 / 8
 }
 
-// ── Larger scroll: fine + coarse, LMS patched ──────────────────────────
+// ── Larger scroll: fine + coarse ───────────────────────────────────────
 
 static void test_fine_and_coarse() {
-    u8 dl[3];
-    init_dl(dl);
     MockHal::reset();
-
     ScrollManager<MockPlatform> sm;
-    sm.activate(BPL, SPLPL, FSR);
+    activate(sm);
     sm.set(20, 17);
-    sm.apply(dl, LMS_POS, screen_base(), MAP_WIDTH);
+    sm.write_fine();
 
-    CHECK(MockHal::hscrol == 4);                 // 20 % 16
-    CHECK(MockHal::vscrol == 1);                 // 17 % 8
-
-    // coarse_col = 20/16 = 1, coarse_row = 17/8 = 2.
-    const u16 expected = static_cast<u16>(SCREEN_BASE + 2 * MAP_WIDTH + 1);
-    CHECK(read16(dl, LMS_POS) == expected);
+    CHECK(MockHal::hscrol == 0);        // 20 % 4
+    CHECK(MockHal::vscrol == 1);        // 17 % 8
+    CHECK(sm.coarse_col() == 5);        // 20 / 4
+    CHECK(sm.coarse_row() == 2);        // 17 / 8
 }
 
-// ── move(): relative scroll arithmetic ─────────────────────────────────
+// ── Coarse offsets clamp at the map's right / bottom edge ──────────────
+
+static void test_edge_clamp() {
+    ScrollManager<MockPlatform> sm;
+    activate(sm);
+
+    // Horizontal: max coarse col = map_width - bytes_per_line = 64 - 40 = 24.
+    sm.set(4 * 100, 0);                 // would be coarse_col 100
+    CHECK(sm.coarse_col() == 24);
+
+    // Vertical: max coarse row = map_height - visible_lines = 32 - 22 = 10.
+    sm.set(0, 8 * 100);                 // would be coarse_row 100
+    CHECK(sm.coarse_row() == 10);
+}
+
+// ── move(): relative scroll arithmetic, clamped at the origin ──────────
 
 static void test_move() {
     ScrollManager<MockPlatform> sm;
@@ -146,60 +141,37 @@ static void test_move() {
     CHECK(sm.x() == 15);
     CHECK(sm.y() == 7);
 
-    // Negative past the origin clamps at 0 rather than wrapping.
     sm.move(-100, -100);
     CHECK(sm.x() == 0);
     CHECK(sm.y() == 0);
 }
 
-// ── suspend()/resume() gate hardware writes ────────────────────────────
+// ── active()/suspend()/resume() flags ──────────────────────────────────
 
-static void test_suspend() {
-    u8 dl[3];
-    init_dl(dl);
-
+static void test_flags() {
     ScrollManager<MockPlatform> sm;
-    sm.activate(BPL, SPLPL, FSR);
+    CHECK(!sm.active());                // inactive before activate()
+    CHECK(!sm.suspended());
 
-    // Suspended: apply() touches neither the registers nor the LMS.
+    activate(sm);
+    CHECK(sm.active());
+
     sm.suspend();
-    sm.set(20, 17);
-    MockHal::reset();
-    sm.apply(dl, LMS_POS, screen_base(), MAP_WIDTH);
-    CHECK(MockHal::hscrol_writes == 0);
-    CHECK(MockHal::vscrol_writes == 0);
-    CHECK(read16(dl, LMS_POS) == SCREEN_BASE);   // LMS left untouched
-
-    // Resumed: writes occur and the LMS is patched.
+    CHECK(sm.suspended());
     sm.resume();
-    sm.apply(dl, LMS_POS, screen_base(), MAP_WIDTH);
-    CHECK(MockHal::hscrol_writes > 0);
-    CHECK(MockHal::vscrol_writes > 0);
-    CHECK(read16(dl, LMS_POS) == static_cast<u16>(SCREEN_BASE + 2 * MAP_WIDTH + 1));
-}
+    CHECK(!sm.suspended());
 
-// ── apply() before activate() is inert ─────────────────────────────────
-
-static void test_inactive() {
-    u8 dl[3];
-    init_dl(dl);
-    MockHal::reset();
-
-    ScrollManager<MockPlatform> sm;   // never activated
-    sm.set(20, 17);
-    sm.apply(dl, LMS_POS, screen_base(), MAP_WIDTH);
-    CHECK(MockHal::hscrol_writes == 0);
-    CHECK(MockHal::vscrol_writes == 0);
-    CHECK(read16(dl, LMS_POS) == SCREEN_BASE);
+    sm.deactivate();
+    CHECK(!sm.active());
 }
 
 int main() {
     test_zero();
     test_fine_only();
     test_fine_and_coarse();
+    test_edge_clamp();
     test_move();
-    test_suspend();
-    test_inactive();
+    test_flags();
 
     if (g_failures == 0) {
         printf("ALL TESTS PASSED\n");

--- a/tests/generic/test_scroll.cpp
+++ b/tests/generic/test_scroll.cpp
@@ -96,9 +96,12 @@ static void test_fine_only() {
     sm.set(3, 5);
     sm.write_fine();
 
-    CHECK(MockHal::hscrol == 3);        // 3 % 4
-    CHECK(MockHal::vscrol == 5);        // 5 % 8
-    CHECK(sm.coarse_col() == 0);        // 3 / 4
+    // Horizontal fine scrolls opposite coarse: the remainder is inverted (cell - r)
+    // and its cell advanced by one. Vertical fine scrolls the same way as coarse,
+    // so its remainder is raw and coarse_row is the plain quotient.
+    CHECK(MockHal::hscrol == 1);        // 4 - (3 % 4)
+    CHECK(MockHal::vscrol == 5);        // 5 % 8 (no inversion)
+    CHECK(sm.coarse_col() == 1);        // 3 / 4 == 0, +1 for the inverted fine
     CHECK(sm.coarse_row() == 0);        // 5 / 8
 }
 
@@ -111,9 +114,9 @@ static void test_fine_and_coarse() {
     sm.set(20, 17);
     sm.write_fine();
 
-    CHECK(MockHal::hscrol == 0);        // 20 % 4
-    CHECK(MockHal::vscrol == 1);        // 17 % 8
-    CHECK(sm.coarse_col() == 5);        // 20 / 4
+    CHECK(MockHal::hscrol == 0);        // 20 % 4 == 0 -> no inversion, no carry
+    CHECK(MockHal::vscrol == 1);        // 17 % 8 (no inversion)
+    CHECK(sm.coarse_col() == 5);        // 20 / 4, exact
     CHECK(sm.coarse_row() == 2);        // 17 / 8
 }
 

--- a/tests/generic/test_scroll.cpp
+++ b/tests/generic/test_scroll.cpp
@@ -59,17 +59,17 @@ static unsigned g_failures = 0;
 
 // ── Shared test geometry (a Mode-2 scroll region over a 64x32 map) ──────
 //
-//   bytes_per_line = 40, scanlines_per_line = 8, fine_scroll_range = 4.
-//   map 64 wide x 32 tall, 22 visible lines.
+//   fetch_width = 48 (40 display + 8 HSCROLL margin), scanlines_per_line = 8,
+//   fine_scroll_range = 4. Map 64 wide x 32 tall, 22 visible lines.
 static constexpr u16 MAP_W   = 64;
 static constexpr u16 MAP_H   = 32;
 static constexpr u8  VIS     = 22;
-static constexpr u8  BPL     = 40;
+static constexpr u8  FETCH   = 48;
 static constexpr u8  SPLPL   = 8;
 static constexpr u8  FSR     = 4;
 
 static void activate(ScrollManager<MockPlatform>& sm) {
-    sm.activate(MAP_W, MAP_H, VIS, BPL, SPLPL, FSR);
+    sm.activate(MAP_W, MAP_H, VIS, FETCH, SPLPL, FSR);
 }
 
 // ── Zero scroll: registers cleared, coarse 0 ───────────────────────────
@@ -126,9 +126,9 @@ static void test_edge_clamp() {
     ScrollManager<MockPlatform> sm;
     activate(sm);
 
-    // Horizontal: max coarse col = map_width - bytes_per_line = 64 - 40 = 24.
+    // Horizontal: max coarse col = map_width - fetch_width = 64 - 48 = 16.
     sm.set(4 * 100, 0);                 // would be coarse_col 100
-    CHECK(sm.coarse_col() == 24);
+    CHECK(sm.coarse_col() == 16);
 
     // Vertical: max coarse row = map_height - visible_lines = 32 - 22 = 10.
     sm.set(0, 8 * 100);                 // would be coarse_row 100

--- a/tests/generic/test_scroll.cpp
+++ b/tests/generic/test_scroll.cpp
@@ -68,8 +68,10 @@ static constexpr u8  FETCH   = 48;
 static constexpr u8  SPLPL   = 8;
 static constexpr u8  FSR     = 4;
 
+// invert_x = true, invert_y = false mirrors the ANTIC convention the Atari backend
+// supplies (horizontal fine register opposes coarse; vertical matches it).
 static void activate(ScrollManager<MockPlatform>& sm) {
-    sm.activate(MAP_W, MAP_H, VIS, FETCH, SPLPL, FSR);
+    sm.activate(MAP_W, MAP_H, VIS, FETCH, SPLPL, FSR, /*invert_x=*/true, /*invert_y=*/false);
 }
 
 // ── Zero scroll: registers cleared, coarse 0 ───────────────────────────


### PR DESCRIPTION
This pull request introduces a major new feature: hardware scrolling support, including an end-to-end demo for validation, and refactors the engine to support portable, backend-agnostic scrolling. The changes add a new `ScrollRegion` abstraction for display layouts, update the build system to support a new scroll demo, and extend the engine and backend traits to support fine/coarse scrolling. The most important changes are summarized below.

**New Hardware Scrolling Support**

* Added a hardware scrolling system: declare a scrolling region using `engine::ScrollRegion<Inner, MapW, MapH>` in a `DisplayLayout`, bind a `TileMap` as the source with `Game::scroll_map(map)`, and control scrolling with `Game::scroll.move()`/`set()`. The engine now splits scroll positions into fine (HSCROL/VSCROL) and coarse (per-line LMS) components, clamps at map edges, and keeps the tile viewport in sync. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R34) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR196-R221) [[3]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR245-R251) [[4]](diffhunk://#diff-db5b57b1e4d996052a51bbb16477dd14929d302ed0a6c4028776dd4430f68129R165-R171) [[5]](diffhunk://#diff-db5b57b1e4d996052a51bbb16477dd14929d302ed0a6c4028776dd4430f68129R182-R221) [[6]](diffhunk://#diff-db5b57b1e4d996052a51bbb16477dd14929d302ed0a6c4028776dd4430f68129R263-R276) [[7]](diffhunk://#diff-aecbc3142c253c9326db956ed6b8b967742b59c54c69dd0cf31b9cbe56dfb164R22-R26) [[8]](diffhunk://#diff-aff452aee9299f37f2f5546b0204296f3f314e2306053a01c55073ab61e48bc8R59-R60)

* Introduced a scroll validation demo (`atari_scroll_test.xex`) that demonstrates smooth hardware scrolling over a 64×32 tilemap with a fixed HUD, built independently of the main hardware test. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R34) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR67-R75) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR116-R138) [[4]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cR64-R102) [[5]](diffhunk://#diff-ed69992ab978564304d65db95f9b135bd4ec41ad73da9f8b4666547a361bec94R1-R158)

**Engine and API Refactoring**

* Refactored `ScrollManager` to separate fine/coarse scrolling logic, making it portable and backend-agnostic. The backend now supplies inversion and fetch width through display traits, and the generic scroll layer no longer references ANTIC specifics. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R34) [[2]](diffhunk://#diff-aecbc3142c253c9326db956ed6b8b967742b59c54c69dd0cf31b9cbe56dfb164R22-R26)

* Extended `DisplayLayout` and region types to support scroll metadata, including new `ScrollRegion`, and updated the API for binding and managing scroll maps. [[1]](diffhunk://#diff-db5b57b1e4d996052a51bbb16477dd14929d302ed0a6c4028776dd4430f68129R165-R171) [[2]](diffhunk://#diff-db5b57b1e4d996052a51bbb16477dd14929d302ed0a6c4028776dd4430f68129R182-R221) [[3]](diffhunk://#diff-db5b57b1e4d996052a51bbb16477dd14929d302ed0a6c4028776dd4430f68129R263-R276) [[4]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR196-R221)

**Build System Updates**

* Updated `CMakeLists.txt` to add a new build target for the scroll validation demo, supporting both generic and dedicated Atari toolchain builds. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR67-R75) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR116-R138)

**Documentation**

* Added comprehensive documentation for the scroll demo, including build instructions, expected behavior, and testable observations to verify correct hardware scrolling.

---

**References:**  
[[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R34) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR67-R75) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR116-R138) [[4]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cR64-R102) [[5]](diffhunk://#diff-ed69992ab978564304d65db95f9b135bd4ec41ad73da9f8b4666547a361bec94R1-R158) [[6]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR196-R221) [[7]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR245-R251) [[8]](diffhunk://#diff-db5b57b1e4d996052a51bbb16477dd14929d302ed0a6c4028776dd4430f68129R165-R171) [[9]](diffhunk://#diff-db5b57b1e4d996052a51bbb16477dd14929d302ed0a6c4028776dd4430f68129R182-R221) [[10]](diffhunk://#diff-db5b57b1e4d996052a51bbb16477dd14929d302ed0a6c4028776dd4430f68129R263-R276) [[11]](diffhunk://#diff-aecbc3142c253c9326db956ed6b8b967742b59c54c69dd0cf31b9cbe56dfb164R22-R26) [[12]](diffhunk://#diff-aff452aee9299f37f2f5546b0204296f3f314e2306053a01c55073ab61e48bc8R59-R60)