### PR TITLE
Fixes to vbxe demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+### Added
+- `Game::antic_playfield(bool)` (Atari, opt-in): enable/disable the ANTIC
+  playfield (character/bitmap) DMA, preserving display-list and P/M DMA. Under an
+  opaque VBXE overlay the ANTIC playfield is invisible, but its per-scanline VRAM
+  DMA starves the blitter's restore copies; calling `antic_playfield(false)` after
+  init frees the bus.
+
+### Fixed
+- VBXE `Background::Bitmap` overlay ran the game loop at ~8 Hz instead of 60 on
+  real hardware: the hidden ANTIC text playfield's DMA contended the VRAM bus and
+  stalled the blitter's per-frame VRAM→VRAM restore copies, overrunning the VBI.
+  The `atari_vbxe_sprites` demo now calls `Game::antic_playfield(false)`, restoring
+  full-rate motion. (Regression was masked because the dirty-rect restore was
+  host-validated on `mos-sim`, which doesn't model VBXE/ANTIC bus timing.)
+- `atari_vbxe_sprites`: sprite X position was computed as `u8` over a 40..259
+  range, wrapping past 255 and briefly jumping the shape to the far left; the
+  slide now stays within the valid u8 coordinate range.
+
 ## [0.2.0] - 2026-06-03
 
 ### Added

--- a/demo/README.md
+++ b/demo/README.md
@@ -167,9 +167,13 @@ prints through the portable `Game::overlay_*` text seam.
 
 Double-buffered `Background::Bitmap`: the background is drawn once with
 `Game::gfx()` into the VRAM master, published, and two sprites slide over it.
+Because the overlay is opaque, the demo calls `Game::antic_playfield(false)` after
+setup: the hidden ANTIC text playfield's DMA would otherwise contend the VRAM bus
+and stall the blitter's per-frame restore copies, throttling motion to ~8 Hz.
 
 | Observation | Proves |
 |---|---|
 | The `vbxe_gfx` picture as a steady background | `gfx()` master canvas + `overlay_publish_background()` |
 | A red ball and a multi-colour pixel sprite slide across | `make_sprite` (Packed1bpp) + `make_pixel_sprite` (Pixel8bpp) |
 | The background stays intact under the moving sprites | per-frame footprint restore from the master (flicker-free) |
+| The sprites move at full speed (~60 px/s) | `Game::antic_playfield(false)` frees the VRAM bus for the blitter |

--- a/demo/vbxe_bringup.cpp
+++ b/demo/vbxe_bringup.cpp
@@ -39,12 +39,28 @@ using engine::u32;
 namespace M = atari;
 namespace V = atari::vbxe;
 
+// Diagnostic mode: 0 = colour bars, 1 = solid fill, 2 = VRAM round-trip probe,
+// 3 = two animated sprites (blitter). Override at configure time with
+// `cmake -DEDGE_VBXE_BRINGUP_MODE=N` (passes -DVBXE_BRINGUP_MODE=N); default 0.
+// Defined here (before the Config typedef) because it selects the buffer policy.
+#ifndef VBXE_BRINGUP_MODE
+#define VBXE_BRINGUP_MODE 0
+#endif
+
 // ── Platform + game configuration ────────────────────────────────────────
 //
-// VBXE config: SR_320, DOUBLE-buffered, $D640, MEMAC-A $B000/4K. Double-buffering
-// gives MODE 3 flicker-free sprites (render the hidden page, then flip). The
-// static modes (0/1/2) just paint fb_a and never flip, so they're unaffected.
-using Cfg = V::Config<V::Mode::SR_320, V::Buffers::Double>;
+// VBXE config: SR_320, $D640, MEMAC-A $B000/4K. The buffer policy tracks the
+// diagnostic mode. MODE 3 (sprites) is DOUBLE-buffered for flicker-free animation
+// (render the hidden page, then flip). The static modes (0/1/2) MUST be
+// SINGLE-buffered: the engine's frame service flips pages every VBI in
+// double-buffer mode, and since those modes only paint fb_a once, a flip would
+// show the unpainted (transparent, index 0) back page — the ANTIC playfield reads
+// through and the painted content appears to vanish.
+#if VBXE_BRINGUP_MODE == 3
+using Cfg = V::Config<V::Mode::SR_320, V::Buffers::Double>;   // sprite demo: flip pages
+#else
+using Cfg = V::Config<V::Mode::SR_320, V::Buffers::Single>;   // static paint: no flip
+#endif
 using Platform = M::Platform<
     M::Machine::XL,
     M::RAM::Baseline,
@@ -162,13 +178,6 @@ static void load_test_palette() {
     Game::print(0, 11, (bad == 0) ? "RESULT: CLEAN - VBI ATOMIC"
                                   : "RESULT: STILL CORRUPT");
 }
-
-// Diagnostic mode: 0 = colour bars, 1 = solid fill, 2 = VRAM round-trip probe,
-// 3 = two animated sprites (blitter). Override at configure time with
-// `cmake -DEDGE_VBXE_BRINGUP_MODE=N` (passes -DVBXE_BRINGUP_MODE=N); default 0.
-#ifndef VBXE_BRINGUP_MODE
-#define VBXE_BRINGUP_MODE 0
-#endif
 
 int main() {
     // Bring up the overlay: MEMAC window, cleared (transparent) framebuffer,

--- a/demo/vbxe_sprites_over_bitmap.cpp
+++ b/demo/vbxe_sprites_over_bitmap.cpp
@@ -119,13 +119,22 @@ int main() {
     draw_background();               // draw into the VRAM master canvas
     Game::overlay_publish_background();  // seed both display pages from the master
 
+    // The overlay is opaque, so the ANTIC text playfield behind it is invisible —
+    // but its per-scanline VRAM-bus DMA would otherwise starve the blitter's
+    // master->framebuffer restore copies and throttle the game loop to ~8 Hz.
+    // Dropping the (hidden) playfield fetch frees the bus for full 60 Hz motion.
+    Game::antic_playfield(false);
+
     Game::sprite_color(0, 1);        // kBall coloured palette-1 index 1 (red)
 
     // Two sprites sliding horizontally over the (unchanging) background.
     Game::run([](const auto&) {
         static u16 t = 0; ++t;
-        const u8 x0 = static_cast<u8>(40 + (t % 220));
-        const u8 x1 = static_cast<u8>(40 + ((t + 110) % 220));
+        // Slide both 8px shapes across the screen, offset by half a period. Range
+        // 40..239 keeps the sprite (x + 8) within the u8 x coordinate, so the
+        // position never wraps past 255 and jumps to the far left.
+        const u8 x0 = static_cast<u8>(40 + (t % 200));
+        const u8 x1 = static_cast<u8>(40 + ((t + 100) % 200));
         Game::sprite(0, kBall, x0, 120);
         Game::sprite(1, kPix,  x1, 150);
     });

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -280,6 +280,14 @@ Background / compositing (for sprites-over-bitmap):
 - `Game::overlay_publish_background()` — publish the bitmap drawn via `Game::gfx()`
   to the live display page(s); sprite footprints are then restored from it each
   frame
+- `Game::antic_playfield(bool enable)` — enable/disable the ANTIC playfield
+  (character/bitmap) DMA. **Atari-only, opt-in.** When an opaque VBXE overlay
+  covers the screen the ANTIC playfield is invisible, but its per-scanline VRAM
+  DMA starves the blitter's restore copies and can collapse the compositor's
+  per-frame budget (e.g. `Background::Bitmap` ran the loop at ~8 Hz instead of
+  60). Call `antic_playfield(false)` once after init — and after any
+  `set_screen`, which re-enables it — to free the bus; the overlay keeps driving
+  the display. Leave it enabled for transparent overlays that show ANTIC through.
 
 Overlay collision snapshots, latched at the frame service:
 

--- a/engine/core.h
+++ b/engine/core.h
@@ -226,6 +226,17 @@ public:
         Platform::hal::overlay_publish_background();
     }
 
+    // Enable/disable the ANTIC playfield (character/bitmap) DMA. When an opaque
+    // VBXE overlay covers the screen the ANTIC playfield is invisible, but its
+    // per-scanline VRAM-bus DMA starves the blitter's restore copies and collapses
+    // the overlay compositor's per-frame budget. Call antic_playfield(false) once
+    // after init (and after any set_screen, which re-enables it) to free the bus;
+    // the overlay keeps driving the display. Leave it enabled for transparent
+    // overlays that show ANTIC through. Atari-only; opt-in (see API_REFERENCE.md).
+    static void antic_playfield(bool enable) {
+        Platform::hal::set_antic_playfield_dma(enable);
+    }
+
     // ── Overlay text mode (VBXE Text_80; no-op on platforms without it) ──
     // A dedicated text surface separate from the baseline ANTIC TextRegion API.
     // Chars are raw font indices (no screen-code remap); `attr` is the cell colour

--- a/engine/platform/atari/hal.h
+++ b/engine/platform/atari/hal.h
@@ -131,6 +131,18 @@ struct Hal {
         *os::SDMCTL = static_cast<uint8_t>((*os::SDMCTL & dmactl::PM_DMA_MASK) |
                                            dmactl::DL_ENABLE | mode_bits);
     }
+    // Toggle ONLY the ANTIC playfield fetch (the character/bitmap DMA), preserving
+    // the DL-enable and P/M bits. Under an opaque VBXE overlay the ANTIC playfield
+    // is fully hidden, yet its per-scanline VRAM-bus DMA starves the blitter's
+    // VRAM-read restore copies — collapsing the overlay compositor's per-frame
+    // budget (sprites-over-bitmap ran the game loop at ~8 Hz instead of 60).
+    // Dropping the playfield fetch frees the bus; the overlay still drives the
+    // display via its XDL, and DL/P-M DMA keep running. `on` restores normal width.
+    static void set_antic_playfield_dma(bool on) {
+        *os::SDMCTL = static_cast<uint8_t>(
+            (*os::SDMCTL & static_cast<uint8_t>(~dmactl::PLAYFIELD_MASK)) |
+            (on ? dmactl::PLAYFIELD_NORMAL : 0u));
+    }
     static void set_display_program(const uint8_t* dl) {
         const uint16_t a = static_cast<uint16_t>(reinterpret_cast<uintptr_t>(dl));
         *os::SDLSTL = static_cast<uint8_t>(a & 0xFF);


### PR DESCRIPTION
This pull request introduces an important performance optimization for Atari platforms using an opaque VBXE overlay by allowing the ANTIC playfield DMA to be selectively disabled. This prevents unnecessary VRAM bus contention, restoring full-speed blitter operations and resolving a major slowdown in the sprites-over-bitmap demo. Additionally, the buffer policy in the VBXE bringup demo is now mode-dependent, and documentation is updated to reflect these changes.

**Performance and Feature Improvements:**

* Added `Game::antic_playfield(bool)` to enable or disable the ANTIC playfield (character/bitmap) DMA, freeing the VRAM bus when a fully opaque VBXE overlay is active and preserving display-list and P/M DMA. This is opt-in and Atari-specific. [[1]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR229-R239) [[2]](diffhunk://#diff-4c3491c55edf80784db49ae86c675b89b8d858fb5a181e7029d6b94583f7f129R134-R145) [[3]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cR283-R290)
* Fixed a major slowdown (~8 Hz instead of 60 Hz) in the VBXE `Background::Bitmap` overlay by disabling the hidden ANTIC playfield's DMA in the `atari_vbxe_sprites` demo, restoring full-rate sprite motion. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R31) [[2]](diffhunk://#diff-bf43016d43412f58e637994e05ae40569a9537dadec5ff95e12219a85d27fa84R122-R137) [[3]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cR170-R179)

**Demo and Buffer Policy Adjustments:**

* Updated the VBXE bringup demo's buffer policy to select double- or single-buffering based on the diagnostic mode, ensuring correct display behavior and preventing content from vanishing in static modes. [[1]](diffhunk://#diff-1d78710f4de02e403dcadd9774104b6cefe06bb945ec56638142c825a4db93f6R42-R63) [[2]](diffhunk://#diff-1d78710f4de02e403dcadd9774104b6cefe06bb945ec56638142c825a4db93f6L166-L172)

**Bug Fixes:**

* Corrected sprite X position calculation in `atari_vbxe_sprites` to prevent wrapping past 255 and ensure sprites remain within valid coordinate ranges. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R31) [[2]](diffhunk://#diff-bf43016d43412f58e637994e05ae40569a9537dadec5ff95e12219a85d27fa84R122-R137)

**Documentation:**

* Updated `CHANGELOG.md`, `API_REFERENCE.md`, and `demo/README.md` to document the new `Game::antic_playfield(bool)` API, its usage, and the resolved performance regression. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R31) [[2]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cR283-R290) [[3]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cR170-R179)