### PR TITLE
Multiplexed sprite demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+### Added
+- P/M sprite multiplexer now runs on real hardware. New lean raw zone-boundary
+  DLI `edge_multiplex_dli` (platform/atari/dli_dispatch.h): it copies a zone's
+  eight pre-baked bytes (HPOSP0-3 + COLPM0-3) from a flat table to GTIA and shares
+  the C++ dispatcher's chain tail, staying under one mode line so closely-spaced
+  boundaries don't re-enter. Backed by `SpriteManager::arm_multiplex_dli()` and the
+  new HAL seam `hal::multiplex_dli()` / `hal::install_multiplex_dli()`.
+
+### Changed
+- **HAL contract (breaking for custom platforms):** the sprite commit now requires
+  `hal::set_color_pm()` (zone 0's colour moved from a direct COLPM write to the OS
+  PCOLR shadow), and a baseline HAL must now provide `hal::multiplex_dli()` and
+  `hal::install_multiplex_dli()`. No game-author-facing API changed.
+- P/M commit clears each sprite's **exact footprint** instead of a per-player
+  min/max range, which degenerated to the whole strip under multiplexing
+  (DECISIONS.md ADR-022 revision).
+- Zone-boundary raster hooks are registered RAW again (dynamic hooks route through
+  `edge_multiplex_dli`, not the C++ dispatcher).
+
+### Fixed
+- **Multiplexer crash on hardware (~15 s in, garbled screen + JAM):** the
+  un-guarded deferred VBI could overrun a frame; the next VBI NMI re-entered the
+  trampoline and corrupted the saved llvm-mos soft-stack pointer on unwind, drifting
+  it down into `.text` until stack writes overwrote code. Added an `edge_vbi_busy`
+  re-entry guard (DECISIONS.md ADR-028). The service also gates DLI NMIs off while
+  it rebuilds the raster chain.
+- **Top-zone sprites rendered black:** zone 0's colour was written straight to
+  COLPM during the VBI, then zeroed by the OS PCOLR→COLPM copy that runs after it.
+  Routed zone 0 through the PCOLR shadow; the boundary DLIs still write COLPM
+  directly (they run after the copy).
+- **VBI overrun / stutter with 9 sprites:** the wide per-player clear (above) was
+  the cause; the per-sprite exact-extent clear pulls the commit back under one frame.
+- **Ghost / split sprites at zone seams:** the boundary scanline is biased up by one
+  mode line (`kBoundaryBias`) so the player switch lands in the inter-zone gap,
+  since the DLI fires at the end of its mode line.
+
 ## [0.3.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-05
+
 ### Added
 - P/M sprite multiplexer now runs on real hardware. New lean raw zone-boundary
   DLI `edge_multiplex_dli` (platform/atari/dli_dispatch.h): it copies a zone's

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,15 @@ if(EDGE_BUILD_DEMO)
     set_target_properties(atari_vbxe_sprites PROPERTIES OUTPUT_NAME "atari_vbxe_sprites.xex")
     target_link_options(atari_vbxe_sprites PRIVATE
         "LINKER:--Map=$<TARGET_FILE_DIR:atari_vbxe_sprites>/atari_vbxe_sprites.map")
+
+    # P/M multiplexer demo — independent .xex (no charset header; OS ROM font).
+    add_executable(multiplex_demo demo/multiplex_demo.cpp)
+    target_compile_options(multiplex_demo PRIVATE
+        -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra)
+    target_include_directories(multiplex_demo PRIVATE ${CMAKE_SOURCE_DIR})
+    set_target_properties(multiplex_demo PROPERTIES OUTPUT_NAME "multiplex_demo.xex")
+    target_link_options(multiplex_demo PRIVATE
+        "LINKER:--Map=$<TARGET_FILE_DIR:multiplex_demo>/multiplex_demo.map")
     return()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EDGE (Eight-bit Damned! Game Engine)
 
-> **Applies to EDGE v0.3.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
+> **Applies to EDGE v0.4.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
 
 EDGE is a C++20 game engine for constrained 6502-class systems, built around a small, deterministic, compile-time configured API instead of a heavy runtime.
 The project is Atari-first today, but its architecture is intended to support additional 6502-family platforms over time. Game code is written against portable engine subsystems while hardware details live behind a platform HAL and compile-time capability profiles.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Hardware validation demo (`atari_hw_test.xex`)
 
-> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.4.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 A minimal Atari 8-bit program that drives every engine subsystem at once, so
 the engine's live ANTIC path can be confirmed on real hardware / emulators

--- a/demo/multiplex_demo.cpp
+++ b/demo/multiplex_demo.cpp
@@ -1,0 +1,242 @@
+// demo/multiplex_demo.cpp — Edge engine P/M multiplexer demo.
+//
+// Nine logical sprites (8x8 diamonds) bounce over a full-screen ANTIC mode-2
+// text field. With only four hardware players, the engine's sprite multiplexer
+// (engine/sprites.h) Y-sorts the active sprites every frame and splits the
+// screen into vertical zones of up to four players each, reprogramming the
+// player horizontal positions + colours at each zone boundary via a raster
+// hook. Watch the ZONES count in the status line change as the diamonds cross
+// each other in Y.
+//
+// ── CODEBASE FACTS (gathered before writing; see citations) ──────────────
+//
+// A) .xex reference program: demo/atari_hw_test.cpp
+//    - includes:  <stdint.h>, <engine/platform/atari/platform.h>, <engine/core.h>
+//    - Platform alias:  using Platform = atari::Platform<Machine, RAM, gfx,
+//                       Sound, TV>;                       (hw_test.cpp:43-48)
+//    - GameConfig shape: `using screens = engine::ScreenSet<...>;` plus the
+//                       scalar fields max_sprites / sound_channels.
+//                                                          (hw_test.cpp:55-59)
+//    - main pattern:    Game::init(); ... setup ... Game::run(frame_step);
+//                                                          (hw_test.cpp:169-208)
+//      (atari_scroll_test.cpp:139 confirms the no-charset Game::init() form.)
+//
+// B) engine/core.h
+//    - Game::print(col,row,str) / Game::put_char / Game::print_num ARE provided
+//      as single-screen shorthands for region 0.            (core.h:271-280)
+//    - Multiplex accessor: Game::multiplex is an alias for the sprite manager;
+//      Game::multiplex.zone_count() returns the live zone count.
+//                                          (core.h:150; sprites.h:417)
+//    - max_raster_hooks IS a GameConfig field (defaulted to 12 otherwise).
+//                                                            (core.h:65-70)
+//    - initial_screen typedef is OPTIONAL (defaults to screen_at<0>); supplying
+//      it is fine.                                           (core.h:47-53)
+//
+// C) engine/sprites.h
+//    - sprite() signature:  void sprite(u8 slot, const Shape&, u8 x, u8 y);
+//      Game::sprite forwards to it.            (sprites.h:151; core.h:198-201)
+//    - sprite_color(slot,color) takes a LOGICAL SPRITE SLOT, not a hardware
+//      player. It stores the colour on the logical sprite; the multiplexer
+//      then drives that colour onto whichever hardware player the sprite lands
+//      on per zone (zone.color[p] = sprites_[..].color), so colour FOLLOWS the
+//      sprite across player reassignments.   (sprites.h:175, 243, 437)
+//      >> Consequence: all 9 sprites must be coloured (not just 4). The task
+//         brief's "per hardware player 0-3" note is inverted from the actual
+//         engine model; this demo colours every logical sprite instead.
+//    - X coordinate maps to RAW HPOSP: HAL set_sprite_x writes HPOSP directly
+//      (hal.h:214), so the visible window is ~48..208. => X_MIN=48, X_MAX=208.
+//    - make_sprite is engine::make_sprite<W,H>(...).         (sprites.h:62)
+//
+// D) engine/display.h / engine/screen.h
+//    - engine::TextRegion<Mode, Height> is the text region template.
+//                                                            (display.h:159)
+//    - ANTIC mode-2 token: atari::Mode::MODE_2.   (platform/atari/modes.h:45)
+//    - ScreenSet does NOT require an initial_screen typedef. (screen.h:50-58)
+//    - The DemoScreen flags sprites_active / pm_resolution / scroll_active /
+//      use_row_table are forward-looking: the current engine does not read them
+//      (sprite resolution defaults to SingleLine in SpriteManager, which is what
+//      this demo wants). They are declared as documentation, per the brief.
+//
+// E) engine/types.h
+//    - u8 / u16 / i8(int8_t) live in namespace engine.       (types.h:23-27)
+//
+// F) CMakeLists.txt — existing .xex targets use, per demo .cpp:
+//      add_executable(<name> demo/<file>.cpp)
+//      target_compile_options(<name> PRIVATE <atari8-dos opts>)
+//      target_include_directories(<name> PRIVATE ${CMAKE_SOURCE_DIR})
+//      set_target_properties(<name> PROPERTIES OUTPUT_NAME "<name>.xex")
+//      target_link_options(<name> PRIVATE "LINKER:--Map=.../<name>.map")
+//    (CMakeLists.txt:63-72) — replicated for multiplex_demo in the next step.
+//
+// ── Pure engine API ──────────────────────────────────────────────────────
+// Every interaction is through engine::Core (Game::*) or Platform::hal (the
+// same surface the hw_test demo treats as engine API for one-time GTIA setup).
+// No poke()s, no magic addresses, no inline assembly.
+
+#include <stdint.h>
+
+#include <engine/platform/atari/platform.h>
+#include <engine/core.h>
+
+using engine::u8;
+using engine::u16;
+using engine::i8;
+namespace M = atari;
+
+// ── Platform + game configuration ────────────────────────────────────────
+
+using Platform = atari::Platform<
+    atari::Machine::XL,
+    atari::RAM::Baseline,
+    atari::gfx::Baseline,
+    atari::Sound::Mono,
+    atari::TV::NTSC>;
+
+struct DemoScreen {
+    using display = engine::DisplayLayout<
+        engine::TextRegion<M::Mode::MODE_2, 24>
+    >;
+    static constexpr bool sprites_active = true;
+    static constexpr auto pm_resolution =
+        engine::SpriteVerticalResolution::SingleLine;
+    static constexpr bool scroll_active  = false;
+    static constexpr bool use_row_table  = false;
+};
+
+struct GameConfig {
+    using screens         = engine::ScreenSet<DemoScreen>;
+    using initial_screen  = DemoScreen;
+    static constexpr u8 max_sprites      = 9;
+    // The brief asked for 0, but SoundManager static_asserts MaxChannels >= 1
+    // (engine/sound.h:81); this demo plays no sound, so the single channel is
+    // simply unused.
+    static constexpr u8 sound_channels   = 1;
+    // 9 sprites => ceil(9/4)=3 zones => 2 zone-boundary DLIs, plus headroom
+    // for future user raster hooks.                          (core.h:65-70)
+    static constexpr u8 max_raster_hooks = 8;
+};
+
+using Game = engine::Core<Platform, GameConfig>;
+
+// ── Sprite shape (constexpr, ROM-resident) ───────────────────────────────
+
+constexpr auto sprite_shape = engine::make_sprite<8, 8>({
+    0b00011000,
+    0b00111100,
+    0b01111110,
+    0b11111111,
+    0b11111111,
+    0b01111110,
+    0b00111100,
+    0b00011000,
+});
+
+// ── Game state (static; no heap) ─────────────────────────────────────────
+
+struct Mover {
+    u8 x;
+    u8 y;
+    i8 dx;
+    i8 dy;
+};
+
+static Mover movers[9];
+
+// Raw-HPOSP visible window (X is written straight to HPOSP; hal.h:214).
+static constexpr u8 X_MIN = 48;
+static constexpr u8 X_MAX = 208;
+
+// Vertical bounce limits (P/M scanline space).
+static constexpr u8 Y_MIN = 16;
+static constexpr u8 Y_MAX = 220;
+
+// ── Per-frame logic (runs once per VBI via Game::run) ────────────────────
+
+static void frame_step(const engine::Input& input) {
+    (void)input;   // no input in this demo — the sprites self-animate.
+
+    for (u8 i = 0; i < 9; ++i) {
+        movers[i].x = static_cast<u8>(movers[i].x + movers[i].dx);
+        movers[i].y = static_cast<u8>(movers[i].y + movers[i].dy);
+
+        // Bounce X — clamp THEN reverse (raw-HPOSP window).
+        if (movers[i].x <= X_MIN) {
+            movers[i].x = X_MIN;
+            movers[i].dx = static_cast<i8>(-movers[i].dx);
+        }
+        if (movers[i].x >= X_MAX) {
+            movers[i].x = X_MAX;
+            movers[i].dx = static_cast<i8>(-movers[i].dx);
+        }
+
+        // Bounce Y.
+        if (movers[i].y <= Y_MIN) {
+            movers[i].y = Y_MIN;
+            movers[i].dy = static_cast<i8>(-movers[i].dy);
+        }
+        if (movers[i].y >= Y_MAX) {
+            movers[i].y = Y_MAX;
+            movers[i].dy = static_cast<i8>(-movers[i].dy);
+        }
+
+        // Buffer the logical sprite; the VBI Y-sorts, zones, and commits it.
+        Game::sprite(i, sprite_shape, movers[i].x, movers[i].y);
+    }
+
+    // Status line: live zone count from the multiplexer + the sprite total.
+    Game::print(0, 0, "ZONES:");
+    Game::print_num(7, 0, Game::multiplex.zone_count(), 1);
+    Game::print(10, 0, "SPRITES:9");
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────
+
+int main() {
+    // Build the display list, set up P/M (single-line DMA), arm the DLI
+    // dispatcher, install the deferred-VBI frame service. No charset arg => the
+    // OS ROM font is used for the text field.
+    Game::init();
+
+    // Single-width player objects, so each diamond is 8 px wide on screen.
+    for (u8 p = 0; p < 4; ++p)
+        Platform::hal::set_player_size(p, M::sizep::NORMAL);
+
+    // Readable text: white luminance on a black field/border (via the OS colour
+    // shadows the deferred VBI copies to hardware each frame).
+    Platform::hal::set_color_pf(4, 0x00);   // COLBK  : background / border
+    Platform::hal::set_color_pf(2, 0x00);   // COLPF2 : text background
+    Platform::hal::set_color_pf(1, 0x0E);   // COLPF1 : text luminance
+
+    // Colour every LOGICAL sprite. sprite_color() indexes the logical slot, not
+    // a hardware player (sprites.h:175); the multiplexer drives each sprite's
+    // own colour onto whichever player it occupies in its zone, so a diamond
+    // keeps its hue no matter which of the 4 players it is multiplexed onto.
+    // Four visually distinct Atari hues, cycled across the nine sprites.
+    static constexpr u8 kHues[4] = {
+        0x28,   // orange
+        0x58,   // green
+        0x98,   // blue
+        0xC8,   // pink
+    };
+    for (u8 i = 0; i < 9; ++i)
+        Game::sprite_color(i, kHues[i & 3]);
+
+    // Spread the diamonds across the vertical field so they start in different
+    // zones; no two share a Y, velocities are +/-1 only (no unsigned wrap at the
+    // bounce boundaries). X values sit inside the raw-HPOSP window [48,208].
+    movers[0] = { 80,  30,  1,  1};
+    movers[1] = { 90,  50, -1,  1};
+    movers[2] = {100,  70,  1, -1};
+    movers[3] = {110,  90, -1, -1};
+    movers[4] = {120, 110,  1,  1};
+    movers[5] = {130, 130, -1,  1};
+    movers[6] = {140, 150,  1, -1};
+    movers[7] = {150, 170, -1, -1};
+    movers[8] = {160, 190,  1,  1};
+
+    // Static status-line label drawn once; the dynamic fields update per frame.
+    // (frame_step rewrites the whole line every frame, so nothing else here.)
+
+    // One callback per frame, forever.
+    Game::run(frame_step);
+}

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # EDGE API Reference
 
-> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.4.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This reference is organized in two layers:
 

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -1,6 +1,6 @@
 # EDGE Atari Platform Guide
 
-> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.4.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This document describes the first concrete EDGE backend: the Atari 8-bit family.
 

--- a/documents/QUICK_START.md
+++ b/documents/QUICK_START.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.4.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This guide introduces EDGE from the engine author's point of view first, then shows the current concrete setup using the Atari backend.
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 # EDGE Engine Documentation
 
-> **Applies to EDGE v0.3.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.4.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 EDGE is a C++ engine for building games and interactive applications on constrained 6502-class systems.
 

--- a/engine/core.h
+++ b/engine/core.h
@@ -178,6 +178,7 @@ public:
             tiles.bind_charset_page(page_of(charset_buffer_));
         }
         interrupts.arm_dispatch();
+        sprites.arm_multiplex_dli();   // bind the raw zone-boundary DLI (baseline)
         Platform::hal::install_frame_isr(&frame_service);
     }
     static void init() {
@@ -191,6 +192,7 @@ public:
         }
         set_screen<InitialScreen>([] {});
         interrupts.arm_dispatch();
+        sprites.arm_multiplex_dli();   // bind the raw zone-boundary DLI (baseline)
         Platform::hal::install_frame_isr(&frame_service);
     }
 
@@ -366,6 +368,19 @@ public:
         // 0. Suppress idle-dim (the backend would otherwise dim/cycle colours
         //    after a few minutes of no console/keyboard input).
         Platform::hal::suppress_idle_dim();
+
+        // 0a. Gate raster (DLI) NMIs off for the duration of this service. The
+        //     deferred VBI rewrites the raster-hook chain state below
+        //     (VDSLST/current_ and the multiplexer's mux_index_/mux_table_), and
+        //     a heavy service (e.g. the 9-sprite multiplexer) can still be running
+        //     when it overruns vertical blank into the visible region — where a
+        //     zone-boundary DLI would otherwise fire mid-rewrite and corrupt the
+        //     chain (raw DLIs are not re-entrant against the builder). prepare_chain
+        //     re-arms NMIEN at the end once the chain is consistent, so any boundary
+        //     line the beam has not yet reached still fires this frame; one the
+        //     overrun already passed is simply skipped for the frame (a cosmetic
+        //     seam, not a crash). Backends with no raster hooks just stay disabled.
+        Platform::hal::disable_raster();
 
         // 1. Input capture.
         u8 joy[kPorts];

--- a/engine/interrupt.h
+++ b/engine/interrupt.h
@@ -150,6 +150,15 @@ public:
     //
     // begin_dynamic() discards the dynamic tail, keeping the static slots.
     // add_dynamic_raster_hook() appends a raw, top-priority slot.
+    //
+    // The slot is registered RAW: `h` is a backend-supplied, hand-written DLI that
+    // ANTIC enters directly (the multiplexer's edge_multiplex_dli). Routing it
+    // through the generic C++ dispatcher was tried and failed on hardware — the
+    // dispatcher's full $80-$9F save makes each DLI ~11 scanlines, and a DLI is an
+    // unmaskable, non-re-entrant NMI, so two zone boundaries landing within a mode
+    // line of each other corrupt the shared dispatch state (ADR-019). The raw
+    // handler stays under a scanline by writing pre-baked registers, then chains
+    // VDSLST from the next_ table just like the dispatcher (it shares that tail).
     void begin_dynamic() { total_count_ = static_count_; }
 
     void add_dynamic_raster_hook(u8 scanline, void (*h)()) {

--- a/engine/platform/atari/dli_dispatch.h
+++ b/engine/platform/atari/dli_dispatch.h
@@ -12,13 +12,20 @@
 // edge_dli_dispatch() is the wrapper for C++ handlers. On entry (from ANTIC via
 // VDSLST) it:
 //   1. saves A/X/Y,
-//   2. loads the current handler address from handler_lo_/handler_hi_ indexed
+//   2. saves the llvm-mos zero-page imaginary registers ($80-$9F): a C++ handler
+//      is an ordinary function that uses them, and the DLI interrupts the main
+//      thread mid-computation, which is using the very same locations. Without
+//      this, a non-trivial handler (e.g. the multiplexer's zone-boundary hook)
+//      corrupts the main thread's zero page and crashes it. Mirrors
+//      edge_vbi_trampoline (hal.h), which closes the identical gap for the VBI.
+//   3. loads the current handler address from handler_lo_/handler_hi_ indexed
 //      by current_ and patches it into a JSR operand,
-//   3. JSRs the handler (a non-capturing C++ lambda / function — ADR-020),
-//   4. loads next_lo_/next_hi_[current_] and stores it into VDSLST ($0200/$0201)
+//   4. JSRs the handler (a non-capturing C++ lambda / function — ADR-020),
+//   5. restores $80-$9F,
+//   6. loads next_lo_/next_hi_[current_] and stores it into VDSLST ($0200/$0201)
 //      so the next DLI of the frame enters correctly,
-//   5. increments current_,
-//   6. restores A/X/Y and RTIs.
+//   7. increments current_,
+//   8. restores A/X/Y and RTIs.
 //
 // The table base addresses and the current_ ZP location are not known until the
 // single InterruptManager instance is placed in RAM, so they are patched into
@@ -55,6 +62,27 @@ extern uint8_t edge_dli_op_nlo;    // LDA next_lo_,X          (abs, 2-byte opera
 extern uint8_t edge_dli_op_nhi;    // LDA next_hi_,X          (abs, 2-byte operand)
 extern uint8_t edge_dli_op_inc;    // INC current_            (abs, 2-byte operand)
 
+// ── Lean multiplex DLI (the sprite multiplexer's zone-boundary hook) ──
+//
+// edge_multiplex_dli is a *raw* handler ANTIC enters directly (no C++ dispatcher,
+// no $80-$9F save): the multiplexer pre-bakes each zone boundary's four HPOSP and
+// four COLPM bytes into a flat table (engine/sprites.h, mux_table_), so the DLI is
+// just eight LDA/STA pairs + an index bump — ~150 cycles (~1.3 scanlines) versus
+// the C++ dispatcher's ~11. That length matters: a DLI is an unmaskable NMI and
+// the dispatch path is not re-entrant, so a handler longer than the gap between
+// two zone boundaries gets preempted mid-flight and corrupts the shared save
+// buffer / chain index (it trashed the llvm-mos soft-stack pointer). Staying well
+// under one mode line keeps boundaries that fall on adjacent lines safe.
+//
+// It still participates in the InterruptManager chain: after writing its
+// registers it falls through to the generic dispatcher's tail (edge_dli_op_curx2)
+// via JMP, which re-points VDSLST from next_*[current_] and bumps current_ — the
+// same already-patched machinery, so user raster hooks compose normally.
+[[gnu::naked]] void edge_multiplex_dli();
+extern uint8_t edge_mux_op_index;  // LDA mux_index_   (abs, operand at +1)
+extern uint8_t edge_mux_op_table;  // first LDA mux_table_+0,x; load k at +k*6
+extern uint8_t edge_mux_op_inc;    // INC mux_index_   (abs, operand at +1)
+
 } // extern "C"
 
 // The dispatcher body. Placeholder operands ($00 / $FFFF) are overwritten by
@@ -76,6 +104,14 @@ edge_dli_dispatch:
     pha
     tya
     pha
+    ; Save the llvm-mos imaginary registers $80-$9F before entering the C++
+    ; handler — it uses them, and so does the main thread this DLI interrupted.
+    ldx #31
+.Ledge_dli_save:
+    lda $80,x
+    sta edge_dli_zp_save,x
+    dex
+    bpl .Ledge_dli_save
 edge_dli_op_curx:
     ldx $ffff               ; X = current_  (abs operand patched)
 edge_dli_op_hlo:
@@ -86,6 +122,14 @@ edge_dli_op_hhi:
     sta edge_dli_jsr+2
 edge_dli_jsr:
     jsr $ffff               ; call handler  (operand self-modified above)
+    ; Restore the imaginary registers the handler clobbered, so the interrupted
+    ; main thread resumes with its zero page intact.
+    ldx #31
+.Ledge_dli_restore:
+    lda edge_dli_zp_save,x
+    sta $80,x
+    dex
+    bpl .Ledge_dli_restore
 edge_dli_op_curx2:
     ldx $ffff               ; reload current_  (abs operand patched)
 edge_dli_op_nlo:
@@ -105,6 +149,52 @@ edge_dli_op_inc:
 
 edge_dli_terminal:
     rti                     ; no-op terminal: nothing left to chain
+
+edge_dli_zp_save:
+    .fill 32                ; saved $80-$9F (llvm-mos imaginary registers)
+)");
+
+// The lean multiplex DLI. Placeholder operands ($FFFF) are overwritten by
+// install_multiplex(); the GTIA register stores are fixed. Each LDA/STA pair is
+// 6 bytes, so the operand of table-load k is at (edge_mux_op_table + k*6 + 1).
+asm(R"(
+    .globl edge_multiplex_dli
+    .globl edge_mux_op_index
+    .globl edge_mux_op_table
+    .globl edge_mux_op_inc
+
+edge_multiplex_dli:
+    pha
+    txa
+    pha
+    tya
+    pha
+edge_mux_op_index:
+    lda $ffff               ; A = mux_index_  (abs operand patched)
+    asl
+    asl
+    asl                     ; X = mux_index_ * 8  (row offset into the flat table)
+    tax
+edge_mux_op_table:
+    lda $ffff,x             ; mux_table_+0,x   (operand patched)
+    sta $d000               ; HPOSP0
+    lda $ffff,x             ; mux_table_+1,x
+    sta $d001               ; HPOSP1
+    lda $ffff,x             ; mux_table_+2,x
+    sta $d002               ; HPOSP2
+    lda $ffff,x             ; mux_table_+3,x
+    sta $d003               ; HPOSP3
+    lda $ffff,x             ; mux_table_+4,x
+    sta $d012               ; COLPM0
+    lda $ffff,x             ; mux_table_+5,x
+    sta $d013               ; COLPM1
+    lda $ffff,x             ; mux_table_+6,x
+    sta $d014               ; COLPM2
+    lda $ffff,x             ; mux_table_+7,x
+    sta $d015               ; COLPM3
+edge_mux_op_inc:
+    inc $ffff               ; ++mux_index_  (abs operand patched)
+    jmp edge_dli_op_curx2   ; share the generic chain tail + epilogue (RTI)
 )");
 
 // install_dispatch — patch the table/current_ addresses into the dispatcher
@@ -128,6 +218,22 @@ inline void install_dispatch(uint16_t cur,
     patch16(&edge_dli_op_hhi, handler_hi);
     patch16(&edge_dli_op_nlo, next_lo);
     patch16(&edge_dli_op_nhi, next_hi);
+}
+
+// install_multiplex — patch the lean multiplex DLI's operands with the addresses
+// of the multiplexer's flat position/colour table and its per-frame fire index
+// (both members of the single SpriteManager instance, so the addresses are
+// stable). The eight table loads index mux_table_ + 0..7, six bytes apart.
+inline void install_multiplex(uint16_t table, uint16_t index) {
+    auto patch16 = [](uint8_t* opcode, uint16_t addr) {
+        opcode[1] = static_cast<uint8_t>(addr & 0xFF);
+        opcode[2] = static_cast<uint8_t>(addr >> 8);
+    };
+    patch16(&edge_mux_op_index, index);
+    patch16(&edge_mux_op_inc,   index);
+    uint8_t* tbl = &edge_mux_op_table;
+    for (uint8_t k = 0; k < 8; ++k)
+        patch16(tbl + k * 6, static_cast<uint16_t>(table + k));
 }
 
 } // namespace atari

--- a/engine/platform/atari/hal.h
+++ b/engine/platform/atari/hal.h
@@ -41,6 +41,18 @@ namespace atari {
 //
 // Mirrors dli_dispatch.h: a naked routine whose JSR operand is self-modified by
 // install_vbi() to point at the service. Never executed under mos-sim (no NMI).
+//
+// RE-ENTRY GUARD (edge_vbi_busy): the deferred VBI is an NMI, and a heavy service
+// (e.g. the 9-sprite sprite multiplexer) can overrun a frame. The next frame's VBI
+// NMI would then re-enter this trampoline *while it is still running* — and the
+// inner save loop would overwrite edge_vbi_zp_save with the outer call's
+// already-allocated $80-$9F. On unwind the main thread's llvm-mos soft-stack
+// pointer (__rc0/__rc1 at $80/$81) comes back one service frame lower than it went
+// in; that drift accumulates every overrun until the pointer walks down into the
+// code and the next service's stack writes corrupt it → crash. The guard makes a
+// re-entrant VBI a no-op (straight to XITVBV): one frame's service is skipped (a
+// cosmetic hiccup) instead of corrupting the soft stack. A in-service flag, not a
+// disable of NMIs, because the VBI NMI itself must keep being delivered.
 extern "C" {
 [[gnu::naked]] void edge_vbi_trampoline();
 extern uint8_t edge_vbi_jsr;   // first byte of the JSR; operand begins at +1
@@ -50,6 +62,9 @@ asm(R"(
     .globl edge_vbi_trampoline
     .globl edge_vbi_jsr
 edge_vbi_trampoline:
+    lda edge_vbi_busy
+    bne .Ledge_vbi_skip        ; already mid-service → don't re-enter; just exit
+    inc edge_vbi_busy
     ldx #31
 .Ledge_vbi_save:
     lda $80,x
@@ -64,7 +79,11 @@ edge_vbi_jsr:
     sta $80,x
     dex
     bpl .Ledge_vbi_restore
+    dec edge_vbi_busy
+.Ledge_vbi_skip:
     jmp $e462                  ; XITVBV
+edge_vbi_busy:
+    .byte 0
 edge_vbi_zp_save:
     .fill 32
 )");
@@ -109,6 +128,14 @@ struct Hal {
                                      uint16_t handler_lo, uint16_t handler_hi,
                                      uint16_t next_lo, uint16_t next_hi) {
         install_dispatch(cur, handler_lo, handler_hi, next_lo, next_hi);
+    }
+
+    // The raw zone-boundary handler the sprite multiplexer registers as its
+    // dynamic raster hook (engine/sprites.h), and the patch step that binds it to
+    // the multiplexer's flat position/colour table. Defined in dli_dispatch.h.
+    static void (*multiplex_dli())() { return &edge_multiplex_dli; }
+    static void install_multiplex_dli(uint16_t table, uint16_t index) {
+        install_multiplex(table, index);
     }
 
     // ── Display list / ANTIC DMA ──

--- a/engine/sprites.h
+++ b/engine/sprites.h
@@ -144,6 +144,11 @@ public:
     static constexpr u8 kPlayers  = 4;
     static constexpr u8 kMissiles = 4;
 
+    // Zone-boundary DLIs fire at the end of an 8-scanline mode line; bias the
+    // boundary up by ~one mode line so the player-position switch lands in the gap
+    // between zones (see update_zones). Layout-tunable; one MODE_2 line.
+    static constexpr u8 kBoundaryBias = 8;
+
     using caps = engine::caps_of_t<Platform>;
 
     // ── Logical sprite state (buffered; committed during the frame service) ──
@@ -247,15 +252,26 @@ public:
                     zi.color[p]             = 0;
                 }
             }
-            // Boundary: zone 0 from the top; later zones at the midpoint of the
-            // gap between adjacent groups.
+            // Boundary: zone 0 from the top; later zones in the gap between
+            // adjacent groups. boundary_scanline is consumed by the HAL as a
+            // display-list-relative scanline (program_raster_lines), while sprite
+            // Y is the P/M strip offset; on the standard layout the two track ~1:1.
+            // The DLI fires at the END of its 8-scanline mode line, i.e. a few
+            // lines BELOW the value here, so bias the switch up by kBoundaryBias so
+            // it lands in the inter-zone gap rather than partway through the lower
+            // zone's first sprite (which reads as a split "ghost" sprite). Never
+            // raise it above the previous zone's last sprite. Tune kBoundaryBias on
+            // hardware if the seams sit visibly off the sprites.
             if (z == 0) {
                 zi.boundary_scanline = 0;
             } else {
                 const u8 prev_last  = sprites_[order_[first - 1]].y;
                 const u8 this_first = sprites_[order_[first]].y;
-                zi.boundary_scanline =
-                    static_cast<u8>((prev_last + this_first) / 2);
+                const u8 mid = static_cast<u8>((prev_last + this_first) / 2);
+                u8 b = (mid > kBoundaryBias) ? static_cast<u8>(mid - kBoundaryBias)
+                                             : static_cast<u8>(0);
+                if (b < prev_last) b = prev_last;
+                zi.boundary_scanline = b;
             }
         }
     }
@@ -292,22 +308,25 @@ public:
     void commit_pm(u8* sprite_base) {
         const u8 res = static_cast<u8>(res_);
 
-        // 1. Clear last frame's dirty range for each player.
-        for (u8 p = 0; p < kPlayers; ++p) {
-            if (dirty_min_y_[p] <= dirty_max_y_[p]) {
-                const u16 base = Platform::hal::sprite_strip_offset(res, p);
-                for (u16 y = dirty_min_y_[p]; y <= dirty_max_y_[p]; ++y) {
-                    sprite_base[base + y] = 0;
-                }
-            }
+        // 1. Erase each sprite's exact strip footprint from last frame — only the
+        //    bytes it actually wrote, not the whole inter-sprite span. A player
+        //    multiplexes several sprites at different Y, so the old per-player
+        //    [min,max] clear zeroed the (mostly empty) gaps between them too; with
+        //    9 sprites spread down the screen that pushed the commit past one frame.
+        //    Clearing exact extents (≤ MaxSprites × height bytes) keeps it inside
+        //    the VBI. prev_player_ == kNotDrawn means the sprite wasn't drawn (and
+        //    prev_height_ is 0 on the very first commit, so nothing is cleared).
+        for (u8 i = 0; i < MaxSprites; ++i) {
+            if (prev_player_[i] == kNotDrawn) continue;
+            const u16 off = static_cast<u16>(
+                Platform::hal::sprite_strip_offset(res, prev_player_[i]) +
+                prev_y_[i]);
+            for (u8 r = 0; r < prev_height_[i]; ++r) sprite_base[off + r] = 0;
+            prev_player_[i] = kNotDrawn;
         }
 
-        // 2. Reset working dirty range.
-        u8 new_min[kPlayers];
-        u8 new_max[kPlayers];
-        for (u8 p = 0; p < kPlayers; ++p) { new_min[p] = 0xFF; new_max[p] = 0; }
-
-        // 3. Copy each active sprite's shape into its assigned player's strip.
+        // 2. Copy each active sprite's shape into its assigned player's strip and
+        //    record the exact footprint for next frame's erase.
         for (u8 z = 0; z < zone_count_; ++z) {
             const ZoneInfo& zi = zones_[z];
             for (u8 p = 0; p < kPlayers; ++p) {
@@ -317,63 +336,75 @@ public:
                 const u16 base = Platform::hal::sprite_strip_offset(res, p);
                 const u8 yb = (res_ == SpriteVerticalResolution::SingleLine)
                                   ? s.y : static_cast<u8>(s.y >> 1);
-                for (u8 r = 0; r < s.height; ++r) {
-                    sprite_base[base + yb + r] = s.shape[r];
-                }
-                const u8 lo_y = yb;
-                const u8 hi_y = static_cast<u8>(yb + s.height - 1);
-                if (lo_y < new_min[p]) new_min[p] = lo_y;
-                if (hi_y > new_max[p]) new_max[p] = hi_y;
+                const u16 off = static_cast<u16>(base + yb);
+                for (u8 r = 0; r < s.height; ++r) sprite_base[off + r] = s.shape[r];
+                prev_player_[li] = p;
+                prev_y_[li]      = yb;
+                prev_height_[li] = s.height;
             }
         }
 
-        // 4. Write zone-0 sprite positions + colours (the frame service sets the first
-        //    zone; later zones are armed by the boundary raster hooks). The colour register is the
-        //    hardware register, written after the OS shadow→hardware copy so it
-        //    holds for the frame and gives this zone's sprites their colours.
+        // 3. Write zone-0 sprite positions + colours (the frame service sets the
+        //    first zone from the top; later zones are armed by the boundary raster
+        //    hooks). Position goes straight to HPOSP (no OS shadow exists for it),
+        //    but the COLOUR must go through the OS PCOLR shadow: this runs in the
+        //    VBI, *before* the OS copies PCOLR→COLPM, so a direct COLPM write here
+        //    would be overwritten (zeroed) by that copy and zone 0 would show black.
+        //    The boundary DLIs, by contrast, run during the visible frame *after*
+        //    the copy, so they write COLPM directly (set_sprite_color).
         if (zone_count_ > 0) {
             for (u8 p = 0; p < kPlayers; ++p) {
                 Platform::hal::set_sprite_x(p, zones_[0].hpos[p]);
-                Platform::hal::set_sprite_color(p, zones_[0].color[p]);
+                Platform::hal::set_color_pm(p, zones_[0].color[p]);
             }
         }
         // Missiles are direct, not multiplexed (ADR-025).
         for (u8 m = 0; m < kMissiles; ++m) {
             Platform::hal::set_projectile_x(m, missile_x_[m]);
         }
-
-        // 5. Record this frame's dirty ranges for next frame's clear.
-        for (u8 p = 0; p < kPlayers; ++p) {
-            dirty_min_y_[p] = new_min[p];
-            dirty_max_y_[p] = new_max[p];
-        }
     }
 
     // ── Raster-hook construction ──
     //
-    // Register a raw boundary raster hook for each zone after the first (zone 0's
-    // positions are set by the frame-service commit). The handler walks per-frame static
-    // state: s_hook_zone_ is reset here and advanced by each hook, which writes
-    // the corresponding zone's sprite positions through the HAL.
+    // Register a boundary raster hook for each zone after the first (zone 0's
+    // positions are set by the frame-service commit), and pre-bake that zone's four
+    // HPOSP + four COLPM bytes into mux_table_ in fire order. The raw DLI
+    // (Platform::hal::multiplex_dli, edge_multiplex_dli on Atari) reads row
+    // mux_index_, copies the eight bytes straight to the GTIA registers, and bumps
+    // the index — no per-DLI work, so it stays well under a scanline (see the
+    // re-entrancy note in interrupt.h::add_dynamic_raster_hook). mux_index_ is reset
+    // here, in the VBI, before the frame's first boundary DLI fires.
     //
-    // This implements the position-write logic and the per-frame registration. The
-    // production raw handler also needs the backend prologue/epilogue (chain the
-    // next raster vector via InterruptManager::next_raster_addr()); that platform
-    // glue is added with the live hardware path — it is never executed under the
-    // simulator (no hardware raster), consistent with the backend dispatcher.
+    // Under the simulator there is no hardware raster, so the hook is registered
+    // (and the table built) but never entered.
     template <typename IM>
     void build_raster_hooks(IM& im) {
+        im.begin_dynamic();
         // A blitter backend has no hardware players to reposition mid-frame, so no
         // zone-boundary DLIs are needed — just clear any stale dynamic hooks.
-        if constexpr (caps::has_blitter) {
-            im.begin_dynamic();
-            return;
-        }
-        s_active_   = this;
-        s_hook_zone_ = 0;
-        im.begin_dynamic();
+        if constexpr (caps::has_blitter) return;
+
+        mux_index_ = 0;
+        void (*const h)() = Platform::hal::multiplex_dli();
         for (u8 z = 1; z < zone_count_; ++z) {
-            im.add_dynamic_raster_hook(zones_[z].boundary_scanline, &zone_boundary_hook);
+            const ZoneInfo& zi = zones_[z];
+            u8* row = &mux_table_[static_cast<u8>((z - 1) * kMuxRow)];
+            for (u8 p = 0; p < kPlayers; ++p) {
+                row[p]            = zi.hpos[p];
+                row[p + kPlayers] = zi.color[p];
+            }
+            im.add_dynamic_raster_hook(zi.boundary_scanline, h);
+        }
+    }
+
+    // One-time setup: bind the raw multiplex DLI to this manager's flat table and
+    // fire index (the single instance never moves). engine::Core::init calls this on
+    // baseline backends; discarded on blitter backends, which have no boundary DLIs.
+    void arm_multiplex_dli() {
+        if constexpr (!caps::has_blitter) {
+            Platform::hal::install_multiplex_dli(
+                static_cast<u16>(reinterpret_cast<uintptr_t>(mux_table_)),
+                static_cast<u16>(reinterpret_cast<uintptr_t>(&mux_index_)));
         }
     }
 
@@ -426,27 +457,19 @@ private:
                (LogicalSprite::FLAG_ACTIVE | LogicalSprite::FLAG_VISIBLE);
     }
 
-    // Raw boundary raster hook: advance to the next zone and write its sprite positions
-    // and colours (so each zone's sprites show their own colour, not the slot's).
-    static void zone_boundary_hook() {
-        SpriteManager* m = s_active_;
-        const u8 z = static_cast<u8>(++s_hook_zone_);
-        const ZoneInfo& zi = m->zones_[z];
-        for (u8 p = 0; p < kPlayers; ++p) {
-            Platform::hal::set_sprite_x(p, zi.hpos[p]);
-            Platform::hal::set_sprite_color(p, zi.color[p]);
-        }
-    }
-
     LogicalSprite sprites_[MaxSprites] = {};
     ZoneInfo      zones_[MaxZones]     = {};
     u8            zone_count_          = 0;
     u8            active_count_        = 0;
 
-    // Tracked dirty Y range per player (ADR-022). Init empty (min>max) so the
-    // first commit clears nothing.
-    u8 dirty_min_y_[kPlayers] = {0xFF, 0xFF, 0xFF, 0xFF};
-    u8 dirty_max_y_[kPlayers] = {0, 0, 0, 0};
+    // Per-sprite footprint from last commit, for the exact-extent erase (ADR-022).
+    // prev_player_[i] is the hardware player logical sprite i was drawn on, or
+    // kNotDrawn if it wasn't; prev_y_/prev_height_ are its strip offset and height.
+    // prev_height_ inits to 0 so the very first commit erases nothing.
+    static constexpr u8 kNotDrawn = 0xFF;
+    u8 prev_player_[MaxSprites] = {};
+    u8 prev_y_[MaxSprites]      = {};
+    u8 prev_height_[MaxSprites] = {};
 
     // Buffered missile positions (no multiplexing, ADR-025).
     u8 missile_x_[kMissiles]      = {};
@@ -458,17 +481,15 @@ private:
 
     SpriteVerticalResolution res_ = SpriteVerticalResolution::SingleLine;
 
-    // Per-frame raster-hook walker state (one set per template instantiation).
-    static SpriteManager* s_active_;
-    static u8             s_hook_zone_;
+    // Flat per-boundary register table the raw multiplex DLI walks: one kMuxRow-byte
+    // row per zone after the first, [HPOSP0..3, COLPM0..3], in fire (scanline)
+    // order. mux_index_ is the row the next boundary DLI will consume; reset to 0
+    // each frame by build_raster_hooks and bumped by the DLI (engine HAL +
+    // platform/atari/dli_dispatch.h own the hardware side).
+    static constexpr u8 kMuxRow = kPlayers * 2;   // 4 HPOSP + 4 COLPM
+    u8 mux_table_[MaxZones * kMuxRow] = {};
+    u8 mux_index_ = 0;
 };
-
-template <typename Platform, u8 MaxSprites, u8 MaxZones>
-SpriteManager<Platform, MaxSprites, MaxZones>*
-    SpriteManager<Platform, MaxSprites, MaxZones>::s_active_ = nullptr;
-
-template <typename Platform, u8 MaxSprites, u8 MaxZones>
-u8 SpriteManager<Platform, MaxSprites, MaxZones>::s_hook_zone_ = 0;
 
 } // namespace engine
 

--- a/engine/version.h
+++ b/engine/version.h
@@ -10,8 +10,8 @@
 // EDGE follows Semantic Versioning (https://semver.org/): MAJOR.MINOR.PATCH.
 
 #define EDGE_VERSION_MAJOR 0
-#define EDGE_VERSION_MINOR 3
+#define EDGE_VERSION_MINOR 4
 #define EDGE_VERSION_PATCH 0
-#define EDGE_VERSION_STRING "0.3.0"
+#define EDGE_VERSION_STRING "0.4.0"
 
 #endif // ENGINE_VERSION_H

--- a/tests/backends/atari/test_atari_core.cpp
+++ b/tests/backends/atari/test_atari_core.cpp
@@ -64,6 +64,7 @@ struct MockHal {
     static void set_sprite_x(u8, u8) {}
     static void set_projectile_x(u8, u8) {}
     static void set_sprite_color(u8, u8) {}
+    static void set_color_pm(u8, u8) {}
     static uint16_t sprite_strip_offset(u8, u8 s) { return static_cast<uint16_t>(s * 256); }
     static uint16_t sprite_strip_size(u8) { return 256; }
     static uint16_t raster_dispatch_addr() { return 0xD15A; }
@@ -73,6 +74,9 @@ struct MockHal {
     static void enable_raster()  {}
     static void disable_raster() {}
     static void install_raster_dispatch(u16, u16, u16, u16, u16) {}
+    static void mux_noop() {}
+    static void (*multiplex_dli())() { return &mux_noop; }
+    static void install_multiplex_dli(u16, u16) {}
     static u8   read_joystick(u8) { return 0; }
     static u8   read_keyboard()   { return 0; }
     static u8   coll_player_playfield(u8) { return 0; }

--- a/tests/generic/test_core.cpp
+++ b/tests/generic/test_core.cpp
@@ -84,6 +84,9 @@ struct MockHal {
     static void enable_raster()  {}
     static void disable_raster() {}
     static void install_raster_dispatch(u16, u16, u16, u16, u16) {}
+    static void mux_noop() {}
+    static void (*multiplex_dli())() { return &mux_noop; }
+    static void install_multiplex_dli(u16, u16) {}
 
     // Input capture (injected).
     static u8 read_joystick(u8 port) { return joy_state[port]; }

--- a/tests/generic/test_sprites.cpp
+++ b/tests/generic/test_sprites.cpp
@@ -33,6 +33,10 @@ struct MockHal {
     static void set_sprite_x(u8 player,  u8 x) { hposp[player]  = x; }
     static void set_projectile_x(u8 missile, u8 x) { hposm[missile] = x; }
     static void set_sprite_color(u8 player,  u8 c) { colpm[player]  = c; }
+    // Zone-0 colour now goes through the PCOLR shadow; the mock treats it as the
+    // player's effective colour (no OS copy to model), so the color-follows test
+    // keeps checking colpm[].
+    static void set_color_pm(u8 player, u8 c) { colpm[player] = c; }
 
     static u16 sprite_strip_offset(u8 res, u8 player) {
         const bool single = (res == 0);
@@ -41,6 +45,11 @@ struct MockHal {
         return static_cast<u16>(base + player * stride);
     }
     static u16 sprite_strip_size(u8 res) { return (res == 0) ? 256 : 128; }
+
+    // The raw multiplex DLI is hardware-only; build_raster_hooks just needs a
+    // valid handler pointer for the slot (never entered under the simulator).
+    static void mux_noop() {}
+    static void (*multiplex_dli())() { return &mux_noop; }
 };
 u8 MockHal::hposp[4] = {};
 u8 MockHal::hposm[4] = {};
@@ -99,9 +108,11 @@ static void test_five_sprites_two_zones() {
     CHECK(mgr.logical(z1.player_assignment[0]).y == 90);
     CHECK(z1.player_assignment[1] == ZoneInfo::UNUSED);
 
-    // The boundary falls between zone 0's last sprite (70) and zone 1's (90).
-    CHECK(z1.boundary_scanline > 70 && z1.boundary_scanline < 90);
-    CHECK(z1.boundary_scanline == 80);     // midpoint
+    // The boundary falls between zone 0's last sprite (70) and zone 1's (90),
+    // biased up by one mode line (kBoundaryBias = 8) so the DLI — which fires at
+    // the end of its mode line — switches players in the gap, not mid-sprite.
+    CHECK(z1.boundary_scanline >= 70 && z1.boundary_scanline < 90);
+    CHECK(z1.boundary_scanline == 72);     // midpoint 80 - kBoundaryBias 8
     CHECK(z0.boundary_scanline == 0);      // zone 0 is active from the top
 }
 


### PR DESCRIPTION
This pull request introduces EDGE v0.4.0, focusing on a major overhaul and hardware validation of the P/M (Player/Missile) sprite multiplexer for Atari 8-bit systems. The update includes a new hardware-backed, zone-boundary DLI (Display List Interrupt) handler, several breaking changes to the HAL contract, and a comprehensive demo showcasing the multiplexer in action. It also fixes several hardware-specific bugs and updates documentation and versioning across the codebase.

**Major new features and changes:**

**Sprite Multiplexer and DLI Overhaul**
- The sprite multiplexer now runs on real hardware with a new, efficient raw zone-boundary DLI (`edge_multiplex_dli` in `platform/atari/dli_dispatch.h`). This handler copies pre-baked sprite data directly to hardware registers, ensuring correct operation even when zone boundaries are closely spaced. The multiplexer is now backed by `SpriteManager::arm_multiplex_dli()` and new HAL functions (`hal::multiplex_dli()`, `hal::install_multiplex_dli()`). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR181) [[3]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR195)

**HAL Contract and Engine Core Changes (Breaking for Custom Platforms)**
- The HAL interface now requires implementations of `hal::set_color_pm()`, `hal::multiplex_dli()`, and `hal::install_multiplex_dli()`. Sprite commit logic now uses the OS PCOLR shadow for zone 0 color instead of writing directly to COLPM, and raster hooks for zone boundaries are registered as raw handlers. No changes to the game-author-facing API. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR372-R384) [[3]](diffhunk://#diff-973ef41b92e9603d3a6d6991d2d336f6413cc6043a8b672683a5d6a39fc2f889R153-R161)

**Bug Fixes and Robustness**
- Fixes a multiplexer crash on hardware due to unguarded deferred VBI overruns, which could corrupt the soft-stack pointer and cause system instability. Adds a re-entry guard and disables DLI NMIs during the VBI service to prevent race conditions. Also fixes issues with sprite coloring in the top zone, stutter with 9 sprites, and visual artifacts at zone seams. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR372-R384)

**Demo and Build System**
- Adds a new `multiplex_demo` program (`demo/multiplex_demo.cpp`) demonstrating nine logical sprites bouncing across the screen, with the live zone count displayed. The demo is built as an independent `.xex` binary and is integrated into the CMake build system. [[1]](diffhunk://#diff-fb9a1c8c48aafdde7ae4c888cd7bf52f79795392b1fce02fc2fecfda9fa21eb0R1-R242) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR120-R128)

**Documentation and Versioning**
- Updates all documentation and readme files to reference EDGE v0.4.0. Adds a detailed changelog entry for this release. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL3-R3) [[3]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cL3-R3) [[4]](diffhunk://#diff-38612f5904fb8c3dc3283d855aa486c7bc5ce02c15edd6b90be1e8424fcf0b99L3-R3) [[5]](diffhunk://#diff-b1b484de02794082600e79848bdf85fed4c26408fc1b36fb451beb48866d64d7L3-R3) [[6]](diffhunk://#diff-48492ab448322dc75b3414244c16ea64f9498bb9185bff4a0cb5c1d26c991306L3-R3) [[7]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51)

---

**Most important changes:**

**Sprite Multiplexer and DLI Overhaul**
- Introduced a hardware-backed, efficient raw zone-boundary DLI (`edge_multiplex_dli`) and updated the multiplexer to run reliably on real hardware, using pre-baked sprite data and sharing the dispatcher chain tail. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR181) [[3]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR195)

**HAL Contract and Engine Core**
- Updated the HAL contract (breaking change) to require new DLI-related functions and to use the OS PCOLR shadow for color management. Raster hooks for zone boundaries are now registered as raw handlers. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR372-R384) [[3]](diffhunk://#diff-973ef41b92e9603d3a6d6991d2d336f6413cc6043a8b672683a5d6a39fc2f889R153-R161)

**Bug Fixes**
- Fixed multiplexer crash and stack corruption by adding a VBI re-entry guard and gating off DLI NMIs during the VBI service. Also fixed issues with sprite coloring, stutter, and visual artifacts at zone seams. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR372-R384)

**Demo and Build System**
- Added a new `multiplex_demo` program and integrated it into the build system, providing a real hardware validation and demonstration of the new multiplexer. [[1]](diffhunk://#diff-fb9a1c8c48aafdde7ae4c888cd7bf52f79795392b1fce02fc2fecfda9fa21eb0R1-R242) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR120-R128)

**Documentation and Versioning**
- Updated all documentation and version references to v0.4.0, including a detailed changelog for this release. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL3-R3) [[3]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cL3-R3) [[4]](diffhunk://#diff-38612f5904fb8c3dc3283d855aa486c7bc5ce02c15edd6b90be1e8424fcf0b99L3-R3) [[5]](diffhunk://#diff-b1b484de02794082600e79848bdf85fed4c26408fc1b36fb451beb48866d64d7L3-R3) [[6]](diffhunk://#diff-48492ab448322dc75b3414244c16ea64f9498bb9185bff4a0cb5c1d26c991306L3-R3) [[7]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51)