### PR TITLE
Purge atari from generic api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-07
+
+API-cleanup release: Atari-specific names are purged from the generic engine
+surface, and a platform-specific escape hatch is relocated to the platform layer
+(ADR-031). Breaking for Atari game code that called `Game::antic_playfield()` and for
+any custom backend implementing the display-traits contract.
+
+### Added
+- `screen_buffer_alignment` capability field (`engine/config/capabilities.h`,
+  default `1` = no constraint) — a platform-supplied screen-buffer alignment
+  granularity. The Atari profile sets it to `4096`, replacing a hardcoded scan-
+  boundary constant in `engine/screen.h`, so the portable screen manager asks for the
+  alignment it needs without encoding ANTIC's 4K page behaviour.
+
+### Changed
+- Display-traits predicate `is_vbxe(ModeT)` renamed to `is_overlay_mode(ModeT)` — the
+  `engine/display_traits.h` contract member and its Atari specialization. The name now
+  describes what it tests (an overlay vs base mode) rather than the chip that
+  introduced it. **Breaking** for custom backends that specialise the traits seam.
+- Purged Atari chip/register names (ANTIC, VBXE, P/M, DLI, GTIA, …) from the generic
+  `engine/*.h` headers — comments and identifiers now use portable
+  capability/feature vocabulary. Engine-header rule: no hardware addresses, register
+  names, or platform-specific types outside the `Platform` template parameter.
+
+### Removed
+- `Game::antic_playfield(bool)` removed from the engine facade. The Atari playfield-
+  DMA escape hatch is now the free function `atari::set_playfield_dma(bool)` in the
+  Atari platform layer, reached by including the Atari platform header. Per ADR-031,
+  platform-specific escape hatches belong on the platform, not on the generic `Game::`
+  facade. **Breaking** for Atari game code that called it.
+- `DisplayLayout::antic_region_count` removed — an unused public layout query (no
+  engine consumers; it degraded to `region_count` on any platform without an overlay
+  plane). Its only consumers were unit tests, now expressed via `region_count` and the
+  existing `has_overlay` / `is_pure_overlay` queries.
+
 ## [0.4.1] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EDGE (Eight-bit Damned! Game Engine)
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](./CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
 
 EDGE is a C++20 game engine for constrained 6502-class systems, built around a small, deterministic, compile-time configured API instead of a heavy runtime.
 The project is Atari-first today, but its architecture is intended to support additional 6502-family platforms over time. Game code is written against portable engine subsystems while hardware details live behind a platform HAL and compile-time capability profiles.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Hardware validation demo (`atari_hw_test.xex`)
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 A minimal Atari 8-bit program that drives every engine subsystem at once, so
 the engine's live ANTIC path can be confirmed on real hardware / emulators
@@ -171,7 +171,7 @@ The screen is a pure-overlay `DisplayLayout<OverlayRegion<VBXE_SR, 240>>`, so
 `set_screen` keeps ANTIC DMA off automatically — without that, the hidden ANTIC
 playfield's DMA would contend the VRAM bus and stall the blitter's per-frame
 restore copies, throttling motion to ~8 Hz. (Earlier versions of this demo
-achieved the same with a manual `Game::antic_playfield(false)` call.)
+achieved the same with a manual `atari::set_playfield_dma(false)` call.)
 
 | Observation | Proves |
 |---|---|

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -1,6 +1,6 @@
 # API Design
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 The user-facing API for the engine. This document describes what
 a game author writes. Internal engine implementation details are
@@ -367,7 +367,7 @@ struct OverlayScreen {
 
 A *pure-overlay* screen (only `OverlayRegion`s) turns ANTIC DMA
 off automatically in `set_screen` — there is no manual
-`antic_playfield(false)` to remember — and the engine
+playfield-DMA disable to remember — and the engine
 compile-time-checks the region's mode/height against the
 platform's VBXE `Config`. Mixing an `OverlayRegion` with ANTIC
 `TextRegion`/`BitmapRegion`s in one layout positions the overlay

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 System design, component relationships, and the abstraction
 boundaries that make the engine portable across 6502 platforms

--- a/docs/CONSTRAINTS.md
+++ b/docs/CONSTRAINTS.md
@@ -1,6 +1,6 @@
 # Constraints
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Hardware budgets, platform targets, and non-negotiable rules that
 every design decision must respect.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1419,3 +1419,84 @@ toolchain. Until the window region is reserved in the linker, a
 binary whose heap grows up or stack grows down into the chosen
 window could still collide — verify against the `.map` if the
 binary grows substantially.
+
+## ADR-031: Platform-Specific Escape Hatches Belong on the Platform, Not Game::
+
+**Status:** Accepted
+
+**Context:**
+During initial implementation, `Game::antic_playfield(bool)` was added
+to `engine/core.h` as a convenience method for disabling ANTIC playfield
+DMA on VBXE overlay screens. It was placed on the `Game::` facade because
+that was the path of least resistance — game code already uses `Game::`
+for everything else.
+
+A subsequent portability audit (the header leakage cleanup) flagged the
+method: `antic_playfield` embeds a chip name in the generic engine
+facade and has no meaningful implementation on any non-Atari backend.
+The initial FIXME proposed renaming it to a neutral portable name.
+
+That diagnosis was wrong. The problem is not the name — it is the
+location. There is no portable concept to rename it to. A C64 backend
+has no equivalent DMA control; a hypothetical Apple II backend doesn't
+either. The operation is intrinsically Atari-specific.
+
+**Options Considered:**
+
+1. **Rename to a neutral name on Game::** (rejected): `set_playfield_dma`,
+   `set_background_fetch`, etc. Forces every future backend to implement
+   or stub a concept that may not exist on its hardware. The `Game::`
+   facade becomes polluted with lowest-common-denominator wrappers around
+   hardware quirks. A C64 game author sees a method that does nothing on
+   their platform. Wrong abstraction.
+
+2. **Gate behind `if constexpr` on Game::** (rejected): exposes the
+   method only when `caps::has_antic_dma_control` or similar is true.
+   Keeps it on `Game::` but invisible on non-Atari builds. Still wrong —
+   it couples the engine facade to a platform capability that exists
+   solely because one chip works a particular way. Capability flags should
+   describe features game code cares about, not hardware quirks the engine
+   needs to manage internally.
+
+3. **Remove from Game:: and expose through the platform layer** (chosen):
+   The method is removed from `engine/core.h`. The equivalent function is
+   exposed directly in the Atari platform headers
+   (`engine/platform/atari/antic.h` or similar). Atari game code that
+   needs it calls the platform function directly. Non-Atari game code
+   never sees it.
+
+**Decision:**
+`Game::antic_playfield()` is removed from `engine/core.h`.
+The functionality is exposed as a free function in the Atari platform
+layer. Atari game code accesses it by including the Atari platform
+header directly. The `Game::` facade exposes no platform-specific
+escape hatches.
+
+**Rationale:**
+The `Game::` facade exists to give game code a single portable surface.
+It should expose only operations that every backend can meaningfully
+implement. Platform-specific escape hatches — DMA controls, chip-specific
+registers, hardware quirks — belong on the platform layer, reachable
+directly by game code that has already committed to a specific platform
+by virtue of its platform type alias.
+
+This is the same reason `Game::sid_volume()` would be wrong on a
+C64 backend: not because SID is a bad name, but because it doesn't
+belong on the generic facade. Platform-specific code reaches
+platform-specific hardware through platform-specific APIs. The engine
+facade stays clean.
+
+**Principle established:**
+If a method on `Game::` has no meaningful implementation on a
+hypothetical second backend, it does not belong on `Game::`. Move it
+to the platform layer. Game code that is already platform-specific
+(by platform type alias) can include platform headers directly without
+compromising portability.
+
+**Tradeoff:**
+Atari game code that calls `Game::antic_playfield()` must be updated to
+call the platform function directly. Since EDGE is pre-1.0 and the only
+callers are the engine's own demos, this is a one-site update. Future
+callers will find the function where it semantically belongs — in the
+Atari platform headers — rather than on a generic facade that implies
+cross-platform availability.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Decisions made during design, with rationale. These explain the
 "why" behind architectural choices and document tradeoffs.

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # EDGE API Reference
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This reference is organized in two layers:
 
@@ -165,8 +165,8 @@ The engine exposes three display-region kinds:
   in VBXE VRAM (zero screen-buffer RAM). `Mode` is a VBXE overlay mode
   (`atari::Mode::VBXE_SR`/`VBXE_HR`/`VBXE_LR`/`VBXE_T80`). Region order sets the
   overlay's vertical position. A layout of only `OverlayRegion`s is a *pure
-  overlay*: `set_screen` keeps ANTIC DMA off for it automatically (no
-  `antic_playfield(false)` needed), and its `OverlayRegion` mode/height are checked
+  overlay*: `set_screen` keeps ANTIC DMA off for it automatically (no manual
+  playfield-DMA disable needed), and its `OverlayRegion` mode/height are checked
   against the platform's VBXE `Config` at compile time.
 
 These are composed into a screen layout:
@@ -287,18 +287,20 @@ Background / compositing (for sprites-over-bitmap):
 - `Game::overlay_publish_background()` — publish the bitmap drawn via `Game::gfx()`
   to the live display page(s); sprite footprints are then restored from it each
   frame
-- `Game::antic_playfield(bool enable)` — enable/disable the ANTIC playfield
-  (character/bitmap) DMA. **Atari-only, opt-in escape hatch.** The common case is
-  now automatic: a *pure-overlay* screen (`DisplayLayout` of only
-  `OverlayRegion`s) keeps ANTIC DMA off through `set_screen`, so you do **not**
-  need to call this. When an opaque VBXE overlay covers the screen the ANTIC
-  playfield is invisible, but its per-scanline VRAM DMA starves the blitter's
-  restore copies and can collapse the compositor's per-frame budget (e.g.
-  `Background::Bitmap` ran the loop at ~8 Hz instead of 60). Use this only for the
-  cases the engine can't infer: a transparent overlay that shows ANTIC through
-  (leave it enabled), or a mixed overlay+ANTIC layout where you want the playfield
-  fetch off anyway. It toggles only the playfield bits; any `set_screen` on a
-  non-pure-overlay layout re-enables them.
+- `atari::set_playfield_dma(bool enable)` — enable/disable the ANTIC playfield
+  (character/bitmap) DMA. **Atari platform-layer function, opt-in escape hatch** —
+  it lives in the Atari platform headers, *not* on `Game::` (ADR-031: platform-
+  specific escape hatches belong on the platform). Reach it by including the Atari
+  platform header your game already uses. The common case is now automatic: a
+  *pure-overlay* screen (`DisplayLayout` of only `OverlayRegion`s) keeps ANTIC DMA
+  off through `set_screen`, so you do **not** need to call this. When an opaque VBXE
+  overlay covers the screen the ANTIC playfield is invisible, but its per-scanline
+  VRAM DMA starves the blitter's restore copies and can collapse the compositor's
+  per-frame budget (e.g. `Background::Bitmap` ran the loop at ~8 Hz instead of 60).
+  Use it only for the cases the engine can't infer: a transparent overlay that shows
+  ANTIC through (leave it enabled), or a mixed overlay+ANTIC layout where you want
+  the playfield fetch off anyway. It toggles only the playfield bits; any
+  `set_screen` on a non-pure-overlay layout re-enables them.
 
 Overlay collision snapshots, latched at the frame service:
 

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -1,6 +1,6 @@
 # EDGE Atari Platform Guide
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This document describes the first concrete EDGE backend: the Atari 8-bit family.
 

--- a/documents/QUICK_START.md
+++ b/documents/QUICK_START.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This guide introduces EDGE from the engine author's point of view first, then shows the current concrete setup using the Atari backend.
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 # EDGE Engine Documentation
 
-> **Applies to EDGE v0.4.1** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.5.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 EDGE is a C++ engine for building games and interactive applications on constrained 6502-class systems.
 

--- a/engine/config/capabilities.h
+++ b/engine/config/capabilities.h
@@ -87,6 +87,10 @@ struct Capabilities {
     static constexpr u32 extended_ram_bytes = 0;
     static constexpr u16 extended_bank_size = 0;
     static constexpr u8  zp_available       = 0;
+    // Required alignment for the shared screen buffer in bytes.
+    // 1 = no constraint. Platform sets this to its display
+    // hardware's scan-boundary granularity.
+    static constexpr u16 screen_buffer_alignment = 1;
 
     // ── Input ──
     static constexpr u8   joystick_ports = 0;

--- a/engine/core.h
+++ b/engine/core.h
@@ -184,7 +184,7 @@ public:
             tiles.bind_charset_page(page_of(charset_buffer_));
         }
         interrupts.arm_dispatch();
-        sprites.arm_multiplex_dli();   // bind the raw zone-boundary raster hook (baseline)
+        sprites.arm_multiplex_hook();  // bind the raw zone-boundary raster hook (baseline)
         Platform::hal::install_frame_isr(&frame_service);
     }
     static void init() {
@@ -199,7 +199,7 @@ public:
         setup_sprites();
         set_screen<InitialScreen>([] {});
         interrupts.arm_dispatch();
-        sprites.arm_multiplex_dli();   // bind the raw zone-boundary raster hook (baseline)
+        sprites.arm_multiplex_hook();  // bind the raw zone-boundary raster hook (baseline)
         Platform::hal::install_frame_isr(&frame_service);
     }
 

--- a/engine/core.h
+++ b/engine/core.h
@@ -164,7 +164,7 @@ public:
         if constexpr (caps::has_blitter) {
             // Overlay bring-up (HAL sets up its memory window, display list, and
             // enable). A pure-overlay InitialScreen no longer needs a manual
-            // antic_playfield(false): set_screen keeps playfield DMA off for it, so
+            // playfield-DMA disable: set_screen keeps playfield DMA off for it, so
             // the playfield never contends the VRAM bus (see screen.h).
             Platform::hal::overlay_init();
         }
@@ -190,7 +190,7 @@ public:
     static void init() {
         using caps = engine::caps_of_t<Platform>;
         if constexpr (caps::has_blitter) {
-            // Pure-overlay layouts no longer need a manual antic_playfield(false):
+            // Pure-overlay layouts no longer need a manual playfield-DMA disable:
             // set_screen keeps playfield DMA off for them (see screen.h).
             Platform::hal::overlay_init();
         }
@@ -239,25 +239,6 @@ public:
     // master each frame. No-op on platforms without an overlay or in Flat mode.
     static void overlay_publish_background() {
         Platform::hal::overlay_publish_background();
-    }
-
-    // Enable/disable the playfield (character/bitmap) DMA. The common opaque
-    // overlay-only case is now automatic: a pure-overlay screen (is_pure_overlay)
-    // keeps playfield DMA off through set_screen, so no manual call is needed. This
-    // remains as an escape hatch for the cases the engine can't infer: a transparent
-    // overlay that shows the playfield through (leave it enabled), or a mixed
-    // overlay+playfield layout where you want the playfield fetch off to free the
-    // VRAM bus even though playfield regions are present. When an opaque overlay
-    // covers the screen the playfield is invisible, but its per-scanline VRAM-bus
-    // DMA starves the blitter's restore copies and collapses the overlay
-    // compositor's per-frame budget. Re-enabled by any set_screen on a
-    // non-pure-overlay layout. Backends without a separate playfield layer treat
-    // this as a no-op (see API_REFERENCE.md).
-    // FIXME[HAL]: the public name antic_playfield() and the seam
-    // set_antic_playfield_dma() embed the ANTIC chip name; rename to a neutral
-    // playfield-DMA seam (e.g. set_playfield_dma) once the HAL is generalized.
-    static void antic_playfield(bool enable) {
-        Platform::hal::set_antic_playfield_dma(enable);
     }
 
     // ── Overlay text mode (80-column overlay text; no-op on platforms without it) ──

--- a/engine/core.h
+++ b/engine/core.h
@@ -162,44 +162,44 @@ public:
     static void init(const Charset& cs) {
         using caps = engine::caps_of_t<Platform>;
         if constexpr (caps::has_blitter) {
-            // VBXE overlay bring-up (MEMAC window + full-screen XDL + enable).
-            // A pure-overlay InitialScreen no longer needs a manual
-            // antic_playfield(false): set_screen keeps ANTIC DMA off for it, so
+            // Overlay bring-up (HAL sets up its memory window, display list, and
+            // enable). A pure-overlay InitialScreen no longer needs a manual
+            // antic_playfield(false): set_screen keeps playfield DMA off for it, so
             // the playfield never contends the VRAM bus (see screen.h).
             Platform::hal::overlay_init();
         }
-        // Arm the P/M base + DMA on every backend. On baseline this is the hardware
-        // sprite path; on a blitter backend the players composite in VRAM instead,
-        // but the four hardware MISSILES are still used directly (ADR-025), so they
-        // need P/M DMA armed to render below the overlay. Done before set_screen so
-        // the P/M DMA bits survive its SDMCTL rewrite (the screen manager preserves
-        // them via the PM_DMA_MASK partition — see hal.h SDMCTL note). The empty
-        // player strips on a blitter backend simply draw nothing.
+        // Arm the hardware-sprite base + DMA on every backend. On baseline this is
+        // the hardware sprite path; on a blitter backend the players composite in
+        // VRAM instead, but the four hardware MISSILES are still used directly
+        // (ADR-025), so they need sprite DMA armed to render below the overlay. Done
+        // before set_screen so the sprite-DMA bits survive its display-DMA reprogram
+        // (the screen manager preserves the sprite-DMA bits — see the HAL note). The
+        // empty player strips on a blitter backend simply draw nothing.
         setup_sprites();
         set_screen<InitialScreen>([] {});
-        // The ANTIC charset buffer is only used by the baseline tile path; the
-        // VBXE overlay-font upload to VRAM lands with the 4b text path.
+        // The character-set buffer is only used by the baseline tile path; the
+        // blitter backend's overlay-font upload to VRAM lands with the 4b text path.
         if constexpr (!caps::has_blitter) {
             tiles.init_charset(cs, charset_buffer_);
             tiles.bind_charset_page(page_of(charset_buffer_));
         }
         interrupts.arm_dispatch();
-        sprites.arm_multiplex_dli();   // bind the raw zone-boundary DLI (baseline)
+        sprites.arm_multiplex_dli();   // bind the raw zone-boundary raster hook (baseline)
         Platform::hal::install_frame_isr(&frame_service);
     }
     static void init() {
         using caps = engine::caps_of_t<Platform>;
         if constexpr (caps::has_blitter) {
             // Pure-overlay layouts no longer need a manual antic_playfield(false):
-            // set_screen keeps ANTIC DMA off for them (see screen.h).
+            // set_screen keeps playfield DMA off for them (see screen.h).
             Platform::hal::overlay_init();
         }
-        // Arm P/M base + DMA on every backend (hardware sprites on baseline; the
-        // hardware missiles on a blitter backend — see init(cs) above).
+        // Arm hardware-sprite base + DMA on every backend (hardware sprites on
+        // baseline; the hardware missiles on a blitter backend — see init(cs) above).
         setup_sprites();
         set_screen<InitialScreen>([] {});
         interrupts.arm_dispatch();
-        sprites.arm_multiplex_dli();   // bind the raw zone-boundary DLI (baseline)
+        sprites.arm_multiplex_dli();   // bind the raw zone-boundary raster hook (baseline)
         Platform::hal::install_frame_isr(&frame_service);
     }
 
@@ -241,23 +241,27 @@ public:
         Platform::hal::overlay_publish_background();
     }
 
-    // Enable/disable the ANTIC playfield (character/bitmap) DMA. The common
-    // opaque VBXE-only case is now automatic: a pure-overlay screen
-    // (is_pure_overlay) keeps ANTIC DMA off through set_screen, so no manual call
-    // is needed. This remains as an escape hatch for the cases the engine can't
-    // infer: a transparent overlay that shows ANTIC through (leave it enabled),
-    // or a mixed overlay+ANTIC layout where you want the playfield fetch off to
-    // free the VRAM bus even though ANTIC regions are present. When an opaque
-    // overlay covers the screen the ANTIC playfield is invisible, but its
-    // per-scanline VRAM-bus DMA starves the blitter's restore copies and
-    // collapses the overlay compositor's per-frame budget. Re-enabled by any
-    // set_screen on a non-pure-overlay layout. Atari-only (see API_REFERENCE.md).
+    // Enable/disable the playfield (character/bitmap) DMA. The common opaque
+    // overlay-only case is now automatic: a pure-overlay screen (is_pure_overlay)
+    // keeps playfield DMA off through set_screen, so no manual call is needed. This
+    // remains as an escape hatch for the cases the engine can't infer: a transparent
+    // overlay that shows the playfield through (leave it enabled), or a mixed
+    // overlay+playfield layout where you want the playfield fetch off to free the
+    // VRAM bus even though playfield regions are present. When an opaque overlay
+    // covers the screen the playfield is invisible, but its per-scanline VRAM-bus
+    // DMA starves the blitter's restore copies and collapses the overlay
+    // compositor's per-frame budget. Re-enabled by any set_screen on a
+    // non-pure-overlay layout. Backends without a separate playfield layer treat
+    // this as a no-op (see API_REFERENCE.md).
+    // FIXME[HAL]: the public name antic_playfield() and the seam
+    // set_antic_playfield_dma() embed the ANTIC chip name; rename to a neutral
+    // playfield-DMA seam (e.g. set_playfield_dma) once the HAL is generalized.
     static void antic_playfield(bool enable) {
         Platform::hal::set_antic_playfield_dma(enable);
     }
 
-    // ── Overlay text mode (VBXE Text_80; no-op on platforms without it) ──
-    // A dedicated text surface separate from the baseline ANTIC TextRegion API.
+    // ── Overlay text mode (80-column overlay text; no-op on platforms without it) ──
+    // A dedicated text surface separate from the baseline TextRegion API.
     // Chars are raw font indices (no screen-code remap); `attr` is the cell colour
     // attribute (foreground index in b0-b6; b7=1 = opaque background). Call after
     // init(), on a Text_80 overlay config.
@@ -296,7 +300,7 @@ public:
     static auto& region() { return screen.template region<S, N>(); }
 
     // ── Bitmap drawing ──
-    // The bitmap canvas: the VBXE overlay framebuffer on blitter platforms, else a
+    // The bitmap canvas: the overlay framebuffer on blitter platforms, else a
     // BitmapRegion (GameConfig::bitmap_region) via its software view. Call after
     // init(); on baseline the view is bound to the screen buffer by set_screen().
     static Gfx& gfx() { return gfx_; }
@@ -306,23 +310,23 @@ public:
     // scroll_map() once the game has bound its map buffer.
     template <typename S, typename Cb>
     static void set_screen(Cb cb) {
-        // Config agreement: if this screen declares a VBXE overlay region, its
-        // mode and height must match the VBXE Config the graphics axis was built
-        // with — otherwise the ANTIC display list reserves overlay scanlines that
-        // disagree with the live overlay framebuffer (silent corruption). Checked
-        // here (not in the generic ScreenManager) because the VBXE Config is only
+        // Config agreement: if this screen declares an overlay region, its mode and
+        // height must match the overlay graphics config the graphics axis was built
+        // with — otherwise the display list reserves overlay scanlines that disagree
+        // with the live overlay framebuffer (silent corruption). Checked here (not in
+        // the generic ScreenManager) because the overlay graphics config is only
         // reachable through Platform::graphics, and this runs for every screen.
         if constexpr (engine::caps_of_t<Platform>::has_blitter) {
             using Layout = typename S::display;
             if constexpr (Layout::has_overlay) {
                 using OvRegion =
                     typename Layout::template region_at<Layout::overlay_region_index()>;
-                using Cfg = typename Platform::graphics::config;  // gfx::VBXE<Cfg>::config
+                using Cfg = typename Platform::graphics::config;  // the graphics axis's overlay config
                 static_assert(OvRegion::height <= Cfg::fb_height,
-                    "OverlayRegion height exceeds the VBXE framebuffer height");
+                    "OverlayRegion height exceeds the overlay framebuffer height");
                 static_assert(OvRegion::mode == Cfg::overlay_mode,
-                    "OverlayRegion mode does not match the VBXE Config overlay_mode "
-                    "(e.g. OverlayRegion<VBXE_SR> under a Config<VBXE_HR>)");
+                    "OverlayRegion mode does not match the overlay graphics config's "
+                    "overlay_mode (e.g. a narrow OverlayRegion under a wide Config)");
             }
         }
 
@@ -377,14 +381,15 @@ public:
         //    after a few minutes of no console/keyboard input).
         Platform::hal::suppress_idle_dim();
 
-        // 0a. Gate raster (DLI) NMIs off for the duration of this service. The
-        //     deferred VBI rewrites the raster-hook chain state below
-        //     (VDSLST/current_ and the multiplexer's mux_index_/mux_table_), and
-        //     a heavy service (e.g. the 9-sprite multiplexer) can still be running
-        //     when it overruns vertical blank into the visible region — where a
-        //     zone-boundary DLI would otherwise fire mid-rewrite and corrupt the
-        //     chain (raw DLIs are not re-entrant against the builder). prepare_chain
-        //     re-arms NMIEN at the end once the chain is consistent, so any boundary
+        // 0a. Gate raster interrupts off for the duration of this service. The
+        //     deferred frame service rewrites the raster-hook chain state below
+        //     (the raster-hook vector/current_ and the multiplexer's
+        //     mux_index_/mux_table_), and a heavy service (e.g. the 9-sprite
+        //     multiplexer) can still be running when it overruns vertical blank into
+        //     the visible region — where a zone-boundary raster hook would otherwise
+        //     fire mid-rewrite and corrupt the chain (raw raster hooks are not
+        //     re-entrant against the builder). prepare_chain re-arms raster
+        //     interrupts at the end once the chain is consistent, so any boundary
         //     line the beam has not yet reached still fires this frame; one the
         //     overrun already passed is simply skipped for the frame (a cosmetic
         //     seam, not a crash). Backends with no raster hooks just stay disabled.
@@ -406,32 +411,33 @@ public:
         sound.tick();
 
         // 3. Commit buffered sprite state (pre-commit hook first). The path
-        //    diverges by backend: VBXE composes the overlay via the blitter and
-        //    has its own collision model; baseline writes P/M hardware sprites.
+        //    diverges by backend: a blitter backend composes the overlay and
+        //    has its own collision model; the baseline writes hardware sprites.
         if (hooks.pre_sprite_commit) hooks.pre_sprite_commit();
 
         // Commit buffered sprites — self-dispatching by backend.
         if constexpr (caps::has_blitter) {
-            // VBXE: present first — show the page composed last frame (which had a
-            // full frame's display time to finish) and flip so we now compose the
-            // hidden page. Then commit this frame's blits (commit_blitter clears the
-            // back page and queues a blit per active sprite) and start them async.
-            // The blit is deliberately NOT waited on here: a synchronous wait makes
-            // the VBI outrun a frame, letting the next VBI NMI re-enter this handler
-            // (stack overflow). The present's wait is for LAST frame's blit, already
+            // Blitter backend: present first — show the page composed last frame
+            // (which had a full frame's display time to finish) and flip so we now
+            // compose the hidden page. Then commit this frame's blits (commit_blitter
+            // clears the back page and queues a blit per active sprite) and start them
+            // async. The blit is deliberately NOT waited on here: a synchronous wait
+            // makes the frame service outrun a frame, letting the next frame interrupt
+            // re-enter this handler (stack overflow). The present's wait is for LAST
+            // frame's blit, already
             // finished, so it returns at once. Single-buffer present is a no-op (it
             // composes the visible page in place, dirty-rect).
             Platform::hal::overlay_present();
             sprites.commit(pm_buffer_);
             Platform::hal::overlay_submit();
 
-            // 4. Latch overlay collisions (overlay↔PF/PMG and overlay↔overlay).
+            // 4. Latch overlay collisions (overlay↔playfield/sprite and overlay↔overlay).
             if constexpr (caps::has_overlay_collision) {
                 overlay_collision_      = Platform::hal::overlay_collision();
                 overlay_blit_collision_ = Platform::hal::overlay_blit_collision();
             }
         } else {
-            // Baseline P/M path: write P/M memory, then latch + clear collisions.
+            // Baseline path: write hardware-sprite memory, then latch + clear collisions.
             sprites.commit(pm_buffer_);
             for (u8 i = 0; i < 4; ++i) {
                 collisions_.s_bg[i] = Platform::hal::coll_player_playfield(i);
@@ -442,13 +448,14 @@ public:
             Platform::hal::clear_collisions();
         }
 
-        // 5. Recompute multiplex zones for the next commit (harmless on VBXE,
+        // 5. Recompute multiplex zones for the next commit (harmless on a blitter backend,
         //    where no sprites are committed yet — the Y-sort over zero active
         //    sprites yields no zones).
         sprites.update_zones();
 
-        // 6. Rebuild the raster-hook chain and arm per-line delivery. VBXE needs
-        //    no zone-boundary DLIs (no hardware players to reposition), so the
+        // 6. Rebuild the raster-hook chain and arm per-line delivery. A blitter
+        //    backend needs no zone-boundary raster hooks (no hardware players to
+        //    reposition), so the
         //    hook rebuild is baseline-only; prepare_chain still runs for both.
         if constexpr (!caps::has_blitter) {
             sprites.build_raster_hooks(interrupts);
@@ -503,7 +510,7 @@ private:
     static inline SpriteCollisionState collisions_{};
 
     // ── Overlay frame state (neutral; meaningful only on extended-graphics
-    //    platforms — a few bytes on baseline, never named with VBXE identity) ──
+    //    platforms — a few bytes on baseline, never named with backend identity) ──
     static inline u8   overlay_collision_      = 0;
     static inline u8   overlay_blit_collision_ = 0;
 };

--- a/engine/display.h
+++ b/engine/display.h
@@ -213,7 +213,7 @@ struct ScrollRegion {
     static constexpr u8        height         = Inner::height;   // visible rows / lines
     static constexpr bool      is_text        = Inner::is_text;
     static constexpr bool      is_scroll      = true;
-    static constexpr bool      is_overlay     = false;   // overlays never ANTIC-scroll
+    static constexpr bool      is_overlay     = false;   // overlays never hardware-scroll
     static constexpr u8        bytes_per_line = Inner::bytes_per_line;
     static constexpr u16       ram_bytes      = 0;               // backed by the map buffer
     static constexpr u16       map_width      = MapW;
@@ -224,16 +224,15 @@ struct ScrollRegion {
 
 // ── OverlayRegion ─────────────────────────────────────────────────────
 //
-// A region drawn into the VBXE overlay plane rather than the shared ANTIC screen
-// buffer. Its pixels live in VBXE VRAM, so `ram_bytes` is 0 (like ScrollRegion it
-// contributes nothing to the screen buffer or to following regions' offsets), and
-// it is *not* an ANTIC display-list mode line — the backend builder reads
-// `is_overlay` to skip it. Drawing goes through Game::gfx() (the blitter/MEMAC
-// path), not the view below.
+// A region drawn into the overlay plane rather than the shared screen buffer. Its
+// pixels live in VRAM, so `ram_bytes` is 0 (like ScrollRegion it contributes
+// nothing to the screen buffer or to following regions' offsets), and it is *not* a
+// display-list mode line — the backend builder reads `is_overlay` to skip it.
+// Drawing goes through Game::gfx() (the blitter path), not the view below.
 //
-// `bytes_per_line` and `map_width` are u16 here because VBXE_SR reaches 320
-// bytes/line — wider than any ANTIC mode (so the existing TextRegion/BitmapRegion
-// keep their u8). The mode must be one of the VBXE overlay modes.
+// `bytes_per_line` and `map_width` are u16 here because an overlay mode can reach
+// 320 bytes/line — wider than any baseline mode (so the existing TextRegion/
+// BitmapRegion keep their u8). The mode must be one of the overlay modes.
 template <auto M, u8 Height>
 struct OverlayRegion {
     using mode_type = decltype(M);
@@ -243,19 +242,23 @@ struct OverlayRegion {
         engine::display::traits<mode_type>::is_text(M);
     static constexpr bool      is_scroll      = false;
     static constexpr bool      is_overlay     = true;
-    static constexpr u16       bytes_per_line =          // u16: VBXE reaches 320
+    static constexpr u16       bytes_per_line =          // u16: overlay modes reach 320
         engine::display::traits<mode_type>::bytes_per_line(M);
     static constexpr u16       ram_bytes      = 0;        // VRAM-backed, not screen buffer
     static constexpr u16       map_width      = bytes_per_line;
     static constexpr u16       map_height     = Height;
 
+    // FIXME[HAL]: the display-traits seam is_vbxe() embeds the VBXE product name;
+    // rename it to a neutral predicate (e.g. is_overlay_mode) across
+    // display_traits.h and the backend's traits specialization. The assert message
+    // likewise names concrete VBXE mode tokens and moves with that rename.
     static_assert(engine::display::traits<mode_type>::is_vbxe(M),
                   "OverlayRegion requires a VBXE mode (VBXE_SR, VBXE_HR, VBXE_LR, VBXE_T80)");
 
     // Placeholder view: a typed metadata handle, not a drawing surface. Overlay
     // pixels live in VRAM, so the view's `ptr` is nullptr at runtime and must not
     // be dereferenced — drawing goes through Game::gfx(), which dispatches to the
-    // blitter/MEMAC path. (For VBXE_T80 this will later become an OverlayTextView.)
+    // blitter path. (For the overlay text mode this will later become an OverlayTextView.)
     using view = BitmapRegionView<M, Height>;
 };
 
@@ -297,9 +300,9 @@ struct DisplayLayout {
     static constexpr u8  region_mode_byte[region_count]      =
         { engine::display::traits<typename Regions::mode_type>::mode_opcode(
               Regions::mode)... };
-    // u16: VBXE overlay regions reach 320 bytes/line (wider than any ANTIC mode).
-    // The ANTIC display-list builder skips overlay regions (region_is_overlay), so
-    // ANTIC entries still hold their familiar small (<=40) values.
+    // u16: overlay regions reach 320 bytes/line (wider than any baseline mode).
+    // The display-list builder skips overlay regions (region_is_overlay), so
+    // baseline entries still hold their familiar small (<=40) values.
     static constexpr u16 region_bytes_per_line[region_count] =
         { Regions::bytes_per_line... };
     static constexpr bool region_is_text[region_count]       = { Regions::is_text... };
@@ -307,8 +310,8 @@ struct DisplayLayout {
     static constexpr bool region_is_scroll[region_count]     = { Regions::is_scroll... };
     static constexpr u16 region_map_width[region_count]      = { Regions::map_width... };
     static constexpr u16 region_map_height[region_count]     = { Regions::map_height... };
-    // Overlay metadata: which regions draw into the VBXE overlay plane (VRAM) rather
-    // than the ANTIC screen buffer. The backend builder skips these mode lines.
+    // Overlay metadata: which regions draw into the overlay plane (VRAM) rather
+    // than the screen buffer. The backend builder skips these mode lines.
     static constexpr bool region_is_overlay[region_count]    = { Regions::is_overlay... };
 
     // True if any region in this layout scrolls.
@@ -317,11 +320,11 @@ struct DisplayLayout {
     // True if any region is an overlay.
     static constexpr bool has_overlay = (Regions::is_overlay || ... || false);
 
-    // True if ALL regions are overlay — ANTIC can be fully disabled. (region_count
+    // True if ALL regions are overlay — playfield DMA can be fully disabled. (region_count
     // >= 1 is asserted, so a layout with no overlay regions is correctly false.)
     static constexpr bool is_pure_overlay = (Regions::is_overlay && ... && true);
 
-    // Count of non-overlay (ANTIC) regions.
+    // Count of non-overlay (playfield) regions.
     static constexpr u8 antic_region_count =
         static_cast<u8>(((!Regions::is_overlay ? 1 : 0) + ... + 0));
 

--- a/engine/display.h
+++ b/engine/display.h
@@ -320,10 +320,6 @@ struct DisplayLayout {
     // >= 1 is asserted, so a layout with no overlay regions is correctly false.)
     static constexpr bool is_pure_overlay = (Regions::is_overlay && ... && true);
 
-    // Count of non-overlay (playfield) regions.
-    static constexpr u8 antic_region_count =
-        static_cast<u8>(((!Regions::is_overlay ? 1 : 0) + ... + 0));
-
     // Index of the first scrolling region, or region_count if none.
     static constexpr u8 scroll_region_index() {
         for (u8 i = 0; i < region_count; ++i)

--- a/engine/display.h
+++ b/engine/display.h
@@ -248,12 +248,8 @@ struct OverlayRegion {
     static constexpr u16       map_width      = bytes_per_line;
     static constexpr u16       map_height     = Height;
 
-    // FIXME[HAL]: the display-traits seam is_vbxe() embeds the VBXE product name;
-    // rename it to a neutral predicate (e.g. is_overlay_mode) across
-    // display_traits.h and the backend's traits specialization. The assert message
-    // likewise names concrete VBXE mode tokens and moves with that rename.
-    static_assert(engine::display::traits<mode_type>::is_vbxe(M),
-                  "OverlayRegion requires a VBXE mode (VBXE_SR, VBXE_HR, VBXE_LR, VBXE_T80)");
+    static_assert(engine::display::traits<mode_type>::is_overlay_mode(M),
+                  "OverlayRegion requires an overlay mode — use an overlay-capable mode token");
 
     // Placeholder view: a typed metadata handle, not a drawing surface. Overlay
     // pixels live in VRAM, so the view's `ptr` is nullptr at runtime and must not

--- a/engine/display_traits.h
+++ b/engine/display_traits.h
@@ -14,10 +14,7 @@
 //
 // Required static members of a specialisation `traits<ModeT>` (all constexpr):
 //   static constexpr bool is_text(ModeT);            // text vs bitmap mode
-//   static constexpr bool is_vbxe(ModeT);            // overlay vs base mode
-//     FIXME[HAL]: this required seam name embeds the VBXE product name; rename to a
-//     neutral predicate (e.g. is_overlay_mode) here and in every backend traits
-//     specialization (and its call site in display.h).
+//   static constexpr bool is_overlay_mode(ModeT);    // overlay vs base mode
 //   static constexpr u16  bytes_per_line(ModeT);     // screen-memory width
 //   static constexpr u8   bits_per_pixel(ModeT);     // bitmap packing (text: n/a)
 //   static constexpr u8   scanlines_per_line(ModeT); // mode-line height

--- a/engine/display_traits.h
+++ b/engine/display_traits.h
@@ -14,7 +14,10 @@
 //
 // Required static members of a specialisation `traits<ModeT>` (all constexpr):
 //   static constexpr bool is_text(ModeT);            // text vs bitmap mode
-//   static constexpr bool is_vbxe(ModeT);            // overlay (VBXE) vs base mode
+//   static constexpr bool is_vbxe(ModeT);            // overlay vs base mode
+//     FIXME[HAL]: this required seam name embeds the VBXE product name; rename to a
+//     neutral predicate (e.g. is_overlay_mode) here and in every backend traits
+//     specialization (and its call site in display.h).
 //   static constexpr u16  bytes_per_line(ModeT);     // screen-memory width
 //   static constexpr u8   bits_per_pixel(ModeT);     // bitmap packing (text: n/a)
 //   static constexpr u8   scanlines_per_line(ModeT); // mode-line height

--- a/engine/gfx.h
+++ b/engine/gfx.h
@@ -6,12 +6,12 @@
 // BitmapOps is a portable drawing API over a bitmap "canvas". It dispatches at
 // compile time on the platform's `has_blitter` capability:
 //
-//   * Blitter platforms (VBXE): the canvas is the 256-colour overlay framebuffer
+//   * Blitter platforms: the canvas is the 256-colour overlay framebuffer
 //     (8bpp in VRAM). Operations go through neutral `overlay_bitmap_*` HAL seams,
-//     which use the blitter (rectangle fills) and the MEMAC window (single pixels)
-//     — the generic engine never names a VBXE type.
+//     which use the blitter (rectangle fills) and the backend's memory window
+//     (single pixels) — the generic engine never names a backend type.
 //
-//   * Baseline platforms: the canvas is an ANTIC `BitmapRegion`. Operations
+//   * Baseline platforms: the canvas is a baseline `BitmapRegion`. Operations
 //     delegate to that region's `BitmapRegionView` (engine/display.h), which owns
 //     the mode-dependent (1/2/4 bpp) pixel packing — we do not re-implement it.
 //

--- a/engine/interrupt.h
+++ b/engine/interrupt.h
@@ -151,14 +151,15 @@ public:
     // begin_dynamic() discards the dynamic tail, keeping the static slots.
     // add_dynamic_raster_hook() appends a raw, top-priority slot.
     //
-    // The slot is registered RAW: `h` is a backend-supplied, hand-written DLI that
-    // ANTIC enters directly (the multiplexer's edge_multiplex_dli). Routing it
-    // through the generic C++ dispatcher was tried and failed on hardware — the
-    // dispatcher's full $80-$9F save makes each DLI ~11 scanlines, and a DLI is an
-    // unmaskable, non-re-entrant NMI, so two zone boundaries landing within a mode
-    // line of each other corrupt the shared dispatch state (ADR-019). The raw
-    // handler stays under a scanline by writing pre-baked registers, then chains
-    // VDSLST from the next_ table just like the dispatcher (it shares that tail).
+    // The slot is registered RAW: `h` is a backend-supplied, hand-written raw raster
+    // hook the backend's raster hardware enters directly (the multiplexer's raw
+    // boundary hook). Routing it through the generic C++ dispatcher was tried and
+    // failed on hardware — the dispatcher's full $80-$9F save makes each dispatched
+    // hook ~11 scanlines, and a raster interrupt is unmaskable and non-re-entrant, so
+    // two zone boundaries landing within a mode line of each other corrupt the shared
+    // dispatch state (ADR-019). The raw handler stays under a scanline by writing
+    // pre-baked registers, then chains the raster-hook vector from the next_ table
+    // just like the dispatcher (it shares that tail).
     void begin_dynamic() { total_count_ = static_count_; }
 
     void add_dynamic_raster_hook(u8 scanline, void (*h)()) {

--- a/engine/mmio.h
+++ b/engine/mmio.h
@@ -5,7 +5,7 @@
 //
 // Platform-neutral building blocks for reaching hardware at fixed absolute
 // addresses. This header carries NO hardware constants of its own — a backend
-// (e.g. the Atari VBXE register/MEMAC code) specializes these templates with
+// (e.g. an extended-graphics register/memory-window backend) specializes these with
 // concrete addresses. Generic engine subsystems do not use these directly; they
 // reach hardware through Platform::hal (ARCHITECTURE.md Dependency Rule 2). The
 // types live in the engine layer only so every backend HAL can reuse them
@@ -18,10 +18,10 @@
 //
 // CAUTION: the banked-window bulk helpers select a bank and then access the
 // window; the bank-select register is shared hardware state. If an interrupt
-// (e.g. a VBI that also touches the same chip) preempts a transfer and changes
+// (e.g. a frame interrupt that also touches the same chip) preempts a transfer and changes
 // or disturbs the bank, the rest of the transfer lands in the wrong place. The
-// owning backend must keep the bank stable across interrupts (the Atari VBXE
-// backend does this by having its VBI save/restore MEMAC_BANK_SEL).
+// owning backend must keep the bank stable across interrupts (a backend does this
+// by having its frame interrupt save/restore the bank-select register).
 
 #include <string.h>
 
@@ -32,7 +32,7 @@ namespace engine {
 // ── Memory-mapped register handle ────────────────────────────────────
 //
 // Read via `operator u8`, write via `operator=`. Use as e.g.
-// `Mmio<0xD640>{} = v;` or `u8 x = Mmio<0xD640>{};`.
+// `Mmio<Addr>{} = v;` or `u8 x = Mmio<Addr>{};`.
 template <u16 Address>
 struct Mmio {
     [[gnu::always_inline]] inline operator u8() const noexcept {
@@ -47,7 +47,7 @@ struct Mmio {
 //
 // Like Mmio, but accessed via operator[] returning a reference to the volatile
 // byte. Constant offsets fold to literal absolute addresses; runtime offsets
-// compile to 6502 absolute-indexed addressing (e.g. LDA $B000,X).
+// compile to 6502 absolute-indexed addressing (e.g. LDA Base,X).
 template <u16 Base>
 struct MmioWindow {
     [[gnu::always_inline]] inline volatile u8& operator[](u16 offset) const noexcept {
@@ -70,12 +70,12 @@ constexpr u8 log2_pow2(u32 v) noexcept {
 // A fixed-size aperture at Base into a larger banked backing store. Only one
 // WindowSize-byte bank is visible at a time; which bank shows through is chosen
 // by writing the bank-select register at BankSelAddr. WindowSize must be a
-// power of two and must match the hardware window size (e.g. the VBXE MEMAC
-// SIZE bits). A linear (multi-bank) address splits into
+// power of two and must match the hardware window size (e.g. a banked memory
+// window's SIZE bits). A linear (multi-bank) address splits into
 //   bank   = addr >> bank_shift
 //   offset = addr & offset_mask
 // both of which fold to constants when addr is a constant. BankSelOrMask is
-// OR'd into every bank write (carry e.g. the MEMAC MGE/MBCE enable bit here),
+// OR'd into every bank write (carry e.g. a window-enable bit here),
 // so a bank select is a single LDA #imm / STA with no register read and no
 // temporary.
 template <u16 Base, u32 WindowSize, u16 BankSelAddr, u8 BankSelOrMask = 0x00>
@@ -135,7 +135,7 @@ struct MmioBankedWindow {
     }
 
     // Efficient banked read window -> CPU RAM: mirror of copy(). The bank-walk
-    // lives here so callers (e.g. MEMAC read) never duplicate the boundary math.
+    // lives here so callers (e.g. a banked window read) never duplicate the boundary math.
     inline void read(u32 start, u8* dst, u32 len) const noexcept {
         while (len) {
             const u16 off = static_cast<u16>(start) & offset_mask;

--- a/engine/platform/atari/display_traits.h
+++ b/engine/platform/atari/display_traits.h
@@ -22,7 +22,7 @@ namespace display {
 template <>
 struct traits<atari::Mode> {
     static constexpr bool is_text(atari::Mode m) { return atari::is_text(m); }
-    static constexpr bool is_vbxe(atari::Mode m) { return atari::is_vbxe(m); }
+    static constexpr bool is_overlay_mode(atari::Mode m) { return atari::is_vbxe(m); }
     static constexpr engine::u16 bytes_per_line(atari::Mode m) {
         return atari::bytes_per_line(m);
     }

--- a/engine/platform/atari/hal.h
+++ b/engine/platform/atari/hal.h
@@ -408,6 +408,11 @@ struct Hal {
     }
 };
 
+// Enable or disable playfield DMA. Call this on an opaque overlay screen to
+// prevent ANTIC bus contention with the blitter. Any set_screen() on a
+// non-pure-overlay layout re-enables it automatically.
+inline void set_playfield_dma(bool enable) { Hal::set_antic_playfield_dma(enable); }
+
 } // namespace atari
 
 #endif // ENGINE_PLATFORM_ATARI_HAL_H

--- a/engine/platform/atari/platform.h
+++ b/engine/platform/atari/platform.h
@@ -148,6 +148,7 @@ struct AtariCaps : engine::Capabilities {
     static constexpr u32  extended_ram_bytes = detail::ext_ram_bytes(R);
     static constexpr u16  extended_bank_size = (R == RAM::Baseline) ? 0u : 16384u;
     static constexpr u8   zp_available       = 128;              // after OS
+    static constexpr u16  screen_buffer_alignment = 4096;
 
     // ── Input ──
     // XL/XE expose 2 joystick ports; 400/800 expose 4.

--- a/engine/screen.h
+++ b/engine/screen.h
@@ -21,6 +21,7 @@
 //
 // Depends on display.h and types.h.
 
+#include "config/capabilities.h"
 #include "display.h"
 #include "types.h"
 
@@ -128,6 +129,7 @@ template <typename Platform, typename GameConfig>
 class ScreenManager {
 public:
     using screens = typename GameConfig::screens;
+    using caps    = engine::caps_of_t<Platform>;
 
     // Clamp to at least 1 byte: a pure-overlay-only ScreenSet contributes no
     // screen RAM (overlay pixels live in VRAM, ram_bytes == 0), which would
@@ -136,31 +138,30 @@ public:
     static constexpr u16 buffer_size =
         screens::max_screen_ram > 0 ? screens::max_screen_ram : 1;
 
-    // Alignment that keeps a single-page screen buffer off the display hardware's
-    // 4K scan boundary. The scan-line address counter wraps within a 4K page, so a
-    // mode line whose own bytes straddle a $x000 boundary fetches its tail from the
-    // page start (corruption the display program's per-line address reload can't fix
-    // — it only reloads at line starts; see the backend display-program builder). A
-    // buffer that fits in one 4K page and is aligned to the smallest power of two >=
+    // Alignment that keeps a single-page screen buffer off the platform's
+    // screen-buffer alignment boundary (caps::screen_buffer_alignment — the display
+    // hardware's scan-boundary granularity, or 1 for no constraint). Where the
+    // display hardware's scan-line address counter wraps within that boundary, a mode
+    // line whose own bytes straddle a boundary fetches its tail from the page start
+    // (corruption the display program's per-line address reload can't fix — it only
+    // reloads at line starts; see the backend display-program builder). A buffer that
+    // fits in one boundary-sized page and is aligned to the smallest power of two >=
     // its size can never cross a boundary, so every line stays within one page.
     // Buffers LARGER than a page must span boundaries regardless; those keep
-    // alignment 1 (page-aligning them would force mid-line crossings, since
-    // 4096 % bytes_per_line != 0 for e.g. 40-col modes) and rely on the builder's
-    // per-line address reload landing on row-aligned crossings.
+    // alignment 1 (page-aligning them would force mid-line crossings, since the
+    // boundary is not a multiple of bytes_per_line for e.g. 40-col modes) and rely on
+    // the builder's per-line address reload landing on row-aligned crossings.
     static constexpr u16 pow2_ceil(u16 n) {
         u16 p = 1;
-        while (p < n && p < 4096) p <<= 1;
+        while (p < n && p < caps::screen_buffer_alignment) p <<= 1;
         return p;
     }
-    // FIXME[HAL]: the 4096 scan-boundary granularity is a property of the display
-    // hardware; it should come from a platform trait/capability rather than being a
-    // literal in this engine header (also used in pow2_ceil and the assert below).
     static constexpr u16 buffer_align =
-        buffer_size <= 4096 ? pow2_ceil(buffer_size) : u16{1};
-    // A single-page buffer aligned to >= its own size cannot straddle a 4K boundary.
-    static_assert(buffer_size > 4096 || buffer_align >= buffer_size,
+        buffer_size <= caps::screen_buffer_alignment ? pow2_ceil(buffer_size) : u16{1};
+    // A single-page buffer aligned to >= its own size cannot straddle a boundary.
+    static_assert(buffer_size > caps::screen_buffer_alignment || buffer_align >= buffer_size,
                   "single-page screen buffer must be aligned to >= its size to keep "
-                  "every mode line off the display hardware's 4K scan boundary");
+                  "every mode line within one screen-buffer alignment boundary");
 
     // Switch to screen S: build its display program against the real buffer base
     // (the backend builder inserts any backend-specific reload instructions),
@@ -192,7 +193,7 @@ public:
         // Core::init through the graphics axis) drives the display via its own
         // display list; the backend's 3-byte stub is only a safety pointer for the
         // display-list register. Leaving playfield DMA off frees the VRAM bus for the
-        // blitter — the bus-contention fix (formerly a manual antic_playfield(false)),
+        // blitter — the bus-contention fix (formerly a manual playfield-DMA disable),
         // now automatic.
 
         active_dl_      = dl.bytes;

--- a/engine/screen.h
+++ b/engine/screen.h
@@ -130,33 +130,37 @@ public:
     using screens = typename GameConfig::screens;
 
     // Clamp to at least 1 byte: a pure-overlay-only ScreenSet contributes no
-    // screen RAM (overlay pixels live in VBXE VRAM, ram_bytes == 0), which would
+    // screen RAM (overlay pixels live in VRAM, ram_bytes == 0), which would
     // otherwise make screen_buffer_ a zero-length array (ill-formed). The 1-byte
     // buffer is never read — set_base only computes buf + offset(0).
     static constexpr u16 buffer_size =
         screens::max_screen_ram > 0 ? screens::max_screen_ram : 1;
 
-    // Alignment that keeps a single-page screen buffer off the ANTIC 4K scan
-    // boundary. ANTIC increments only the low 12 bits of its scan counter, so a mode
-    // line whose own bytes straddle a $x000 boundary fetches its tail from the page
-    // start (corruption the display-list LMS can't fix — it only reloads at line
-    // starts; see platform/atari/display_list.h). A buffer that fits in one 4K page
-    // and is aligned to the smallest power of two >= its size can never cross a
-    // boundary, so every line stays within one page. Buffers LARGER than a page must
-    // span boundaries regardless; those keep alignment 1 (page-aligning them would
-    // force mid-line crossings, since 4096 % bytes_per_line != 0 for e.g. 40-col
-    // modes) and rely on the builder's per-line LMS landing on row-aligned crossings.
+    // Alignment that keeps a single-page screen buffer off the display hardware's
+    // 4K scan boundary. The scan-line address counter wraps within a 4K page, so a
+    // mode line whose own bytes straddle a $x000 boundary fetches its tail from the
+    // page start (corruption the display program's per-line address reload can't fix
+    // — it only reloads at line starts; see the backend display-program builder). A
+    // buffer that fits in one 4K page and is aligned to the smallest power of two >=
+    // its size can never cross a boundary, so every line stays within one page.
+    // Buffers LARGER than a page must span boundaries regardless; those keep
+    // alignment 1 (page-aligning them would force mid-line crossings, since
+    // 4096 % bytes_per_line != 0 for e.g. 40-col modes) and rely on the builder's
+    // per-line address reload landing on row-aligned crossings.
     static constexpr u16 pow2_ceil(u16 n) {
         u16 p = 1;
         while (p < n && p < 4096) p <<= 1;
         return p;
     }
+    // FIXME[HAL]: the 4096 scan-boundary granularity is a property of the display
+    // hardware; it should come from a platform trait/capability rather than being a
+    // literal in this engine header (also used in pow2_ceil and the assert below).
     static constexpr u16 buffer_align =
         buffer_size <= 4096 ? pow2_ceil(buffer_size) : u16{1};
     // A single-page buffer aligned to >= its own size cannot straddle a 4K boundary.
     static_assert(buffer_size > 4096 || buffer_align >= buffer_size,
                   "single-page screen buffer must be aligned to >= its size to keep "
-                  "every mode line off the ANTIC 4K scan boundary");
+                  "every mode line off the display hardware's 4K scan boundary");
 
     // Switch to screen S: build its display program against the real buffer base
     // (the backend builder inserts any backend-specific reload instructions),
@@ -179,16 +183,17 @@ public:
         Platform::hal::display_dma_disable();
         Platform::hal::set_display_program(dl.bytes);
         if constexpr (!S::display::is_pure_overlay) {
-            // ANTIC content present (ANTIC-only or mixed overlay+ANTIC):
-            // re-enable playfield DMA. Mixed layouts cost only the DL DMA that
-            // reads blank instructions (~1 cycle/line), not screen fetches.
+            // Playfield content present (playfield-only or mixed overlay+playfield):
+            // re-enable playfield DMA. Mixed layouts cost only the display-program
+            // DMA that reads blank instructions (~1 cycle/line), not screen fetches.
             Platform::hal::display_dma_enable();
         }
-        // Pure overlay: ANTIC stays off. The VBXE overlay (brought up by
-        // Core::init through the graphics axis) drives the display via its XDL;
-        // the 3-byte JVB stub is only a safety pointer for DLISTL. Leaving ANTIC
-        // DMA off frees the VRAM bus for the blitter/MEMAC — the bus-contention
-        // fix (formerly a manual antic_playfield(false)), now automatic.
+        // Pure overlay: playfield DMA stays off. The overlay (brought up by
+        // Core::init through the graphics axis) drives the display via its own
+        // display list; the backend's 3-byte stub is only a safety pointer for the
+        // display-list register. Leaving playfield DMA off frees the VRAM bus for the
+        // blitter — the bus-contention fix (formerly a manual antic_playfield(false)),
+        // now automatic.
 
         active_dl_      = dl.bytes;
         active_dl_size_ = dl.size;

--- a/engine/sprites.h
+++ b/engine/sprites.h
@@ -31,11 +31,11 @@ namespace engine {
 // ── Sprite pixel formats ──────────────────────────────────────────────
 //
 // How a shape's pixels are packed. Neutral (describes packing, not a backend):
-//   Packed1bpp — 1 bit/pixel, 1 byte/row (the Atari P/M format). Renders on any
-//                backend; on a blitter platform it is expanded to 8bpp in VRAM
+//   Packed1bpp — 1 bit/pixel, 1 byte/row (the hardware-sprite format). Renders on
+//                any backend; on a blitter platform it is expanded to 8bpp in VRAM
 //                and coloured per-instance.
 //   Pixel8bpp  — 1 byte/pixel colour indices (W*H bytes). Richer art for blitter
-//                platforms; not representable in hardware P/M, so it requires a
+//                platforms; not representable in hardware sprites, so it requires a
 //                blitter (a static_assert enforces this in sprite()).
 enum class SpriteFormat : u8 { Packed1bpp, Pixel8bpp };
 
@@ -144,7 +144,7 @@ public:
     static constexpr u8 kPlayers  = 4;
     static constexpr u8 kMissiles = 4;
 
-    // Zone-boundary DLIs fire at the end of an 8-scanline mode line; bias the
+    // Zone-boundary raster hooks fire at the end of an 8-scanline mode line; bias the
     // boundary up by ~one mode line so the player-position switch lands in the gap
     // between zones (see update_zones). Layout-tunable; one MODE_2 line.
     static constexpr u8 kBoundaryBias = 8;
@@ -171,7 +171,7 @@ public:
                 shape.data, Shape::width, Shape::height, Shape::format);
         } else {
             static_assert(Shape::format == SpriteFormat::Packed1bpp,
-                "Pixel8bpp sprites require a blitter platform (e.g. VBXE)");
+                "Pixel8bpp sprites require a blitter platform");
         }
     }
 
@@ -259,8 +259,9 @@ public:
             // Boundary: zone 0 from the top; later zones in the gap between
             // adjacent groups. boundary_scanline is consumed by the HAL as a
             // display-list-relative scanline (program_raster_lines), while sprite
-            // Y is the P/M strip offset; on the standard layout the two track ~1:1.
-            // The DLI fires at the END of its 8-scanline mode line, i.e. a few
+            // Y is the hardware-sprite strip offset; on the standard layout the two
+            // track ~1:1. The boundary raster hook fires at the END of its
+            // 8-scanline mode line, i.e. a few
             // lines BELOW the value here, so bias the switch up by kBoundaryBias so
             // it lands in the inter-zone gap rather than partway through the lower
             // zone's first sprite (which reads as a split "ghost" sprite). Never
@@ -288,7 +289,7 @@ public:
     // positions, and record this frame's dirty ranges for the next clear.
     // `sprite_base` points at the sprite base (a real address on hardware, a test buffer
     // under the simulator). On a blitter backend it is ignored — sprites are
-    // composed in VRAM via the overlay seams instead of P/M memory.
+    // composed in VRAM via the overlay seams instead of hardware-sprite memory.
     void commit(u8* sprite_base) {
         if constexpr (caps::has_blitter) {
             commit_blitter(sprite_base);
@@ -299,11 +300,12 @@ public:
 
     // Blitter commit: clear the back buffer, then blit each active sprite (sorted
     // back-to-front by update_zones) into it via the overlay seams. Sprites live in
-    // VRAM (no P/M memory, no tracked-range clear, no zone-0 register writes), but
-    // missiles ARE still the four P/M hardware projectiles on this backend (ADR-025),
-    // so they go through the shared commit_missiles() path into `sprite_base` (the
-    // P/M strip), rendering on the P/M layer below the overlay. The frame service
-    // runs the queued blits afterwards (overlay_submit).
+    // VRAM (no hardware-sprite memory, no tracked-range clear, no zone-0 register
+    // writes), but missiles ARE still the four hardware projectiles on this backend
+    // (ADR-025), so they go through the shared commit_missiles() path into
+    // `sprite_base` (the projectile strip), rendering on the hardware-sprite layer
+    // below the overlay. The frame service runs the queued blits afterwards
+    // (overlay_submit).
     void commit_blitter(u8* sprite_base) {
         Platform::hal::overlay_frame_begin();
         for (u8 i = 0; i < active_count_; ++i) {
@@ -322,7 +324,7 @@ public:
         //    [min,max] clear zeroed the (mostly empty) gaps between them too; with
         //    9 sprites spread down the screen that pushed the commit past one frame.
         //    Clearing exact extents (≤ MaxSprites × height bytes) keeps it inside
-        //    the VBI. prev_player_ == kNotDrawn means the sprite wasn't drawn (and
+        //    the frame service. prev_player_ == kNotDrawn means the sprite wasn't drawn (and
         //    prev_height_ is 0 on the very first commit, so nothing is cleared).
         for (u8 i = 0; i < MaxSprites; ++i) {
             if (prev_player_[i] == kNotDrawn) continue;
@@ -354,12 +356,14 @@ public:
 
         // 3. Write zone-0 sprite positions + colours (the frame service sets the
         //    first zone from the top; later zones are armed by the boundary raster
-        //    hooks). Position goes straight to HPOSP (no OS shadow exists for it),
-        //    but the COLOUR must go through the OS PCOLR shadow: this runs in the
-        //    VBI, *before* the OS copies PCOLR→COLPM, so a direct COLPM write here
-        //    would be overwritten (zeroed) by that copy and zone 0 would show black.
-        //    The boundary DLIs, by contrast, run during the visible frame *after*
-        //    the copy, so they write COLPM directly (set_sprite_color).
+        //    hooks). Position goes straight to the position register (no shadow
+        //    exists for it), but the COLOUR must go through the HAL's shadowed
+        //    colour seam (set_color_pm): this runs in the frame service, *before*
+        //    the backend copies its colour shadows to the live registers, so a
+        //    direct write here would be overwritten (zeroed) by that copy and zone 0
+        //    would show black. The boundary raster hooks, by contrast, run during
+        //    the visible frame *after* the copy, so they write the live colour
+        //    register directly (set_sprite_color).
         if (zone_count_ > 0) {
             for (u8 p = 0; p < kPlayers; ++p) {
                 Platform::hal::set_sprite_x(p, zones_[0].hpos[p]);
@@ -369,14 +373,14 @@ public:
         commit_missiles(sprite_base);
     }
 
-    // Commit the four P/M hardware projectiles into `sprite_base`. Missiles are
-    // direct, not multiplexed (ADR-025), and are used identically on both backends:
-    // the baseline P/M path and the blitter path (where players composite in VRAM
-    // but missiles remain the GTIA projectiles, rendering below the VBXE overlay).
-    // All four share ONE strip (missile_strip_offset): each scanline byte packs the
-    // four missiles two bits apiece (missile m in bits 2m..2m+1), so draws/clears
-    // are read-modify-writes of that 2-bit field — missiles sharing a scanline must
-    // not stomp each other.
+    // Commit the four hardware projectiles into `sprite_base`. Missiles are direct,
+    // not multiplexed (ADR-025), and are used identically on both backends: the
+    // baseline path and the blitter path (where players composite in VRAM but
+    // missiles remain hardware projectiles, rendering below the overlay). All four
+    // share ONE strip (missile_strip_offset): each scanline byte packs the four
+    // missiles two bits apiece (missile m in bits 2m..2m+1), so draws/clears are
+    // read-modify-writes of that 2-bit field — missiles sharing a scanline must not
+    // stomp each other.
     void commit_missiles(u8* sprite_base) {
         const u8  res   = static_cast<u8>(res_);
         const u16 mbase = Platform::hal::missile_strip_offset(res);
@@ -389,7 +393,7 @@ public:
             missile_prev_height_[m] = 0;
         }
         // 2. Draw each shown missile (height > 0) and record its footprint, then push
-        //    its horizontal position (no OS shadow for HPOSM).
+        //    its horizontal position (no shadow for the projectile position register).
         for (u8 m = 0; m < kMissiles; ++m) {
             const u8 h = missile_height_[m];
             if (h > 0) {
@@ -409,12 +413,12 @@ public:
     //
     // Register a boundary raster hook for each zone after the first (zone 0's
     // positions are set by the frame-service commit), and pre-bake that zone's four
-    // HPOSP + four COLPM bytes into mux_table_ in fire order. The raw DLI
-    // (Platform::hal::multiplex_dli, edge_multiplex_dli on Atari) reads row
-    // mux_index_, copies the eight bytes straight to the GTIA registers, and bumps
-    // the index — no per-DLI work, so it stays well under a scanline (see the
-    // re-entrancy note in interrupt.h::add_dynamic_raster_hook). mux_index_ is reset
-    // here, in the VBI, before the frame's first boundary DLI fires.
+    // position + four colour bytes into mux_table_ in fire order. The raw raster
+    // hook (Platform::hal::multiplex_dli) reads row mux_index_, copies the eight
+    // bytes straight to the sprite hardware registers, and bumps the index — no
+    // per-hook work, so it stays well under a scanline (see the re-entrancy note in
+    // interrupt.h::add_dynamic_raster_hook). mux_index_ is reset here, in the frame
+    // service, before the frame's first boundary hook fires.
     //
     // Under the simulator there is no hardware raster, so the hook is registered
     // (and the table built) but never entered.
@@ -422,7 +426,7 @@ public:
     void build_raster_hooks(IM& im) {
         im.begin_dynamic();
         // A blitter backend has no hardware players to reposition mid-frame, so no
-        // zone-boundary DLIs are needed — just clear any stale dynamic hooks.
+        // zone-boundary raster hooks are needed — just clear any stale dynamic hooks.
         if constexpr (caps::has_blitter) return;
 
         mux_index_ = 0;
@@ -438,9 +442,9 @@ public:
         }
     }
 
-    // One-time setup: bind the raw multiplex DLI to this manager's flat table and
+    // One-time setup: bind the raw multiplex raster hook to this manager's flat table and
     // fire index (the single instance never moves). engine::Core::init calls this on
-    // baseline backends; discarded on blitter backends, which have no boundary DLIs.
+    // baseline backends; discarded on blitter backends, which have no boundary raster hooks.
     void arm_multiplex_dli() {
         if constexpr (!caps::has_blitter) {
             Platform::hal::install_multiplex_dli(
@@ -528,12 +532,12 @@ private:
 
     SpriteVerticalResolution res_ = SpriteVerticalResolution::SingleLine;
 
-    // Flat per-boundary register table the raw multiplex DLI walks: one kMuxRow-byte
-    // row per zone after the first, [HPOSP0..3, COLPM0..3], in fire (scanline)
-    // order. mux_index_ is the row the next boundary DLI will consume; reset to 0
-    // each frame by build_raster_hooks and bumped by the DLI (engine HAL +
-    // platform/atari/dli_dispatch.h own the hardware side).
-    static constexpr u8 kMuxRow = kPlayers * 2;   // 4 HPOSP + 4 COLPM
+    // Flat per-boundary register table the raw multiplex hook walks: one kMuxRow-byte
+    // row per zone after the first, [position 0..3, colour 0..3], in fire (scanline)
+    // order. mux_index_ is the row the next boundary hook will consume; reset to 0
+    // each frame by build_raster_hooks and bumped by the hook (the engine HAL and the
+    // backend's raster-dispatch code own the hardware side).
+    static constexpr u8 kMuxRow = kPlayers * 2;   // 4 position + 4 colour
     u8 mux_table_[MaxZones * kMuxRow] = {};
     u8 mux_index_ = 0;
 };

--- a/engine/sprites.h
+++ b/engine/sprites.h
@@ -445,7 +445,7 @@ public:
     // One-time setup: bind the raw multiplex raster hook to this manager's flat table and
     // fire index (the single instance never moves). engine::Core::init calls this on
     // baseline backends; discarded on blitter backends, which have no boundary raster hooks.
-    void arm_multiplex_dli() {
+    void arm_multiplex_hook() {
         if constexpr (!caps::has_blitter) {
             Platform::hal::install_multiplex_dli(
                 static_cast<u16>(reinterpret_cast<uintptr_t>(mux_table_)),

--- a/engine/version.h
+++ b/engine/version.h
@@ -10,8 +10,8 @@
 // EDGE follows Semantic Versioning (https://semver.org/): MAJOR.MINOR.PATCH.
 
 #define EDGE_VERSION_MAJOR 0
-#define EDGE_VERSION_MINOR 4
-#define EDGE_VERSION_PATCH 1
-#define EDGE_VERSION_STRING "0.4.1"
+#define EDGE_VERSION_MINOR 5
+#define EDGE_VERSION_PATCH 0
+#define EDGE_VERSION_STRING "0.5.0"
 
 #endif // ENGINE_VERSION_H

--- a/tests/generic/test_screen.cpp
+++ b/tests/generic/test_screen.cpp
@@ -133,11 +133,11 @@ static_assert(OverlaySR::is_overlay     == true, "OverlayRegion::is_overlay");
 static_assert(OverlaySR::bytes_per_line == 320,  "VBXE_SR = 320 bytes/line (u16)");
 static_assert(OverlaySR::height         == 240,  "overlay height passes through");
 
-// 5. Pure-overlay layout: ANTIC can be fully disabled, costs 0 screen RAM.
+// 5. Pure-overlay layout: playfield DMA can be fully disabled, costs 0 screen RAM.
 using PureOverlay = DisplayLayout<OverlayRegion<M::Mode::VBXE_SR, 240>>;
 static_assert(PureOverlay::is_pure_overlay    == true,  "single overlay is pure");
 static_assert(PureOverlay::has_overlay        == true,  "pure overlay has an overlay");
-static_assert(PureOverlay::antic_region_count == 0,     "no ANTIC regions");
+static_assert(PureOverlay::region_count       == 1,     "single region, all overlay");
 static_assert(PureOverlay::total_ram          == 0,     "overlay-only = 0 screen RAM");
 
 // 6. Mixed layout: overlay over a 3-row text region. Only the text costs RAM.
@@ -147,14 +147,14 @@ using MixedOverlay = DisplayLayout<
 >;
 static_assert(MixedOverlay::is_pure_overlay    == false, "a text region breaks purity");
 static_assert(MixedOverlay::has_overlay        == true,  "still has an overlay");
-static_assert(MixedOverlay::antic_region_count == 1,     "one ANTIC (text) region");
+static_assert(MixedOverlay::region_count       == 2,     "overlay + one text region");
 static_assert(MixedOverlay::total_ram          == 120,   "40x3 text only; overlay = 0");
 static_assert(MixedOverlay::overlay_region_index() == 0, "overlay is region 0");
 
 // 7. Traditional layout: zero overlays. is_pure_overlay must NOT be vacuously true.
 static_assert(TextLayout::has_overlay     == false, "no overlay in a pure-text layout");
 static_assert(TextLayout::is_pure_overlay == false, "no overlay => not pure overlay");
-static_assert(TextLayout::antic_region_count == 1,  "the text region is an ANTIC region");
+static_assert(TextLayout::region_count == 1,  "single non-overlay text region");
 static_assert(TextLayout::overlay_region_index() == TextLayout::region_count,
               "no overlay => index past the end");
 

--- a/tests/generic/test_screen.cpp
+++ b/tests/generic/test_screen.cpp
@@ -159,7 +159,7 @@ static_assert(TextLayout::overlay_region_index() == TextLayout::region_count,
               "no overlay => index past the end");
 
 // NOTE (negative test, kept disabled): instantiating OverlayRegion on a non-VBXE
-// mode must fail the is_vbxe static_assert. Verified manually, e.g.
+// mode must fail the is_overlay_mode static_assert. Verified manually, e.g.
 //   using BadOverlay = OverlayRegion<M::Mode::MODE_2, 24>;  // static_assert fires
 // Left commented out so the suite still builds.
 


### PR DESCRIPTION
This pull request releases EDGE v0.5.0, focusing on a major API cleanup to improve portability and remove Atari-specific details from the generic engine interface. The most significant changes are the relocation of Atari-specific escape hatches to the platform layer, renaming and generalization of display traits, and the introduction of a new screen buffer alignment capability. These changes break compatibility for Atari game code using certain APIs and for custom display backends, but result in a cleaner, more portable engine surface.

**API cleanup and portability improvements:**

* Removed the Atari-specific method `Game::antic_playfield(bool)` from the generic engine facade. This functionality is now available as `atari::set_playfield_dma(bool)` in the Atari platform layer, following ADR-031, which establishes that platform-specific escape hatches belong in the platform layer, not on the generic API. This is a breaking change for Atari game code that called the old method. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R48) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaL244-R245) [[3]](diffhunk://#diff-1ea199fcea0d29740c9df691b542888c877d1c76a4fda36b130b92c9039f5433R1422-R1502) [[4]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL174-R174) [[5]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cL290-R303)
* Purged all Atari chip/register names (ANTIC, VBXE, etc.) from generic engine headers and comments, replacing them with portable capability/feature vocabulary. This ensures the generic engine API is hardware-agnostic. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R48) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaL165-R202)

**Display traits and capability updates:**

* Renamed the display-traits predicate `is_vbxe(ModeT)` to `is_overlay_mode(ModeT)` to clarify its purpose and remove chip-specific terminology. This is a breaking change for custom backends that specialize display traits.
* Added a new `screen_buffer_alignment` capability field in `engine/config/capabilities.h` to specify the required screen buffer alignment per platform (Atari sets this to 4096, replacing hardcoded constants). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R48) [[2]](diffhunk://#diff-0d67cf76d274b3edbbd51de26b3a7ce121b073fb7e4fa9a513c5e9a9a8ffd885R90-R93)

**Documentation and versioning:**

* Updated all documentation and README files to reference version 0.5.0 and reflect the API changes, including the new location and usage of platform-specific functions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL3-R3) [[3]](diffhunk://#diff-0237b3d7fe1c8fa8e17881af69a003519f78956a5040d9e04bdbc9017125e042L3-R3) [[4]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L3-R3) [[5]](diffhunk://#diff-5aa90ada9e14c6a3188620b196900b68fed5edc6e4e8f192a6e29d0384fd3c6dL3-R3) [[6]](diffhunk://#diff-1ea199fcea0d29740c9df691b542888c877d1c76a4fda36b130b92c9039f5433L3-R3) [[7]](diffhunk://#diff-48492ab448322dc75b3414244c16ea64f9498bb9185bff4a0cb5c1d26c991306L3-R3) [[8]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cL3-R3) [[9]](diffhunk://#diff-38612f5904fb8c3dc3283d855aa486c7bc5ce02c15edd6b90be1e8424fcf0b99L3-R3) [[10]](diffhunk://#diff-b1b484de02794082600e79848bdf85fed4c26408fc1b36fb451beb48866d64d7L3-R3)
* Added ADR-031 to the architecture decision records, documenting the rationale for moving platform-specific escape hatches out of the generic engine API.

**Removed deprecated/unused APIs:**

* Removed `DisplayLayout::antic_region_count` as it was unused by the engine and only referenced in unit tests (now replaced by other queries).

These changes make the engine API more portable and maintainable, clarifying the separation between generic and platform-specific functionality.