### PR TITLE
Unified displaylayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,39 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-04
+
 ### Added
-- `Game::antic_playfield(bool)` (Atari, opt-in): enable/disable the ANTIC
-  playfield (character/bitmap) DMA, preserving display-list and P/M DMA. Under an
-  opaque VBXE overlay the ANTIC playfield is invisible, but its per-scanline VRAM
-  DMA starves the blitter's restore copies; calling `antic_playfield(false)` after
-  init frees the bus.
+- `engine::OverlayRegion<Mode, Height>` — a VRAM-backed VBXE overlay region usable
+  inside a `DisplayLayout` alongside ANTIC `TextRegion`/`BitmapRegion`s. It costs
+  zero screen-buffer RAM (its pixels live in VBXE VRAM), and region order sets the
+  overlay's vertical position. New overlay-aware `DisplayLayout` queries:
+  `has_overlay`, `is_pure_overlay`, `overlay_region_index()`.
+- Automatic ANTIC DMA control in `set_screen<S>()`: a **pure-overlay** screen
+  (every region is an `OverlayRegion`) keeps ANTIC DMA off — its display list
+  collapses to a 3-byte JVB stub and the VBXE overlay drives the display via its
+  XDL — which frees the VRAM bus for the blitter. ANTIC-only and mixed
+  overlay+ANTIC screens enable DMA as before. This makes the previous manual
+  `antic_playfield(false)` workaround unnecessary for the common opaque case.
+- `Game::antic_playfield(bool)` (Atari, opt-in) — retained as a manual escape
+  hatch for the cases the engine cannot infer: a transparent overlay that shows
+  ANTIC through (leave it enabled), or a mixed overlay+ANTIC layout that wants the
+  playfield fetch off. Toggles only the playfield DMA, preserving display-list and
+  P/M DMA.
+- Compile-time config-agreement check: `Core::set_screen` `static_assert`s that an
+  `OverlayRegion`'s mode and height match the platform's VBXE `Config`
+  (`overlay_mode`, `fb_height`) — e.g. `OverlayRegion<VBXE_HR>` under a
+  `Config<VBXE_SR>` is a build error instead of silent corruption.
 
 ### Fixed
 - VBXE `Background::Bitmap` overlay ran the game loop at ~8 Hz instead of 60 on
   real hardware: the hidden ANTIC text playfield's DMA contended the VRAM bus and
   stalled the blitter's per-frame VRAM→VRAM restore copies, overrunning the VBI.
-  The `atari_vbxe_sprites` demo now calls `Game::antic_playfield(false)`, restoring
-  full-rate motion. (Regression was masked because the dirty-rect restore was
-  host-validated on `mos-sim`, which doesn't model VBXE/ANTIC bus timing.)
+  The `atari_vbxe_sprites` demo now uses a pure-overlay
+  `DisplayLayout<OverlayRegion<VBXE_SR, 240>>`, so `set_screen` keeps ANTIC DMA off
+  automatically, restoring full-rate motion. (Regression was masked because the
+  dirty-rect restore was host-validated on `mos-sim`, which doesn't model
+  VBXE/ANTIC bus timing.)
 - `atari_vbxe_sprites`: sprite X position was computed as `u8` over a 40..259
   range, wrapping past 255 and briefly jumping the shape to the far left; the
   slide now stays within the valid u8 coordinate range.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EDGE (Eight-bit Damned! Game Engine)
 
-> **Applies to EDGE v0.2.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
+> **Applies to EDGE v0.3.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
 
 EDGE is a C++20 game engine for constrained 6502-class systems, built around a small, deterministic, compile-time configured API instead of a heavy runtime.
 The project is Atari-first today, but its architecture is intended to support additional 6502-family platforms over time. Game code is written against portable engine subsystems while hardware details live behind a platform HAL and compile-time capability profiles.
@@ -50,7 +50,9 @@ Implemented today:
 - fixed-size slot and packed pools
 - fixed-point math and lookup helpers
 - Atari VBXE backend: 256-colour overlay, hardware 80-column text mode, blitter,
-  and a sprites-over-bitmap compositor
+  and a sprites-over-bitmap compositor. The overlay is a first-class
+  `engine::OverlayRegion` in a screen's `DisplayLayout`; a pure-overlay screen
+  turns ANTIC DMA off automatically
 
 Planned or intentionally deferred:
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Hardware validation demo (`atari_hw_test.xex`)
 
-> **Applies to EDGE v0.2.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 A minimal Atari 8-bit program that drives every engine subsystem at once, so
 the engine's live ANTIC path can be confirmed on real hardware / emulators
@@ -167,13 +167,15 @@ prints through the portable `Game::overlay_*` text seam.
 
 Double-buffered `Background::Bitmap`: the background is drawn once with
 `Game::gfx()` into the VRAM master, published, and two sprites slide over it.
-Because the overlay is opaque, the demo calls `Game::antic_playfield(false)` after
-setup: the hidden ANTIC text playfield's DMA would otherwise contend the VRAM bus
-and stall the blitter's per-frame restore copies, throttling motion to ~8 Hz.
+The screen is a pure-overlay `DisplayLayout<OverlayRegion<VBXE_SR, 240>>`, so
+`set_screen` keeps ANTIC DMA off automatically — without that, the hidden ANTIC
+playfield's DMA would contend the VRAM bus and stall the blitter's per-frame
+restore copies, throttling motion to ~8 Hz. (Earlier versions of this demo
+achieved the same with a manual `Game::antic_playfield(false)` call.)
 
 | Observation | Proves |
 |---|---|
 | The `vbxe_gfx` picture as a steady background | `gfx()` master canvas + `overlay_publish_background()` |
 | A red ball and a multi-colour pixel sprite slide across | `make_sprite` (Packed1bpp) + `make_pixel_sprite` (Pixel8bpp) |
 | The background stays intact under the moving sprites | per-frame footprint restore from the master (flicker-free) |
-| The sprites move at full speed (~60 px/s) | `Game::antic_playfield(false)` frees the VRAM bus for the blitter |
+| The sprites move at full speed (~60 px/s) | pure-overlay layout keeps ANTIC DMA off, freeing the VRAM bus for the blitter |

--- a/demo/vbxe_bringup.cpp
+++ b/demo/vbxe_bringup.cpp
@@ -57,9 +57,9 @@ namespace V = atari::vbxe;
 // show the unpainted (transparent, index 0) back page — the ANTIC playfield reads
 // through and the painted content appears to vanish.
 #if VBXE_BRINGUP_MODE == 3
-using Cfg = V::Config<V::Mode::SR_320, V::Buffers::Double>;   // sprite demo: flip pages
+using Cfg = V::Config<M::Mode::VBXE_SR, V::Buffers::Double>;   // sprite demo: flip pages
 #else
-using Cfg = V::Config<V::Mode::SR_320, V::Buffers::Single>;   // static paint: no flip
+using Cfg = V::Config<M::Mode::VBXE_SR, V::Buffers::Single>;   // static paint: no flip
 #endif
 using Platform = M::Platform<
     M::Machine::XL,

--- a/demo/vbxe_gfx.cpp
+++ b/demo/vbxe_gfx.cpp
@@ -34,7 +34,7 @@ namespace V = atari::vbxe;
 //
 // Single-buffered VBXE (SR_320). No bitmap_region in GameConfig, so the gfx
 // canvas is the overlay framebuffer (Region == void, the blitter path).
-using Cfg = V::Config<V::Mode::SR_320, V::Buffers::Single>;
+using Cfg = V::Config<M::Mode::VBXE_SR, V::Buffers::Single>;
 using Platform = M::Platform<
     M::Machine::XL,
     M::RAM::Baseline,

--- a/demo/vbxe_sprites_over_bitmap.cpp
+++ b/demo/vbxe_sprites_over_bitmap.cpp
@@ -40,7 +40,7 @@ namespace V = atari::vbxe;
 //
 // Double-buffered VBXE (SR_320) with Background::Bitmap: gfx() draws into the
 // VRAM master canvas, and the sprite compositor restores footprints from it.
-using Cfg = V::Config<V::Mode::SR_320, V::Buffers::Double, V::RegBase::D640,
+using Cfg = V::Config<M::Mode::VBXE_SR, V::Buffers::Double, V::RegBase::D640,
                       V::MEMAC_A, 0x00000, V::Background::Bitmap>;
 using Platform = M::Platform<
     M::Machine::XL,

--- a/demo/vbxe_sprites_over_bitmap.cpp
+++ b/demo/vbxe_sprites_over_bitmap.cpp
@@ -24,6 +24,8 @@
 //  * VBXE register base $D640 (engine default); a $D740 board needs a Config
 //    override. Run with BASIC DISABLED (MEMAC-A window is $B000-$BFFF). Altirra:
 //    enable the VBXE device with the FX core.
+//  * The screen is a single OverlayRegion (pure overlay), so the engine keeps
+//    ANTIC DMA off automatically — no manual antic_playfield(false) call.
 
 #include <stdint.h>
 
@@ -49,11 +51,16 @@ using Platform = M::Platform<
     M::Sound::Mono,
     M::TV::NTSC>;
 
-struct ScreenText {
-    using display = engine::DisplayLayout<engine::TextRegion<M::Mode::MODE_2, 24>>;
+// A pure-overlay screen: one VBXE overlay region, no ANTIC content. set_screen
+// keeps ANTIC DMA off for it automatically (freeing the VRAM bus), and the
+// OverlayRegion's mode/height are checked against the Config above at compile
+// time (VBXE_SR, 240 == Cfg::fb_height).
+struct GameScreen {
+    using display =
+        engine::DisplayLayout<engine::OverlayRegion<M::Mode::VBXE_SR, 240>>;
 };
 struct GameConfig {
-    using screens = engine::ScreenSet<ScreenText>;
+    using screens = engine::ScreenSet<GameScreen>;
     static constexpr u8 max_sprites    = 2;
     static constexpr u8 sound_channels = 1;
 };
@@ -119,11 +126,10 @@ int main() {
     draw_background();               // draw into the VRAM master canvas
     Game::overlay_publish_background();  // seed both display pages from the master
 
-    // The overlay is opaque, so the ANTIC text playfield behind it is invisible —
-    // but its per-scanline VRAM-bus DMA would otherwise starve the blitter's
-    // master->framebuffer restore copies and throttle the game loop to ~8 Hz.
-    // Dropping the (hidden) playfield fetch frees the bus for full 60 Hz motion.
-    Game::antic_playfield(false);
+    // (ANTIC DMA is already off: GameScreen is a pure-overlay layout, so
+    // set_screen never enabled the playfield — the VRAM bus stays free for the
+    // blitter's restore copies and the loop runs at full 60 Hz. No manual
+    // antic_playfield(false) needed.)
 
     Game::sprite_color(0, 1);        // kBall coloured palette-1 index 1 (red)
 

--- a/demo/vbxe_text.cpp
+++ b/demo/vbxe_text.cpp
@@ -1,6 +1,6 @@
 // demo/vbxe_text.cpp — Edge engine VBXE 80-column text-mode demo.
 //
-// Brings up the VBXE overlay in hardware text mode (Mode::Text_80), uploads the
+// Brings up the VBXE overlay in hardware text mode (Mode::VBXE_T80), uploads the
 // supplied PREPPIE font to VBXE VRAM (CHBASE), and prints text into the character
 // map through the portable engine API (Game::overlay_*). Produces a loadable .xex
 // (mos-atari8-dos target; see CMakeLists.txt). Run on Altirra (or hardware) with a
@@ -30,7 +30,7 @@ namespace V = atari::vbxe;
 // ── Platform + game configuration ────────────────────────────────────────
 //
 // 80-column text overlay, single-buffered. No sprites — the picture persists.
-using Cfg = V::Config<V::Mode::Text_80, V::Buffers::Single>;
+using Cfg = V::Config<M::Mode::VBXE_T80, V::Buffers::Single>;
 using Platform = M::Platform<
     M::Machine::XL,
     M::RAM::Baseline,

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # EDGE API Reference
 
-> **Applies to EDGE v0.2.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This reference is organized in two layers:
 
@@ -157,10 +157,17 @@ The current concrete platform implementation is Atari and is described later in 
 
 ### Region Descriptors
 
-The engine exposes two display-region kinds:
+The engine exposes three display-region kinds:
 
 - `engine::TextRegion<Mode, Height>`
 - `engine::BitmapRegion<Mode, Height>`
+- `engine::OverlayRegion<Mode, Height>` — a VBXE overlay region whose pixels live
+  in VBXE VRAM (zero screen-buffer RAM). `Mode` is a VBXE overlay mode
+  (`atari::Mode::VBXE_SR`/`VBXE_HR`/`VBXE_LR`/`VBXE_T80`). Region order sets the
+  overlay's vertical position. A layout of only `OverlayRegion`s is a *pure
+  overlay*: `set_screen` keeps ANTIC DMA off for it automatically (no
+  `antic_playfield(false)` needed), and its `OverlayRegion` mode/height are checked
+  against the platform's VBXE `Config` at compile time.
 
 These are composed into a screen layout:
 
@@ -281,13 +288,17 @@ Background / compositing (for sprites-over-bitmap):
   to the live display page(s); sprite footprints are then restored from it each
   frame
 - `Game::antic_playfield(bool enable)` — enable/disable the ANTIC playfield
-  (character/bitmap) DMA. **Atari-only, opt-in.** When an opaque VBXE overlay
-  covers the screen the ANTIC playfield is invisible, but its per-scanline VRAM
-  DMA starves the blitter's restore copies and can collapse the compositor's
-  per-frame budget (e.g. `Background::Bitmap` ran the loop at ~8 Hz instead of
-  60). Call `antic_playfield(false)` once after init — and after any
-  `set_screen`, which re-enables it — to free the bus; the overlay keeps driving
-  the display. Leave it enabled for transparent overlays that show ANTIC through.
+  (character/bitmap) DMA. **Atari-only, opt-in escape hatch.** The common case is
+  now automatic: a *pure-overlay* screen (`DisplayLayout` of only
+  `OverlayRegion`s) keeps ANTIC DMA off through `set_screen`, so you do **not**
+  need to call this. When an opaque VBXE overlay covers the screen the ANTIC
+  playfield is invisible, but its per-scanline VRAM DMA starves the blitter's
+  restore copies and can collapse the compositor's per-frame budget (e.g.
+  `Background::Bitmap` ran the loop at ~8 Hz instead of 60). Use this only for the
+  cases the engine can't infer: a transparent overlay that shows ANTIC through
+  (leave it enabled), or a mixed overlay+ANTIC layout where you want the playfield
+  fetch off anyway. It toggles only the playfield bits; any `set_screen` on a
+  non-pure-overlay layout re-enables them.
 
 Overlay collision snapshots, latched at the frame service:
 

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -1,6 +1,6 @@
 # EDGE Atari Platform Guide
 
-> **Applies to EDGE v0.2.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This document describes the first concrete EDGE backend: the Atari 8-bit family.
 

--- a/documents/QUICK_START.md
+++ b/documents/QUICK_START.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-> **Applies to EDGE v0.2.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This guide introduces EDGE from the engine author's point of view first, then shows the current concrete setup using the Atari backend.
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 # EDGE Engine Documentation
 
-> **Applies to EDGE v0.2.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 EDGE is a C++ engine for building games and interactive applications on constrained 6502-class systems.
 

--- a/engine/core.h
+++ b/engine/core.h
@@ -163,6 +163,9 @@ public:
         using caps = engine::caps_of_t<Platform>;
         if constexpr (caps::has_blitter) {
             // VBXE overlay bring-up (MEMAC window + full-screen XDL + enable).
+            // A pure-overlay InitialScreen no longer needs a manual
+            // antic_playfield(false): set_screen keeps ANTIC DMA off for it, so
+            // the playfield never contends the VRAM bus (see screen.h).
             Platform::hal::overlay_init();
         } else {
             setup_sprites();
@@ -180,6 +183,8 @@ public:
     static void init() {
         using caps = engine::caps_of_t<Platform>;
         if constexpr (caps::has_blitter) {
+            // Pure-overlay layouts no longer need a manual antic_playfield(false):
+            // set_screen keeps ANTIC DMA off for them (see screen.h).
             Platform::hal::overlay_init();
         } else {
             setup_sprites();
@@ -226,13 +231,17 @@ public:
         Platform::hal::overlay_publish_background();
     }
 
-    // Enable/disable the ANTIC playfield (character/bitmap) DMA. When an opaque
-    // VBXE overlay covers the screen the ANTIC playfield is invisible, but its
-    // per-scanline VRAM-bus DMA starves the blitter's restore copies and collapses
-    // the overlay compositor's per-frame budget. Call antic_playfield(false) once
-    // after init (and after any set_screen, which re-enables it) to free the bus;
-    // the overlay keeps driving the display. Leave it enabled for transparent
-    // overlays that show ANTIC through. Atari-only; opt-in (see API_REFERENCE.md).
+    // Enable/disable the ANTIC playfield (character/bitmap) DMA. The common
+    // opaque VBXE-only case is now automatic: a pure-overlay screen
+    // (is_pure_overlay) keeps ANTIC DMA off through set_screen, so no manual call
+    // is needed. This remains as an escape hatch for the cases the engine can't
+    // infer: a transparent overlay that shows ANTIC through (leave it enabled),
+    // or a mixed overlay+ANTIC layout where you want the playfield fetch off to
+    // free the VRAM bus even though ANTIC regions are present. When an opaque
+    // overlay covers the screen the ANTIC playfield is invisible, but its
+    // per-scanline VRAM-bus DMA starves the blitter's restore copies and
+    // collapses the overlay compositor's per-frame budget. Re-enabled by any
+    // set_screen on a non-pure-overlay layout. Atari-only (see API_REFERENCE.md).
     static void antic_playfield(bool enable) {
         Platform::hal::set_antic_playfield_dma(enable);
     }
@@ -287,6 +296,26 @@ public:
     // scroll_map() once the game has bound its map buffer.
     template <typename S, typename Cb>
     static void set_screen(Cb cb) {
+        // Config agreement: if this screen declares a VBXE overlay region, its
+        // mode and height must match the VBXE Config the graphics axis was built
+        // with — otherwise the ANTIC display list reserves overlay scanlines that
+        // disagree with the live overlay framebuffer (silent corruption). Checked
+        // here (not in the generic ScreenManager) because the VBXE Config is only
+        // reachable through Platform::graphics, and this runs for every screen.
+        if constexpr (engine::caps_of_t<Platform>::has_blitter) {
+            using Layout = typename S::display;
+            if constexpr (Layout::has_overlay) {
+                using OvRegion =
+                    typename Layout::template region_at<Layout::overlay_region_index()>;
+                using Cfg = typename Platform::graphics::config;  // gfx::VBXE<Cfg>::config
+                static_assert(OvRegion::height <= Cfg::fb_height,
+                    "OverlayRegion height exceeds the VBXE framebuffer height");
+                static_assert(OvRegion::mode == Cfg::overlay_mode,
+                    "OverlayRegion mode does not match the VBXE Config overlay_mode "
+                    "(e.g. OverlayRegion<VBXE_SR> under a Config<VBXE_HR>)");
+            }
+        }
+
         scroll.deactivate();
         screen.template set_screen<S>(cb);
         // Baseline: bind the bitmap canvas to S's first bitmap region (if any), so

--- a/engine/display.h
+++ b/engine/display.h
@@ -163,6 +163,7 @@ struct TextRegion {
     static constexpr u8        height         = Height;   // text rows
     static constexpr bool      is_text        = true;
     static constexpr bool      is_scroll      = false;
+    static constexpr bool      is_overlay     = false;
     static constexpr u8        bytes_per_line =
         engine::display::traits<mode_type>::bytes_per_line(M);
     static constexpr u16       ram_bytes      = static_cast<u16>(Height) * bytes_per_line;
@@ -180,6 +181,7 @@ struct BitmapRegion {
     static constexpr u8        height         = Height;   // scanlines / mode-lines
     static constexpr bool      is_text        = false;
     static constexpr bool      is_scroll      = false;
+    static constexpr bool      is_overlay     = false;
     static constexpr u8        bytes_per_line =
         engine::display::traits<mode_type>::bytes_per_line(M);
     static constexpr u16       ram_bytes      = static_cast<u16>(Height) * bytes_per_line;
@@ -211,12 +213,50 @@ struct ScrollRegion {
     static constexpr u8        height         = Inner::height;   // visible rows / lines
     static constexpr bool      is_text        = Inner::is_text;
     static constexpr bool      is_scroll      = true;
+    static constexpr bool      is_overlay     = false;   // overlays never ANTIC-scroll
     static constexpr u8        bytes_per_line = Inner::bytes_per_line;
     static constexpr u16       ram_bytes      = 0;               // backed by the map buffer
     static constexpr u16       map_width      = MapW;
     static constexpr u16       map_height     = MapH;
 
     using view = typename Inner::view;
+};
+
+// ── OverlayRegion ─────────────────────────────────────────────────────
+//
+// A region drawn into the VBXE overlay plane rather than the shared ANTIC screen
+// buffer. Its pixels live in VBXE VRAM, so `ram_bytes` is 0 (like ScrollRegion it
+// contributes nothing to the screen buffer or to following regions' offsets), and
+// it is *not* an ANTIC display-list mode line — the backend builder reads
+// `is_overlay` to skip it. Drawing goes through Game::gfx() (the blitter/MEMAC
+// path), not the view below.
+//
+// `bytes_per_line` and `map_width` are u16 here because VBXE_SR reaches 320
+// bytes/line — wider than any ANTIC mode (so the existing TextRegion/BitmapRegion
+// keep their u8). The mode must be one of the VBXE overlay modes.
+template <auto M, u8 Height>
+struct OverlayRegion {
+    using mode_type = decltype(M);
+    static constexpr mode_type mode           = M;
+    static constexpr u8        height         = Height;
+    static constexpr bool      is_text        =
+        engine::display::traits<mode_type>::is_text(M);
+    static constexpr bool      is_scroll      = false;
+    static constexpr bool      is_overlay     = true;
+    static constexpr u16       bytes_per_line =          // u16: VBXE reaches 320
+        engine::display::traits<mode_type>::bytes_per_line(M);
+    static constexpr u16       ram_bytes      = 0;        // VRAM-backed, not screen buffer
+    static constexpr u16       map_width      = bytes_per_line;
+    static constexpr u16       map_height     = Height;
+
+    static_assert(engine::display::traits<mode_type>::is_vbxe(M),
+                  "OverlayRegion requires a VBXE mode (VBXE_SR, VBXE_HR, VBXE_LR, VBXE_T80)");
+
+    // Placeholder view: a typed metadata handle, not a drawing surface. Overlay
+    // pixels live in VRAM, so the view's `ptr` is nullptr at runtime and must not
+    // be dereferenced — drawing goes through Game::gfx(), which dispatches to the
+    // blitter/MEMAC path. (For VBXE_T80 this will later become an OverlayTextView.)
+    using view = BitmapRegionView<M, Height>;
 };
 
 // ── Pack indexing helper ──────────────────────────────────────────────
@@ -257,21 +297,45 @@ struct DisplayLayout {
     static constexpr u8  region_mode_byte[region_count]      =
         { engine::display::traits<typename Regions::mode_type>::mode_opcode(
               Regions::mode)... };
-    static constexpr u8  region_bytes_per_line[region_count] =
+    // u16: VBXE overlay regions reach 320 bytes/line (wider than any ANTIC mode).
+    // The ANTIC display-list builder skips overlay regions (region_is_overlay), so
+    // ANTIC entries still hold their familiar small (<=40) values.
+    static constexpr u16 region_bytes_per_line[region_count] =
         { Regions::bytes_per_line... };
     static constexpr bool region_is_text[region_count]       = { Regions::is_text... };
     // Scroll metadata (non-scroll regions report is_scroll=false, map == region).
     static constexpr bool region_is_scroll[region_count]     = { Regions::is_scroll... };
     static constexpr u16 region_map_width[region_count]      = { Regions::map_width... };
     static constexpr u16 region_map_height[region_count]     = { Regions::map_height... };
+    // Overlay metadata: which regions draw into the VBXE overlay plane (VRAM) rather
+    // than the ANTIC screen buffer. The backend builder skips these mode lines.
+    static constexpr bool region_is_overlay[region_count]    = { Regions::is_overlay... };
 
     // True if any region in this layout scrolls.
     static constexpr bool has_scroll = (Regions::is_scroll || ... || false);
+
+    // True if any region is an overlay.
+    static constexpr bool has_overlay = (Regions::is_overlay || ... || false);
+
+    // True if ALL regions are overlay — ANTIC can be fully disabled. (region_count
+    // >= 1 is asserted, so a layout with no overlay regions is correctly false.)
+    static constexpr bool is_pure_overlay = (Regions::is_overlay && ... && true);
+
+    // Count of non-overlay (ANTIC) regions.
+    static constexpr u8 antic_region_count =
+        static_cast<u8>(((!Regions::is_overlay ? 1 : 0) + ... + 0));
 
     // Index of the first scrolling region, or region_count if none.
     static constexpr u8 scroll_region_index() {
         for (u8 i = 0; i < region_count; ++i)
             if (region_is_scroll[i]) return i;
+        return region_count;
+    }
+
+    // Index of the first overlay region, or region_count if none.
+    static constexpr u8 overlay_region_index() {
+        for (u8 i = 0; i < region_count; ++i)
+            if (region_is_overlay[i]) return i;
         return region_count;
     }
 

--- a/engine/display_traits.h
+++ b/engine/display_traits.h
@@ -14,13 +14,14 @@
 //
 // Required static members of a specialisation `traits<ModeT>` (all constexpr):
 //   static constexpr bool is_text(ModeT);            // text vs bitmap mode
-//   static constexpr u8   bytes_per_line(ModeT);     // screen-memory width
+//   static constexpr bool is_vbxe(ModeT);            // overlay (VBXE) vs base mode
+//   static constexpr u16  bytes_per_line(ModeT);     // screen-memory width
 //   static constexpr u8   bits_per_pixel(ModeT);     // bitmap packing (text: n/a)
 //   static constexpr u8   scanlines_per_line(ModeT); // mode-line height
 //   static constexpr u8   mode_opcode(ModeT);        // backend display-program byte
 //   static constexpr u8   to_screen_code(char);      // ASCII -> screen tile code
 //   static constexpr u8   fine_scroll_range(ModeT);  // horizontal fine-scroll modulus
-//   static constexpr u8   scroll_fetch_width(ModeT); // cells fetched per scrolled line
+//   static constexpr u16  scroll_fetch_width(ModeT); // cells fetched per scrolled line
 //   static constexpr bool fine_scroll_inverts_x(ModeT); // fine X register opposes coarse
 //   static constexpr bool fine_scroll_inverts_y(ModeT); // fine Y register opposes coarse
 //                                                    //   (these four only used by scroll-active screens)

--- a/engine/platform/atari/antic.h
+++ b/engine/platform/atari/antic.h
@@ -1,53 +1,24 @@
 #ifndef ENGINE_PLATFORM_ATARI_ANTIC_H
 #define ENGINE_PLATFORM_ATARI_ANTIC_H
 
-// platform/atari/antic.h — ANTIC display modes, display-list encoding, and the
-// per-mode geometry the display subsystem is built on.
+// platform/atari/antic.h — ANTIC display-list encoding and the Player/Missile
+// memory layout.
 //
-// This header is the single source of truth for ANTIC mode geometry. The
-// portable display layer (engine/display.h) is parameterised on a backend mode
-// token and reaches all per-mode geometry through engine::display::traits<ModeT>
-// (engine/display_traits.h); the Atari specialisation in
-// platform/atari/display_traits.h forwards to the constexpr helpers here. So the
-// generic display layer never includes this header — the backend binds to it via
-// the trait specialisation, and a second platform family supplies its own.
+// The display-mode vocabulary (`atari::Mode`) and its per-mode geometry helpers
+// live in modes.h (the single source of truth), which this header includes so
+// every existing includer of antic.h keeps seeing them. What remains here is the
+// ANTIC-specific encoding: the display-list opcode/LMS/DLI bits and the P/M DMA
+// layout.
 //
 // Depends only on hardware documentation (Dependency Rule 7) and types.h.
 
 #include "../../types.h"
+#include "modes.h"
 
 namespace atari {
 
 using engine::u8;
 using engine::u16;
-
-// ── ANTIC display modes ──────────────────────────────────────────────
-//
-// The enum value is the ANTIC display-list mode nibble, so the display-list
-// "mode line" instruction byte for a region is simply `u8(Mode)` (optionally
-// OR'd with the LMS/DLI bits below). Text modes draw characters from the set at
-// CHBASE; bitmap modes draw packed pixels.
-//
-//   text:    MODE_2 (40×24, 1bpp text)   MODE_4 (40×24, 4-colour text)
-//            MODE_6 (20×24, 5-colour)    MODE_3/5/7 variants
-//   bitmap:  MODE_8 (40×24, 4-colour)    BITMAP_D (160×192, 2bpp, "GR.7")
-//            BITMAP_E (160×192, 2bpp)    BITMAP_F (320×192, 1bpp, "GR.8")
-enum class Mode : u8 {
-    MODE_2   = 0x02,
-    MODE_3   = 0x03,
-    MODE_4   = 0x04,
-    MODE_5   = 0x05,
-    MODE_6   = 0x06,
-    MODE_7   = 0x07,
-    MODE_8   = 0x08,
-    BITMAP_9 = 0x09,
-    BITMAP_A = 0x0A,
-    BITMAP_B = 0x0B,
-    BITMAP_C = 0x0C,
-    BITMAP_D = 0x0D,
-    BITMAP_E = 0x0E,
-    BITMAP_F = 0x0F,
-};
 
 // ── Display-list instruction bits / opcodes ──────────────────────────
 //
@@ -64,112 +35,6 @@ inline constexpr u8 DL_JVB     = 0x41;   // jump + wait for vertical blank (loop
 // Blank-line instruction for `n` blank scanlines (1..8). Encoded as (n-1)<<4.
 constexpr u8 dl_blank(u8 n) { return static_cast<u8>((n - 1) << 4); }
 
-// ── Mode geometry ────────────────────────────────────────────────────
-//
-// `bytes_per_line` is the screen-memory width of one mode line. For text modes
-// it is the column count; for bitmap modes it is ceil(width_px * bpp / 8).
-constexpr u8 bytes_per_line(Mode m) {
-    switch (m) {
-        case Mode::MODE_2: case Mode::MODE_3:
-        case Mode::MODE_4: case Mode::MODE_5:
-            return 40;                       // 40-column text
-        case Mode::MODE_6: case Mode::MODE_7:
-            return 20;                       // 20-column text
-        case Mode::MODE_8: case Mode::BITMAP_9:
-            return 10;                       // 40 px, 2bpp / 1bpp narrow
-        case Mode::BITMAP_A: case Mode::BITMAP_B:
-            return 20;                       // 80 px
-        case Mode::BITMAP_C: case Mode::BITMAP_D: case Mode::BITMAP_E:
-            return 40;                       // 160 px (2bpp) / 320 px (1bpp C)
-        case Mode::BITMAP_F:
-            return 40;                       // 320 px, 1bpp
-    }
-    return 40;
-}
-
-// True for character (text) modes, false for bitmap/map modes.
-constexpr bool is_text(Mode m) {
-    return static_cast<u8>(m) >= 0x02 && static_cast<u8>(m) <= 0x07;
-}
-
-// Bits per pixel for bitmap modes (undefined/irrelevant for text modes, where
-// "pixels" are characters). F is hi-res 1bpp; 8/9/A..E are 2bpp; B is 1bpp.
-constexpr u8 bits_per_pixel(Mode m) {
-    switch (m) {
-        case Mode::BITMAP_F: case Mode::MODE_8: case Mode::BITMAP_C:
-            return 1;
-        case Mode::BITMAP_9: case Mode::BITMAP_B:
-            return 1;
-        default:
-            return 2;                        // 4/D/E and the 4-colour map modes
-    }
-}
-
-// Scanlines ANTIC draws for one mode line of this mode. Text rows are 8 tall;
-// the high-resolution bitmap modes (C/E/F) are 1 scanline per line, D is 2.
-constexpr u8 scanlines_per_line(Mode m) {
-    switch (m) {
-        case Mode::MODE_2: case Mode::MODE_4: case Mode::MODE_6:
-        case Mode::MODE_8:
-            return 8;
-        case Mode::MODE_3:
-            return 10;
-        case Mode::MODE_5: case Mode::MODE_7:
-            return 16;
-        case Mode::BITMAP_9: case Mode::BITMAP_A:
-            return 4;
-        case Mode::BITMAP_B: case Mode::BITMAP_D:
-            return 2;
-        case Mode::BITMAP_C: case Mode::BITMAP_E: case Mode::BITMAP_F:
-            return 1;
-    }
-    return 1;
-}
-
-// The display-list mode-line instruction byte for this mode (no LMS/DLI bits).
-constexpr u8 dl_mode_byte(Mode m) { return static_cast<u8>(m); }
-
-// ── Hardware scrolling geometry ──────────────────────────────────────
-//
-// When a mode line has DL_HSCROLL set, ANTIC fetches the *next wider* playfield
-// so there is off-screen content to slide in: a normal-width 40-column text line
-// fetches 48 bytes instead of 40. `scroll_margin` is those extra bytes; a scroll
-// map's row stride must be at least `scroll_fetch_width` so every fetched byte
-// is real map data.
-constexpr u8 scroll_margin(Mode m) {
-    switch (m) {
-        case Mode::MODE_2: case Mode::MODE_3:
-        case Mode::MODE_4: case Mode::MODE_5:
-            return 8;                        // 40-col text: 40 -> 48
-        case Mode::MODE_6: case Mode::MODE_7:
-            return 4;                        // 20-col text: 20 -> 24
-        default:
-            return 8;
-    }
-}
-
-constexpr u8 scroll_fetch_width(Mode m) {
-    return static_cast<u8>(bytes_per_line(m) + scroll_margin(m));
-}
-
-// Fine-scroll modulus: the number of HSCROL color-clock positions that span one
-// character cell, i.e. how far HSCROL advances before a one-byte coarse step.
-// The normal playfield is 160 color clocks wide, so a 40-column cell is 4 color
-// clocks and a 20-column cell is 8. (Vertical fine scroll uses scanlines_per_line
-// as its modulus instead.) THIS is the value to verify against real hardware if a
-// fine->coarse handoff ever jumps — see demo/atari_scroll_test.cpp.
-constexpr u8 fine_scroll_range(Mode m) {
-    switch (m) {
-        case Mode::MODE_2: case Mode::MODE_3:
-        case Mode::MODE_4: case Mode::MODE_5:
-            return 4;                        // 160 color clocks / 40 cells
-        case Mode::MODE_6: case Mode::MODE_7:
-            return 8;                        // 160 color clocks / 20 cells
-        default:
-            return 4;
-    }
-}
-
 // ── Player/Missile memory layout ──────────────────────────────────────
 //
 // The single source of truth for the ANTIC P/M DMA layout, the basis for where
@@ -184,19 +49,6 @@ constexpr u8 fine_scroll_range(Mode m) {
 constexpr u16 pm_player_base (bool single) { return single ? 1024 : 512; }
 constexpr u16 pm_strip_size  (bool single) { return single ? 256  : 128; }
 constexpr u16 pm_missile_base(bool single) { return single ? 768  : 384; }
-
-// ── Character encoding ────────────────────────────────────────────────
-//
-// Convert an ASCII byte to its ANTIC internal screen code (the value stored in
-// screen memory, which differs from ATASCII). The internal code rotates ASCII:
-//   $20-$3F -> $00-$1F,  $40-$5F -> $20-$3F,  $60-$7F -> $40-$5F,
-//   $00-$1F -> $40-$5F.  Used by TextRegionView::print / print_num.
-constexpr u8 ascii_to_internal(char c) {
-    const u8 a = static_cast<u8>(c);
-    if (a < 0x20)  return static_cast<u8>(a + 0x40);
-    if (a < 0x60)  return static_cast<u8>(a - 0x20);
-    return a;                                 // $60-$7F map to themselves
-}
 
 } // namespace atari
 

--- a/engine/platform/atari/display_list.h
+++ b/engine/platform/atari/display_list.h
@@ -39,9 +39,14 @@ template <typename Layout>
 constexpr u16 display_list_base_size() {
     u16 s = 3 + 3;
     for (u8 i = 0; i < Layout::region_count; ++i) {
-        s += Layout::region_is_scroll[i]
-                 ? static_cast<u16>(3 * Layout::region_height[i])
-                 : static_cast<u16>(Layout::region_height[i]) + 2;
+        if (Layout::region_is_overlay[i]) {
+            // Overlay region: ceil(H/8) blank instructions, no mode lines / LMS.
+            s += static_cast<u16>((Layout::region_height[i] + 7) / 8);
+        } else if (Layout::region_is_scroll[i]) {
+            s += static_cast<u16>(3 * Layout::region_height[i]);
+        } else {
+            s += static_cast<u16>(Layout::region_height[i]) + 2;
+        }
     }
     return s;
 }
@@ -57,6 +62,8 @@ constexpr u16 lms_crossings_max(u16 b) {
 // crossing LMS (a 1-byte mode line becomes a 3-byte LMS).
 template <typename Layout>
 constexpr u16 display_list_capacity() {
+    // A pure-overlay layout is just the 3-byte self-looping JVB stub.
+    if constexpr (Layout::is_pure_overlay) return 3;
     u16 s = display_list_base_size<Layout>();
     for (u8 i = 0; i < Layout::region_count; ++i) {
         s += static_cast<u16>(2 * lms_crossings_max(Layout::region_ram[i]));
@@ -70,11 +77,13 @@ template <typename Layout>
 constexpr u16 max_lms_count() {
     u16 n = 0;
     for (u8 i = 0; i < Layout::region_count; ++i) {
+        if (Layout::region_is_overlay[i]) continue;   // overlays emit no LMS
         n += Layout::region_is_scroll[i]
                  ? static_cast<u16>(Layout::region_height[i])
                  : static_cast<u16>(1 + lms_crossings_max(Layout::region_ram[i]));
     }
-    return n;
+    // Min 1 so a pure-overlay layout never declares a zero-length lms_pos[] array.
+    return n < 1 ? 1 : n;
 }
 
 // Total scroll LMS (one per visible line of every scroll region). Sized at least
@@ -130,6 +139,18 @@ struct DisplayProgram {
         lms_count = 0;
         scroll_lms_count = 0;
 
+        // Pure-overlay layout: ANTIC DMA is disabled entirely by the screen
+        // manager, so the list need only satisfy the DLISTL pointer requirement.
+        // Emit a 3-byte self-looping JVB and nothing else.
+        if constexpr (Layout::is_pure_overlay) {
+            bytes[0] = DL_JVB;
+            jvb_pos  = 1;
+            bytes[1] = lo(dl_base);
+            bytes[2] = hi(dl_base);
+            size     = 3;
+            return;
+        }
+
         // Three 8-blank-line instructions (24 scanlines) to centre vertically.
         bytes[p++] = dl_blank(8);
         bytes[p++] = dl_blank(8);
@@ -137,6 +158,21 @@ struct DisplayProgram {
 
         for (u8 r = 0; r < region_count; ++r) {
             const u8  mode = Layout::region_mode_byte[r];
+
+            if (Layout::region_is_overlay[r]) {
+                // Overlay region: its pixels live in VBXE VRAM, not the ANTIC
+                // screen buffer, so reserve its scanlines with blank-line
+                // instructions (ceil(H/8)) instead of mode lines / LMS. Region
+                // order thus controls the overlay's vertical position.
+                u16 blanks = Layout::region_height[r];
+                while (blanks > 0) {
+                    u8 n = blanks > 8 ? static_cast<u8>(8) : static_cast<u8>(blanks);
+                    bytes[p++] = dl_blank(n);
+                    blanks = static_cast<u16>(blanks - n);
+                }
+                region_lms_pos[r] = 0;   // sentinel: no LMS for overlay regions
+                continue;
+            }
 
             if (Layout::region_is_scroll[r]) {
                 // Scroll region: every visible line gets its own LMS (with the

--- a/engine/platform/atari/display_traits.h
+++ b/engine/platform/atari/display_traits.h
@@ -22,7 +22,8 @@ namespace display {
 template <>
 struct traits<atari::Mode> {
     static constexpr bool is_text(atari::Mode m) { return atari::is_text(m); }
-    static constexpr engine::u8 bytes_per_line(atari::Mode m) {
+    static constexpr bool is_vbxe(atari::Mode m) { return atari::is_vbxe(m); }
+    static constexpr engine::u16 bytes_per_line(atari::Mode m) {
         return atari::bytes_per_line(m);
     }
     static constexpr engine::u8 bits_per_pixel(atari::Mode m) {
@@ -37,7 +38,7 @@ struct traits<atari::Mode> {
     static constexpr engine::u8 fine_scroll_range(atari::Mode m) {
         return atari::fine_scroll_range(m);
     }
-    static constexpr engine::u8 scroll_fetch_width(atari::Mode m) {
+    static constexpr engine::u16 scroll_fetch_width(atari::Mode m) {
         return atari::scroll_fetch_width(m);
     }
     // ANTIC register conventions: raising HSCROL moves the picture opposite to the

--- a/engine/platform/atari/modes.h
+++ b/engine/platform/atari/modes.h
@@ -1,0 +1,211 @@
+#ifndef ENGINE_PLATFORM_ATARI_MODES_H
+#define ENGINE_PLATFORM_ATARI_MODES_H
+
+// platform/atari/modes.h — the Atari display-mode vocabulary and the per-mode
+// geometry the display subsystem is built on.
+//
+// This header is the single source of truth for Atari mode geometry: both ANTIC
+// display modes and the VBXE overlay modes live in one `atari::Mode` enum, and
+// every constexpr helper below switches on it. The portable display layer
+// (engine/display.h) is parameterised on a backend mode token and reaches all
+// per-mode geometry through engine::display::traits<ModeT>
+// (engine/display_traits.h); the Atari specialisation in
+// platform/atari/display_traits.h forwards to the helpers here. So the generic
+// display layer never includes this header — the backend binds to it via the
+// trait specialisation, and a second platform family supplies its own.
+//
+// ANTIC display-list encoding (the opcode/DLI/LMS bits and the P/M layout) lives
+// in antic.h, which includes this header.
+//
+// Depends only on hardware documentation (Dependency Rule 7) and types.h.
+
+#include "../../types.h"
+
+namespace atari {
+
+using engine::u8;
+using engine::u16;
+
+// ── Display modes ────────────────────────────────────────────────────
+//
+// For ANTIC modes the enum value is the ANTIC display-list mode nibble, so the
+// display-list "mode line" instruction byte for a region is simply `u8(Mode)`
+// (optionally OR'd with the LMS/DLI bits in antic.h). Text modes draw characters
+// from the set at CHBASE; bitmap modes draw packed pixels.
+//
+//   text:    MODE_2 (40×24, 1bpp text)   MODE_4 (40×24, 4-colour text)
+//            MODE_6 (20×24, 5-colour)    MODE_3/5/7 variants
+//   bitmap:  MODE_8 (40×24, 4-colour)    BITMAP_D (160×192, 2bpp, "GR.7")
+//            BITMAP_E (160×192, 2bpp)    BITMAP_F (320×192, 1bpp, "GR.8")
+//
+// VBXE overlay modes occupy the high range (>= 0x80). They are not ANTIC
+// display-list bytes (dl_mode_byte() returns 0); they describe the VBXE overlay
+// plane the gfx::VBXE axis draws over/under ANTIC output (see vbxe_config.h).
+enum class Mode : u8 {
+    MODE_2   = 0x02,
+    MODE_3   = 0x03,
+    MODE_4   = 0x04,
+    MODE_5   = 0x05,
+    MODE_6   = 0x06,
+    MODE_7   = 0x07,
+    MODE_8   = 0x08,
+    BITMAP_9 = 0x09,
+    BITMAP_A = 0x0A,
+    BITMAP_B = 0x0B,
+    BITMAP_C = 0x0C,
+    BITMAP_D = 0x0D,
+    BITMAP_E = 0x0E,
+    BITMAP_F = 0x0F,
+
+    // VBXE overlay modes (>= 0x80).
+    VBXE_SR  = 0x80,   // Standard Resolution: 320 px, 256 colours, 1 byte/pixel
+    VBXE_HR  = 0x81,   // High Resolution:     640 px, 16 colours, 4bpp (320 bytes/line)
+    VBXE_LR  = 0x82,   // Low Resolution:      160 px, 256 colours, 1 byte/pixel
+    VBXE_T80 = 0x83,   // 80-column text:      char + attribute pairs (160 bytes/line)
+};
+
+// True for the VBXE overlay modes (the high range), false for ANTIC modes.
+constexpr bool is_vbxe(Mode m) { return static_cast<u8>(m) >= 0x80; }
+
+// ── Mode geometry ────────────────────────────────────────────────────
+//
+// `bytes_per_line` is the screen-memory width of one mode line. For text modes
+// it is the column count; for bitmap modes it is ceil(width_px * bpp / 8). The
+// VBXE overlay modes reach 320 bytes/line, so this returns u16.
+constexpr u16 bytes_per_line(Mode m) {
+    switch (m) {
+        case Mode::MODE_2: case Mode::MODE_3:
+        case Mode::MODE_4: case Mode::MODE_5:
+            return 40;                       // 40-column text
+        case Mode::MODE_6: case Mode::MODE_7:
+            return 20;                       // 20-column text
+        case Mode::MODE_8: case Mode::BITMAP_9:
+            return 10;                       // 40 px, 2bpp / 1bpp narrow
+        case Mode::BITMAP_A: case Mode::BITMAP_B:
+            return 20;                       // 80 px
+        case Mode::BITMAP_C: case Mode::BITMAP_D: case Mode::BITMAP_E:
+            return 40;                       // 160 px (2bpp) / 320 px (1bpp C)
+        case Mode::BITMAP_F:
+            return 40;                       // 320 px, 1bpp
+        case Mode::VBXE_SR: case Mode::VBXE_HR:
+            return 320;                      // SR: 320 px × 1 byte; HR: 640 px × 4bpp
+        case Mode::VBXE_LR: case Mode::VBXE_T80:
+            return 160;                      // LR: 160 px × 1 byte; T80: 80 chars × 2
+    }
+    return 40;
+}
+
+// True for character (text) modes, false for bitmap/map/overlay modes. Among the
+// VBXE modes only VBXE_T80 is text.
+constexpr bool is_text(Mode m) {
+    const u8 v = static_cast<u8>(m);
+    return (v >= 0x02 && v <= 0x07) || m == Mode::VBXE_T80;
+}
+
+// Bits per pixel for bitmap modes (undefined/irrelevant for text modes, where
+// "pixels" are characters). F is hi-res 1bpp; 8/9/A..E are 2bpp; B is 1bpp.
+// VBXE: SR/LR are 8bpp (1 byte/pixel), HR is 4bpp.
+constexpr u8 bits_per_pixel(Mode m) {
+    switch (m) {
+        case Mode::BITMAP_F: case Mode::MODE_8: case Mode::BITMAP_C:
+            return 1;
+        case Mode::BITMAP_9: case Mode::BITMAP_B:
+            return 1;
+        case Mode::VBXE_SR: case Mode::VBXE_LR:
+            return 8;
+        case Mode::VBXE_HR:
+            return 4;
+        default:
+            return 2;                        // 4/D/E and the 4-colour map modes
+    }
+}
+
+// Scanlines ANTIC draws for one mode line of this mode. Text rows are 8 tall;
+// the high-resolution bitmap modes (C/E/F) are 1 scanline per line, D is 2. VBXE
+// overlay modes are addressed per-scanline, so 1.
+constexpr u8 scanlines_per_line(Mode m) {
+    switch (m) {
+        case Mode::MODE_2: case Mode::MODE_4: case Mode::MODE_6:
+        case Mode::MODE_8:
+            return 8;
+        case Mode::MODE_3:
+            return 10;
+        case Mode::MODE_5: case Mode::MODE_7:
+            return 16;
+        case Mode::BITMAP_9: case Mode::BITMAP_A:
+            return 4;
+        case Mode::BITMAP_B: case Mode::BITMAP_D:
+            return 2;
+        case Mode::BITMAP_C: case Mode::BITMAP_E: case Mode::BITMAP_F:
+            return 1;
+        case Mode::VBXE_SR: case Mode::VBXE_HR:
+        case Mode::VBXE_LR: case Mode::VBXE_T80:
+            return 1;
+    }
+    return 1;
+}
+
+// The display-list mode-line instruction byte for this mode (no LMS/DLI bits).
+// VBXE overlay modes are not ANTIC display-list bytes, so they return 0.
+constexpr u8 dl_mode_byte(Mode m) {
+    if (is_vbxe(m)) return 0;
+    return static_cast<u8>(m);
+}
+
+// ── Hardware scrolling geometry ──────────────────────────────────────
+//
+// When a mode line has DL_HSCROLL set, ANTIC fetches the *next wider* playfield
+// so there is off-screen content to slide in: a normal-width 40-column text line
+// fetches 48 bytes instead of 40. `scroll_margin` is those extra bytes; a scroll
+// map's row stride must be at least `scroll_fetch_width` so every fetched byte
+// is real map data. (VBXE overlay modes don't ANTIC-scroll.)
+constexpr u8 scroll_margin(Mode m) {
+    switch (m) {
+        case Mode::MODE_2: case Mode::MODE_3:
+        case Mode::MODE_4: case Mode::MODE_5:
+            return 8;                        // 40-col text: 40 -> 48
+        case Mode::MODE_6: case Mode::MODE_7:
+            return 4;                        // 20-col text: 20 -> 24
+        default:
+            return 8;
+    }
+}
+
+constexpr u16 scroll_fetch_width(Mode m) {
+    return static_cast<u16>(bytes_per_line(m) + scroll_margin(m));
+}
+
+// Fine-scroll modulus: the number of HSCROL color-clock positions that span one
+// character cell, i.e. how far HSCROL advances before a one-byte coarse step.
+// The normal playfield is 160 color clocks wide, so a 40-column cell is 4 color
+// clocks and a 20-column cell is 8. (Vertical fine scroll uses scanlines_per_line
+// as its modulus instead.) THIS is the value to verify against real hardware if a
+// fine->coarse handoff ever jumps — see demo/atari_scroll_test.cpp.
+constexpr u8 fine_scroll_range(Mode m) {
+    switch (m) {
+        case Mode::MODE_2: case Mode::MODE_3:
+        case Mode::MODE_4: case Mode::MODE_5:
+            return 4;                        // 160 color clocks / 40 cells
+        case Mode::MODE_6: case Mode::MODE_7:
+            return 8;                        // 160 color clocks / 20 cells
+        default:
+            return 4;
+    }
+}
+
+// ── Character encoding ────────────────────────────────────────────────
+//
+// Convert an ASCII byte to its ANTIC internal screen code (the value stored in
+// screen memory, which differs from ATASCII). The internal code rotates ASCII:
+//   $20-$3F -> $00-$1F,  $40-$5F -> $20-$3F,  $60-$7F -> $40-$5F,
+//   $00-$1F -> $40-$5F.  Used by TextRegionView::print / print_num.
+constexpr u8 ascii_to_internal(char c) {
+    const u8 a = static_cast<u8>(c);
+    if (a < 0x20)  return static_cast<u8>(a + 0x40);
+    if (a < 0x60)  return static_cast<u8>(a - 0x20);
+    return a;                                 // $60-$7F map to themselves
+}
+
+} // namespace atari
+
+#endif // ENGINE_PLATFORM_ATARI_MODES_H

--- a/engine/platform/atari/vbxe_config.h
+++ b/engine/platform/atari/vbxe_config.h
@@ -19,18 +19,20 @@
 
 #include <stdint.h>
 
+#include "modes.h"
+
 namespace atari::vbxe {
 
 // Register decode base. The VBXE answers at $D640 or $D740 depending on how the
 // board is jumpered / which slot it occupies (the manual's "Dx40" with x = 6/7).
 enum class RegBase : uint16_t { D640 = 0xD640, D740 = 0xD740 };
 
-// Overlay display mode (the VBXE overlay plane drawn over/under ANTIC output):
-//   SR_320  — Standard Resolution, 320 px, 256 colours (1 byte/pixel)
-//   HR_640  — High Resolution,     640 px, 16 colours  (1 nibble/pixel)
-//   LR_160  — Low Resolution,      160 px, 256 colours
-//   Text_80 — 80-column text mode  (char + attribute pairs)
-enum class Mode : uint8_t { SR_320, HR_640, LR_160, Text_80 };
+// The overlay display mode (the VBXE overlay plane drawn over/under ANTIC output)
+// is one of the VBXE members of the unified atari::Mode enum (modes.h):
+//   atari::Mode::VBXE_SR  — Standard Resolution, 320 px, 256 colours (1 byte/pixel)
+//   atari::Mode::VBXE_HR  — High Resolution,     640 px, 16 colours  (1 nibble/pixel)
+//   atari::Mode::VBXE_LR  — Low Resolution,      160 px, 256 colours
+//   atari::Mode::VBXE_T80 — 80-column text mode  (char + attribute pairs)
 
 // Framebuffer double-buffering policy.
 enum class Buffers : uint8_t { Single, Double };
@@ -59,7 +61,7 @@ struct MEMAC_B {};
 
 // Full VBXE configuration carried by gfx::VBXE<Config>.
 template <
-    Mode       OverlayMode = Mode::SR_320,
+    atari::Mode OverlayMode = atari::Mode::VBXE_SR,
     Buffers    BufferPolicy = Buffers::Single,
     RegBase    Base = RegBase::D640,
     typename   MemacCfg = MEMAC_A,
@@ -67,19 +69,19 @@ template <
     Background Bg = Background::Flat
 >
 struct Config {
-    static constexpr Mode    overlay_mode  = OverlayMode;
+    static_assert(atari::is_vbxe(OverlayMode),
+                  "VBXE Config overlay_mode must be a VBXE mode (atari::Mode >= 0x80)");
+
+    static constexpr atari::Mode overlay_mode  = OverlayMode;
     static constexpr Buffers buffer_policy = BufferPolicy;
     static constexpr RegBase reg_base      = Base;
     using memac = MemacCfg;
     static constexpr uint32_t vram_offset  = VRAMOffset;
     static constexpr Background background  = Bg;
 
-    // Derived: framebuffer size in bytes
-    static constexpr uint32_t fb_width =
-        (OverlayMode == Mode::SR_320) ? 320 :
-        (OverlayMode == Mode::HR_640) ? 320 :  // 640 pixels but 4bpp = 320 bytes/line
-        (OverlayMode == Mode::LR_160) ? 160 :
-        160;  // Text_80: 160 bytes/line (80 chars x 2 bytes)
+    // Derived: framebuffer size in bytes. Width comes from the single source of
+    // truth in modes.h (SR/HR = 320 bytes/line, LR/T80 = 160).
+    static constexpr uint32_t fb_width  = atari::bytes_per_line(OverlayMode);
     static constexpr uint32_t fb_height = 240;
     static constexpr uint32_t fb_bytes = fb_width * fb_height;
 };

--- a/engine/platform/atari/vbxe_overlay.h
+++ b/engine/platform/atari/vbxe_overlay.h
@@ -378,7 +378,7 @@ struct OverlayHal {
                          src + static_cast<u32>(r) * w, w);
     }
 
-    // ── Overlay text-mode seams (Mode::Text_80; FX Core manual pp.9,14,16) ──
+    // ── Overlay text-mode seams (Mode::VBXE_T80; FX Core manual pp.9,14,16) ──
     //
     // In text mode the "framebuffer" at OVADR is a character map of char+attribute
     // byte pairs (char first), one 8x8 glyph cell per pair; the row stride is

--- a/engine/platform/atari/vbxe_xdl.h
+++ b/engine/platform/atari/vbxe_xdl.h
@@ -64,20 +64,20 @@ inline constexpr u8 ATT_OV_PALETTE = 1;
 // (<= 22). `fb_addr` is the 19-bit VRAM framebuffer address; `fb_stride` the
 // per-line byte step (added after each scanline in pixel modes); `height` the
 // number of scanlines. Graphic modes use GMON (+ HR/LR per Config::overlay_mode);
-// Text_80 uses TMON + CHBASE (font page from the VRAM layout).
+// VBXE_T80 uses TMON + CHBASE (font page from the VRAM layout).
 template <typename Config>
 constexpr u8 build_fullscreen_xdl(u8* buf, u32 fb_addr, u16 fb_stride, u8 height) {
-    constexpr Mode mode = Config::overlay_mode;
-    constexpr bool is_text = (mode == Mode::Text_80);
+    constexpr atari::Mode mode = Config::overlay_mode;
+    constexpr bool is_text = (mode == atari::Mode::VBXE_T80);
 
     u16 ctrl = xdlc::RPTL | xdlc::OVADR | xdlc::ATT | xdlc::END;
     if constexpr (is_text) {
         ctrl |= xdlc::TMON | xdlc::CHBASE;
     } else {
         ctrl |= xdlc::GMON;
-        if constexpr (mode == Mode::HR_640) ctrl |= xdlc::HR;
-        else if constexpr (mode == Mode::LR_160) ctrl |= xdlc::LR;
-        // SR_320: neither HR nor LR.
+        if constexpr (mode == atari::Mode::VBXE_HR) ctrl |= xdlc::HR;
+        else if constexpr (mode == atari::Mode::VBXE_LR) ctrl |= xdlc::LR;
+        // VBXE_SR: neither HR nor LR.
     }
 
     u8 p = 0;

--- a/engine/screen.h
+++ b/engine/screen.h
@@ -129,7 +129,12 @@ class ScreenManager {
 public:
     using screens = typename GameConfig::screens;
 
-    static constexpr u16 buffer_size = screens::max_screen_ram;
+    // Clamp to at least 1 byte: a pure-overlay-only ScreenSet contributes no
+    // screen RAM (overlay pixels live in VBXE VRAM, ram_bytes == 0), which would
+    // otherwise make screen_buffer_ a zero-length array (ill-formed). The 1-byte
+    // buffer is never read — set_base only computes buf + offset(0).
+    static constexpr u16 buffer_size =
+        screens::max_screen_ram > 0 ? screens::max_screen_ram : 1;
 
     // Switch to screen S: build its display program against the real buffer base
     // (the backend builder inserts any backend-specific reload instructions),
@@ -148,10 +153,20 @@ public:
         // Rebind this screen's region views to their buffer slices.
         views_.template for_screen<S>().set_base(screen_buffer_);
 
-        // Program the display: blank DMA, install the program, re-enable DMA.
+        // Program the display. Blank DMA and install the program in all cases.
         Platform::hal::display_dma_disable();
         Platform::hal::set_display_program(dl.bytes);
-        Platform::hal::display_dma_enable();
+        if constexpr (!S::display::is_pure_overlay) {
+            // ANTIC content present (ANTIC-only or mixed overlay+ANTIC):
+            // re-enable playfield DMA. Mixed layouts cost only the DL DMA that
+            // reads blank instructions (~1 cycle/line), not screen fetches.
+            Platform::hal::display_dma_enable();
+        }
+        // Pure overlay: ANTIC stays off. The VBXE overlay (brought up by
+        // Core::init through the graphics axis) drives the display via its XDL;
+        // the 3-byte JVB stub is only a safety pointer for DLISTL. Leaving ANTIC
+        // DMA off frees the VRAM bus for the blitter/MEMAC — the bus-contention
+        // fix (formerly a manual antic_playfield(false)), now automatic.
 
         active_dl_      = dl.bytes;
         active_dl_size_ = dl.size;

--- a/engine/version.h
+++ b/engine/version.h
@@ -10,8 +10,8 @@
 // EDGE follows Semantic Versioning (https://semver.org/): MAJOR.MINOR.PATCH.
 
 #define EDGE_VERSION_MAJOR 0
-#define EDGE_VERSION_MINOR 2
+#define EDGE_VERSION_MINOR 3
 #define EDGE_VERSION_PATCH 0
-#define EDGE_VERSION_STRING "0.2.0"
+#define EDGE_VERSION_STRING "0.3.0"
 
 #endif // ENGINE_VERSION_H

--- a/tests/backends/atari/test_atari_display.cpp
+++ b/tests/backends/atari/test_atari_display.cpp
@@ -77,6 +77,21 @@ static_assert(M::bytes_per_line(M::Mode::MODE_2) == 40,   "Mode 2 = 40 cols");
 static_assert(M::bytes_per_line(M::Mode::BITMAP_E) == 40, "Mode E = 40 bytes/line");
 static_assert(M::bits_per_pixel(M::Mode::BITMAP_E) == 2,  "Mode E is 2bpp");
 
+// ── VBXE overlay mode geometry (unified into atari::Mode, see modes.h) ──
+
+static_assert(M::is_vbxe(M::Mode::VBXE_T80),              "VBXE_T80 is a VBXE mode");
+static_assert(!M::is_vbxe(M::Mode::MODE_2),              "MODE_2 is not a VBXE mode");
+static_assert(M::bytes_per_line(M::Mode::VBXE_SR) == 320, "VBXE_SR = 320 bytes/line");
+static_assert(M::bytes_per_line(M::Mode::VBXE_HR) == 320, "VBXE_HR = 320 bytes/line (640px 4bpp)");
+static_assert(M::bytes_per_line(M::Mode::VBXE_LR) == 160, "VBXE_LR = 160 bytes/line");
+static_assert(M::bytes_per_line(M::Mode::VBXE_T80) == 160,"VBXE_T80 = 160 bytes/line (80 char+attr)");
+static_assert(M::bits_per_pixel(M::Mode::VBXE_SR) == 8,   "VBXE_SR is 8bpp");
+static_assert(M::bits_per_pixel(M::Mode::VBXE_HR) == 4,   "VBXE_HR is 4bpp");
+static_assert(M::is_text(M::Mode::VBXE_T80),              "VBXE_T80 is text");
+static_assert(!M::is_text(M::Mode::VBXE_SR),             "VBXE_SR is not text");
+static_assert(M::scanlines_per_line(M::Mode::VBXE_SR) == 1, "VBXE modes are 1 scanline/line");
+static_assert(M::dl_mode_byte(M::Mode::VBXE_SR) == 0,    "VBXE modes have no ANTIC DL byte");
+
 // ── Runtime harness ────────────────────────────────────────────────────
 
 static unsigned g_failures = 0;

--- a/tests/backends/atari/test_atari_display.cpp
+++ b/tests/backends/atari/test_atari_display.cpp
@@ -22,6 +22,7 @@ using engine::u16;
 using engine::DisplayLayout;
 using engine::TextRegion;
 using engine::BitmapRegion;
+using engine::OverlayRegion;
 using engine::ScreenSet;
 
 namespace M = atari;
@@ -178,10 +179,100 @@ static void test_set_screen_bytes() {
     CHECK(read16(dl, size - 2) == addr_of(dl));
 }
 
+// ── Overlay regions: pure-overlay JVB stub ─────────────────────────────
+//
+// A layout of only OverlayRegions drives no ANTIC mode lines — its pixels live
+// in VBXE VRAM and ANTIC DMA is disabled by the screen manager. The display
+// list collapses to a 3-byte self-looping JVB that only satisfies DLISTL.
+using PureOverlayLayout = DisplayLayout<OverlayRegion<M::Mode::VBXE_SR, 240>>;
+static atari::DisplayProgram<PureOverlayLayout> g_pure_overlay_dl;
+
+static void test_pure_overlay() {
+    // Capacity collapses to the 3-byte stub regardless of overlay height.
+    CHECK(atari::DisplayProgram<PureOverlayLayout>::capacity == 3);
+
+    g_pure_overlay_dl.build(0x4000, 0x3000);
+    CHECK(g_pure_overlay_dl.size == 3);
+    CHECK(g_pure_overlay_dl.bytes[0] == 0x41);          // DL_JVB
+    CHECK(read16(g_pure_overlay_dl.bytes, 1) == 0x3000); // loops the list itself
+    CHECK(g_pure_overlay_dl.lms_count == 0);
+    CHECK(g_pure_overlay_dl.scroll_lms_count == 0);
+}
+
+// ── Overlay regions: overlay above ANTIC text ──────────────────────────
+//
+// A 200-scanline overlay precedes a 3-row Mode 2 text region. The overlay
+// reserves its scanlines with blank-line instructions (ceil(200/8)=25) and
+// emits NO LMS; the text region then emits its mode lines below it.
+using MixedLayout =
+    DisplayLayout<OverlayRegion<M::Mode::VBXE_SR, 200>, TextRegion<M::Mode::MODE_2, 3>>;
+static atari::DisplayProgram<MixedLayout> g_mixed_dl;
+
+static void test_overlay_above_antic() {
+    g_mixed_dl.build(0x4000, 0x3000);
+
+    // 3 leading 8-line blanks + 25 overlay blanks = bytes 0..27, all blank instrs.
+    for (u16 i = 0; i < 28; ++i) CHECK(g_mixed_dl.bytes[i] == M::dl_blank(8));
+
+    // The text region's LMS opcode (Mode 2 | LMS = $42) sits at byte 28, so its
+    // recorded low-byte index is 29.
+    CHECK(g_mixed_dl.bytes[28] == 0x42);
+    CHECK(g_mixed_dl.region_lms_pos[1] == 29);
+
+    // Only the text region contributes an LMS; the overlay contributes none.
+    CHECK(g_mixed_dl.lms_count == 1);
+    CHECK(g_mixed_dl.scroll_lms_count == 0);
+
+    // Overlay region has the no-LMS sentinel; text LMS reloads buffer+0 (the
+    // overlay contributes 0 ram_bytes, so the text offset is unchanged).
+    CHECK(g_mixed_dl.region_lms_pos[0] == 0);
+    CHECK(read16(g_mixed_dl.bytes, g_mixed_dl.region_lms_pos[1]) == 0x4000);
+
+    // List still ends in a JVB looping on its own address.
+    CHECK(g_mixed_dl.bytes[g_mixed_dl.size - 3] == 0x41);
+    CHECK(read16(g_mixed_dl.bytes, g_mixed_dl.size - 2) == 0x3000);
+}
+
+// ── Overlay regions: overlay below ANTIC text ──────────────────────────
+//
+// Reversing the region order puts the text first and the overlay below it,
+// proving that region order controls the overlay's vertical position.
+using OverlayBelowLayout =
+    DisplayLayout<TextRegion<M::Mode::MODE_2, 3>, OverlayRegion<M::Mode::VBXE_SR, 200>>;
+static atari::DisplayProgram<OverlayBelowLayout> g_overlay_below_dl;
+
+static void test_overlay_below_antic() {
+    g_overlay_below_dl.build(0x4000, 0x3000);
+
+    // Bytes 0..2 are the leading centring blanks.
+    for (u16 i = 0; i < 3; ++i) CHECK(g_overlay_below_dl.bytes[i] == M::dl_blank(8));
+
+    // Text region first: LMS opcode at byte 3, low-byte index 4, reloading buffer+0.
+    CHECK(g_overlay_below_dl.bytes[3] == 0x42);
+    CHECK(g_overlay_below_dl.region_lms_pos[0] == 4);
+    CHECK(read16(g_overlay_below_dl.bytes, 4) == 0x4000);
+
+    // 3 text rows: 1 LMS (3 bytes) + 2 plain mode bytes -> first overlay blank at
+    // byte 8. The overlay then emits 25 blank instructions (bytes 8..32).
+    CHECK(g_overlay_below_dl.region_lms_pos[1] == 0);   // overlay sentinel
+    for (u16 i = 8; i < 33; ++i) CHECK(g_overlay_below_dl.bytes[i] == M::dl_blank(8));
+
+    // Only the text region's LMS.
+    CHECK(g_overlay_below_dl.lms_count == 1);
+
+    // JVB follows the overlay blanks.
+    CHECK(g_overlay_below_dl.bytes[33] == 0x41);
+    CHECK(read16(g_overlay_below_dl.bytes, 34) == 0x3000);
+    CHECK(g_overlay_below_dl.size == 36);
+}
+
 int main() {
     test_4k_crossing();
     test_no_crossing();
     test_set_screen_bytes();
+    test_pure_overlay();
+    test_overlay_above_antic();
+    test_overlay_below_antic();
 
     if (g_failures == 0) {
         printf("ALL TESTS PASSED\n");

--- a/tests/backends/atari/test_vbxe.cpp
+++ b/tests/backends/atari/test_vbxe.cpp
@@ -21,18 +21,19 @@
 #include <engine/platform/atari/vbxe_xdl.h>
 
 namespace v = atari::vbxe;
+namespace M = atari;
 
 // ── Config fixtures ──────────────────────────────────────────────────
-using CfgDefault = v::Config<>;                          // D640, SR_320, single, MEMAC-A 4K
-using CfgD740    = v::Config<v::Mode::SR_320, v::Buffers::Single, v::RegBase::D740>;
-using Cfg8K      = v::Config<v::Mode::SR_320, v::Buffers::Single, v::RegBase::D640,
+using CfgDefault = v::Config<>;                          // D640, VBXE_SR, single, MEMAC-A 4K
+using CfgD740    = v::Config<M::Mode::VBXE_SR, v::Buffers::Single, v::RegBase::D740>;
+using Cfg8K      = v::Config<M::Mode::VBXE_SR, v::Buffers::Single, v::RegBase::D640,
                              v::MEMAC_A_Cfg<0xB0, v::WindowSize::_8K>>;
-using CfgB       = v::Config<v::Mode::SR_320, v::Buffers::Single, v::RegBase::D640, v::MEMAC_B>;
-using CfgDouble  = v::Config<v::Mode::SR_320, v::Buffers::Double>;
+using CfgB       = v::Config<M::Mode::VBXE_SR, v::Buffers::Single, v::RegBase::D640, v::MEMAC_B>;
+using CfgDouble  = v::Config<M::Mode::VBXE_SR, v::Buffers::Double>;
 // sprites-over-bitmap: Background::Bitmap adds a master canvas (one framebuffer).
-using CfgBmp     = v::Config<v::Mode::SR_320, v::Buffers::Single, v::RegBase::D640,
+using CfgBmp     = v::Config<M::Mode::VBXE_SR, v::Buffers::Single, v::RegBase::D640,
                              v::MEMAC_A, 0x00000, v::Background::Bitmap>;
-using CfgBmpDbl  = v::Config<v::Mode::SR_320, v::Buffers::Double, v::RegBase::D640,
+using CfgBmpDbl  = v::Config<M::Mode::VBXE_SR, v::Buffers::Double, v::RegBase::D640,
                              v::MEMAC_A, 0x00000, v::Background::Bitmap>;
 
 // ── 1. Register addressing off reg_base ──────────────────────────────
@@ -198,7 +199,7 @@ static_assert(kXdl.buf[9] == 0xFF,   "ATT priority 255");
 // ── 6b. XDL byte layout (full-screen Text_80) ────────────────────────
 // Text mode adds TMON + CHBASE; the hardware advances OVADR by OVSTEP every 8
 // scanlines (one record covers all rows). FX Core manual pp.9,14.
-using CfgText = v::Config<v::Mode::Text_80>;
+using CfgText = v::Config<M::Mode::VBXE_T80>;
 struct XdlTextResult { v::u8 buf[24]; v::u8 len; };
 constexpr XdlTextResult build_text_xdl() {
     XdlTextResult r{};

--- a/tests/backends/atari/test_vbxe_integration.cpp
+++ b/tests/backends/atari/test_vbxe_integration.cpp
@@ -41,7 +41,7 @@ using VbxePlatform = M::Platform<
 // VBXE in 80-column text mode (exercises the overlay-text seam path).
 using VbxeTextPlatform = M::Platform<
     M::Machine::XL, M::RAM::U1MB,
-    M::gfx::VBXE<atari::vbxe::Config<atari::vbxe::Mode::Text_80>>,
+    M::gfx::VBXE<atari::vbxe::Config<atari::Mode::VBXE_T80>>,
     M::Sound::Mono, M::TV::NTSC>;
 
 // VBXE in sprites-over-bitmap mode (double-buffered, Background::Bitmap):
@@ -49,7 +49,7 @@ using VbxeTextPlatform = M::Platform<
 using VbxeBmpPlatform = M::Platform<
     M::Machine::XL, M::RAM::U1MB,
     M::gfx::VBXE<atari::vbxe::Config<
-        atari::vbxe::Mode::SR_320, atari::vbxe::Buffers::Double,
+        atari::Mode::VBXE_SR, atari::vbxe::Buffers::Double,
         atari::vbxe::RegBase::D640, atari::vbxe::MEMAC_A, 0x00000,
         atari::vbxe::Background::Bitmap>>,
     M::Sound::Mono, M::TV::NTSC>;

--- a/tests/generic/test_screen.cpp
+++ b/tests/generic/test_screen.cpp
@@ -27,6 +27,7 @@ using engine::u16;
 using engine::DisplayLayout;
 using engine::TextRegion;
 using engine::BitmapRegion;
+using engine::OverlayRegion;
 using engine::TextRegionView;
 using engine::BitmapRegionView;
 using engine::ScreenSet;
@@ -91,6 +92,49 @@ static_assert(MixedLayout::offset(2) == 7240, "region 2 after header + bitmap");
 using Screens = GameConfig::screens;
 static_assert(Screens::screen_count == 2,      "two screens");
 static_assert(Screens::max_screen_ram == 7280, "max(960, 7280) == 7280");
+
+// ── Compile-time checks: OverlayRegion + overlay-aware DisplayLayout ────
+//
+// VBXE overlay regions are VRAM-backed (ram_bytes == 0), carry the wide (u16)
+// 320-byte VBXE_SR line, and flip the layout's overlay queries. None of these
+// touch the screen buffer.
+
+// 4. OverlayRegion geometry: VRAM-backed, 320 bytes/line (u16, not truncated).
+using OverlaySR = OverlayRegion<M::Mode::VBXE_SR, 240>;
+static_assert(OverlaySR::ram_bytes      == 0,    "overlay is VRAM-backed, 0 screen RAM");
+static_assert(OverlaySR::is_overlay     == true, "OverlayRegion::is_overlay");
+static_assert(OverlaySR::bytes_per_line == 320,  "VBXE_SR = 320 bytes/line (u16)");
+static_assert(OverlaySR::height         == 240,  "overlay height passes through");
+
+// 5. Pure-overlay layout: ANTIC can be fully disabled, costs 0 screen RAM.
+using PureOverlay = DisplayLayout<OverlayRegion<M::Mode::VBXE_SR, 240>>;
+static_assert(PureOverlay::is_pure_overlay    == true,  "single overlay is pure");
+static_assert(PureOverlay::has_overlay        == true,  "pure overlay has an overlay");
+static_assert(PureOverlay::antic_region_count == 0,     "no ANTIC regions");
+static_assert(PureOverlay::total_ram          == 0,     "overlay-only = 0 screen RAM");
+
+// 6. Mixed layout: overlay over a 3-row text region. Only the text costs RAM.
+using MixedOverlay = DisplayLayout<
+    OverlayRegion<M::Mode::VBXE_SR, 200>,
+    TextRegion<M::Mode::MODE_2, 3>
+>;
+static_assert(MixedOverlay::is_pure_overlay    == false, "a text region breaks purity");
+static_assert(MixedOverlay::has_overlay        == true,  "still has an overlay");
+static_assert(MixedOverlay::antic_region_count == 1,     "one ANTIC (text) region");
+static_assert(MixedOverlay::total_ram          == 120,   "40x3 text only; overlay = 0");
+static_assert(MixedOverlay::overlay_region_index() == 0, "overlay is region 0");
+
+// 7. Traditional layout: zero overlays. is_pure_overlay must NOT be vacuously true.
+static_assert(TextLayout::has_overlay     == false, "no overlay in a pure-text layout");
+static_assert(TextLayout::is_pure_overlay == false, "no overlay => not pure overlay");
+static_assert(TextLayout::antic_region_count == 1,  "the text region is an ANTIC region");
+static_assert(TextLayout::overlay_region_index() == TextLayout::region_count,
+              "no overlay => index past the end");
+
+// NOTE (negative test, kept disabled): instantiating OverlayRegion on a non-VBXE
+// mode must fail the is_vbxe static_assert. Verified manually, e.g.
+//   using BadOverlay = OverlayRegion<M::Mode::MODE_2, 24>;  // static_assert fires
+// Left commented out so the suite still builds.
 
 // ── Runtime harness ────────────────────────────────────────────────────
 

--- a/tests/generic/test_screen.cpp
+++ b/tests/generic/test_screen.cpp
@@ -41,13 +41,17 @@ namespace M = atari;
 struct MockHal {
     static const u8* last_program;
     static bool      dma_enabled;
+    static unsigned  enable_calls;
+    static unsigned  disable_calls;
 
-    static void display_dma_disable() { dma_enabled = false; }
-    static void display_dma_enable()  { dma_enabled = true; }
+    static void display_dma_disable() { dma_enabled = false; ++disable_calls; }
+    static void display_dma_enable()  { dma_enabled = true;  ++enable_calls; }
     static void set_display_program(const u8* p) { last_program = p; }
 };
-const u8* MockHal::last_program = nullptr;
-bool      MockHal::dma_enabled  = false;
+const u8* MockHal::last_program  = nullptr;
+bool      MockHal::dma_enabled   = false;
+unsigned  MockHal::enable_calls  = 0;
+unsigned  MockHal::disable_calls = 0;
 
 struct MockPlatform {
     using hal = MockHal;
@@ -72,6 +76,29 @@ struct ScreenMixed {
 struct GameConfig {
     using screens = ScreenSet<ScreenText, ScreenMixed>;
 };
+
+// Overlay screens for the DMA-dispatch tests. Kept in a SEPARATE config/manager
+// so the existing GameConfig/g_sm and their geometry static_asserts are untouched.
+struct ScreenOverlay {        // pure overlay: ANTIC fully disabled
+    using display = DisplayLayout<OverlayRegion<M::Mode::VBXE_SR, 240>>;
+};
+struct ScreenMixedOverlay {   // overlay + ANTIC text: has_overlay, not pure
+    using display = DisplayLayout<
+        OverlayRegion<M::Mode::VBXE_SR, 200>,
+        TextRegion<M::Mode::MODE_2, 3>>;
+};
+struct OverlayConfig {
+    using screens = ScreenSet<ScreenOverlay, ScreenMixedOverlay>;
+};
+
+// A pure-overlay-ONLY config has max_screen_ram == 0; ScreenManager must clamp
+// the buffer to at least 1 byte so screen_buffer_ is never a zero-length array.
+struct PureOverlayOnlyConfig {
+    using screens = ScreenSet<ScreenOverlay>;
+};
+static_assert(
+    engine::ScreenManager<MockPlatform, PureOverlayOnlyConfig>::buffer_size == 1,
+    "pure-overlay-only ScreenSet clamps the screen buffer to 1 byte");
 
 // ── Compile-time checks: DisplayLayout geometry ───────────────────────
 
@@ -227,10 +254,42 @@ static void test_set_screen() {
     CHECK(g_sm.buffer()[40] == 0xC0);
 }
 
+// ── set_screen drives ANTIC DMA from the layout's overlay properties ───
+
+static engine::ScreenManager<MockPlatform, OverlayConfig> g_sm_overlay;
+
+// A pure-overlay screen disables ANTIC DMA and never re-enables it: the program
+// (the 3-byte JVB stub) is still installed as a DLISTL safety pointer.
+static void test_pure_overlay_no_dma_enable() {
+    MockHal::enable_calls  = 0;
+    MockHal::disable_calls = 0;
+    g_sm_overlay.set_screen<ScreenOverlay>([]() {});
+
+    CHECK(MockHal::disable_calls == 1);
+    CHECK(MockHal::enable_calls  == 0);   // ANTIC stays off for a pure overlay
+    CHECK(!MockHal::dma_enabled);
+    CHECK(MockHal::last_program == g_sm_overlay.active_dl());
+    CHECK(g_sm_overlay.active_dl_size() == 3);   // JVB stub
+}
+
+// A mixed overlay+ANTIC screen DOES re-enable DMA (the ANTIC text region needs
+// the playfield fetch); the overlay blank lines just cost DL DMA.
+static void test_mixed_overlay_enables_dma() {
+    MockHal::enable_calls  = 0;
+    MockHal::disable_calls = 0;
+    g_sm_overlay.set_screen<ScreenMixedOverlay>([]() {});
+
+    CHECK(MockHal::disable_calls == 1);
+    CHECK(MockHal::enable_calls  == 1);   // ANTIC region present => enabled
+    CHECK(MockHal::dma_enabled);
+}
+
 int main() {
     test_text_view_put_char();
     test_bitmap_view_plot();
     test_set_screen();
+    test_pure_overlay_no_dma_enable();
+    test_mixed_overlay_enables_dma();
 
     if (g_failures == 0) {
         printf("ALL TESTS PASSED\n");


### PR DESCRIPTION
This pull request introduces EDGE v0.3.0, focusing on major improvements to VBXE overlay support, automatic ANTIC DMA management, and stricter configuration checks. The update simplifies pure-overlay screen usage, making performance optimizations automatic and reducing the need for manual intervention. Documentation and demos have been updated to reflect these changes and clarify the new behavior.

**VBXE Overlay and ANTIC DMA Improvements:**

* Added `engine::OverlayRegion<Mode, Height>`, enabling VRAM-backed VBXE overlays to be used alongside ANTIC regions in a `DisplayLayout`. Overlay regions consume no screen-buffer RAM, and their order determines vertical placement. New queries (`has_overlay`, `is_pure_overlay`, `overlay_region_index()`) support overlay-aware layouts. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R46) [[2]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cL160-R170)
* `set_screen<S>()` now automatically disables ANTIC DMA for pure-overlay screens (those composed solely of `OverlayRegion`s), freeing the VRAM bus for the blitter and improving performance. Manual calls to `Game::antic_playfield(false)` are now only needed for specialized cases (e.g., transparent overlays or mixed layouts). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R46) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaL229-R244) [[3]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cL284-R301)

**Compile-time Safety and Configuration:**

* Added a compile-time check in `Core::set_screen` to ensure that an `OverlayRegion`'s mode and height match the platform's VBXE `Config` (`overlay_mode`, `fb_height`). Mismatches now cause build errors instead of silent corruption. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R46) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR299-R318)

**Documentation and Demo Updates:**

* Updated all documentation and demo files to reference EDGE v0.3.0 and reflect the new overlay and ANTIC DMA behavior. Demos now use pure-overlay layouts and highlight the removal of manual DMA toggling for opaque overlays. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) Fd548b20L2R2, [[2]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cL3-R3) [[3]](diffhunk://#diff-38612f5904fb8c3dc3283d855aa486c7bc5ce02c15edd6b90be1e8424fcf0b99L3-R3) [[4]](diffhunk://#diff-b1b484de02794082600e79848bdf85fed4c26408fc1b36fb451beb48866d64d7L3-R3) [[5]](diffhunk://#diff-48492ab448322dc75b3414244c16ea64f9498bb9185bff4a0cb5c1d26c991306L3-R3) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R55) [[7]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL170-R181) [[8]](diffhunk://#diff-bf43016d43412f58e637994e05ae40569a9537dadec5ff95e12219a85d27fa84R27-R28) [[9]](diffhunk://#diff-bf43016d43412f58e637994e05ae40569a9537dadec5ff95e12219a85d27fa84L52-R63) [[10]](diffhunk://#diff-bf43016d43412f58e637994e05ae40569a9537dadec5ff95e12219a85d27fa84L122-R132)
* Updated code in all relevant demos to use the new `OverlayRegion` and configuration patterns, and to remove now-unnecessary manual calls to `antic_playfield(false)`. [[1]](diffhunk://#diff-1d78710f4de02e403dcadd9774104b6cefe06bb945ec56638142c825a4db93f6L60-R62) [[2]](diffhunk://#diff-505779f53702793a9568f98496ab96c18b5de39d6c673cb3b4e45c836f16d3baL37-R37) [[3]](diffhunk://#diff-bf43016d43412f58e637994e05ae40569a9537dadec5ff95e12219a85d27fa84L43-R45) [[4]](diffhunk://#diff-ab0f262c6ea739f0d07e5db6f837cc10fc188e743a1d4df3993ac8f6a14f5ce8L3-R3) [[5]](diffhunk://#diff-ab0f262c6ea739f0d07e5db6f837cc10fc188e743a1d4df3993ac8f6a14f5ce8L33-R33)

**API and Core Comments:**

* Improved comments and documentation in `engine/core.h` to clarify the new automatic DMA management for pure-overlay layouts and the intended use of `antic_playfield(bool)`. [[1]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR166-R168) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR186-R187) [[3]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaL229-R244)

These changes collectively make EDGE more robust, easier to use for VBXE overlays, and safer against misconfiguration.