### PR TITLE
Fix atari hw test demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ working_documents/
 .claude/
 *.xex
 .github/
+bin/

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -654,6 +654,18 @@ scripts/altirra_probe.sh build-test-9p/netstream_adapter_altirra_probe.xex B   #
 ```
 
 It prints the captured bytes (and keeps the last capture at `/tmp/altirra_probe_last.bin`).
+
+For **demos** (which render to the screen instead of self-dumping to H:), the companion
+`scripts/altirra_screenshot.sh <program.xex> [out.png] [seconds]` boots the `.xex` in
+Altirra and captures a PNG of the display (grabbing the emulator window on `DISPLAY=:0`
+via ImageMagick `import`, cropped to the Atari display pane). It uses the same
+`/debug …/debugcmd:g` startup-trap bypass and always tears the emulator down with
+`wineserver -k`, so nothing is left parked in the debugger:
+
+```bash
+scripts/altirra_screenshot.sh build-demo/atari_hw_test.xex /tmp/hw.png   # then view the PNG
+```
+
 Example Mode A output for the adapter probe (page 6 `$0600..$064F`):
 
 ```

--- a/engine/core.h
+++ b/engine/core.h
@@ -392,19 +392,10 @@ public:
         //    after a few minutes of no console/keyboard input).
         Platform::hal::suppress_idle_dim();
 
-        // 0a. Gate raster interrupts off for the duration of this service. The
-        //     deferred frame service rewrites the raster-hook chain state below
-        //     (the raster-hook vector/current_ and the multiplexer's
-        //     mux_index_/mux_table_), and a heavy service (e.g. the 9-sprite
-        //     multiplexer) can still be running when it overruns vertical blank into
-        //     the visible region — where a zone-boundary raster hook would otherwise
-        //     fire mid-rewrite and corrupt the chain (raw raster hooks are not
-        //     re-entrant against the builder). prepare_chain re-arms raster
-        //     interrupts at the end once the chain is consistent, so any boundary
-        //     line the beam has not yet reached still fires this frame; one the
-        //     overrun already passed is simply skipped for the frame (a cosmetic
-        //     seam, not a crash). Backends with no raster hooks just stay disabled.
-        Platform::hal::disable_raster();
+        // (Raster interrupts are gated off only around the chain rewrite in step 6,
+        //  not for the whole service — see the comment there. Disabling for the
+        //  whole service suppressed earlier user raster hooks every frame when the
+        //  service overran into the visible region past that hook's scanline.)
 
         // 1. Input capture.
         u8 joy[kPorts];
@@ -468,6 +459,27 @@ public:
         //    backend needs no zone-boundary raster hooks (no hardware players to
         //    reposition), so the
         //    hook rebuild is baseline-only; prepare_chain still runs for both.
+        //
+        //    Gate raster interrupts off around this rewrite ONLY when the chain
+        //    actually carries raw zone-boundary (multiplex) raster hooks — i.e. the
+        //    multiplexer split sprites across >1 zone this frame, or it did last
+        //    frame and those raw hooks are still live until prepare_chain replaces
+        //    them. Such a raw hook firing mid-rewrite would read an inconsistent
+        //    chain (it is not re-entrant against the builder). prepare_chain re-arms
+        //    at its end.
+        //
+        //    With a single zone (<=4 sprites) or a static-only chain there is no raw
+        //    hook to protect, so we do NOT gate — gating would suppress earlier user
+        //    raster hooks (e.g. a colour split high on the screen) every frame
+        //    whenever the service overruns into the visible region past that hook's
+        //    scanline: the service runs past the scanline while raster interrupts are
+        //    disabled. (That was the atari_hw_test regression — a whole-service
+        //    disable_raster() at the top of frame_service.)
+        const bool gate_raster =
+            !caps::has_blitter &&
+            (sprites.zone_count() > 1 ||
+             interrupts.raster_hook_count() > interrupts.static_raster_hook_count());
+        if (gate_raster) Platform::hal::disable_raster();
         if constexpr (!caps::has_blitter) {
             sprites.build_raster_hooks(interrupts);
         }

--- a/scripts/altirra_screenshot.sh
+++ b/scripts/altirra_screenshot.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# scripts/altirra_screenshot.sh — boot an EDGE Atari .xex in Altirra (under wine) and
+# capture a PNG screenshot of the emulator window, fully headless/unattended. The
+# companion of altirra_probe.sh: that one captures a page-6 H: dump for probes; this
+# one captures the *visible display* for demos (no H: self-dump needed).
+#
+# Usage:  scripts/altirra_screenshot.sh <program.xex> [out.png] [seconds]
+#   out.png  default /tmp/altirra_shot.png
+#   seconds  emulator warm-up before the grab (default 8) — enough for the demo to
+#            boot and render several frames.
+#
+# Why each piece is load-bearing:
+#   * DISPLAY=:0 is a real X server here, and ImageMagick `import` + `wmctrl` are
+#     installed, so no Xvfb is needed. We grab the Altirra top-level window by name.
+#   * /debug /debugbrkrun /debugcmd:g is REQUIRED: Altirra breaks with a spurious
+#     "program error" at the crt0 RUN entry (the documented false-crash); `g`
+#     (space-free, the only token /debugcmd: accepts) resumes past it so the program
+#     actually runs. Without /debug the program never gets past that trap and the
+#     screen stays blank. The debugger panes are visible in the capture, but the
+#     Atari display occupies the top-left and is clearly readable.
+#   * NEVER `pkill -f Altirra` (it matches this script's own command line). Use
+#     `wineserver -k`, which tears down the wine prefix without name-matching.
+#
+# Env overrides: ALTIRRA_DIR, DISPLAY, ALTIRRA_TV (/ntsc default), ALTIRRA_EXTRA
+# (extra Altirra switches, word-split).
+
+set -u
+ALT_DIR="${ALTIRRA_DIR:-/home/brad/Dropbox/Projects/Atari/Altirra/Altirra-4.50-test4}"
+export DISPLAY="${DISPLAY:-:0}"
+TV="${ALTIRRA_TV:-/ntsc}"
+
+XEX="${1:?usage: altirra_screenshot.sh <program.xex> [out.png] [seconds]}"
+OUT="${2:-/tmp/altirra_shot.png}"
+WARMUP="${3:-8}"
+read -r -a EXTRA <<< "${ALTIRRA_EXTRA:-}"
+
+[ -f "$XEX" ] || { echo "no such xex: $XEX" >&2; exit 2; }
+to_wine() { printf 'Z:%s' "$(printf '%s' "$1" | tr '/' '\\')"; }
+XEX_WIN="$(to_wine "$(readlink -f "$XEX")")"
+
+rm -f "$ALT_DIR/AltirraCrash.mdmp"
+( cd "$ALT_DIR" && wine Altirra64.exe \
+    "$TV" /nobasic /tempprofile /w \
+    /debug /debugbrkrun /debugcmd:g \
+    "${EXTRA[@]}" /run "$XEX_WIN" >/tmp/altirra_screenshot.log 2>&1 ) &
+
+sleep "$WARMUP"
+
+# /debug opens the debugger panes (Registers/Disassembly right, Console/Memory
+# bottom); the Atari display pane sits top-left. ALTIRRA_CROP crops the grab to just
+# that pane for a clean display-only shot. Set ALTIRRA_CROP= (empty) for the full
+# window incl. debugger panes. The default geometry matches the default debugger
+# layout at this window size; widen it if your layout differs.
+CROP="${ALTIRRA_CROP-1170x815+0+18}"
+
+WID="$(wmctrl -l 2>/dev/null | grep -i 'Altirra' | awk '{print $1}' | head -1)"
+rc=1
+if [ -n "$WID" ]; then
+    if import -window "$WID" "$OUT" 2>/tmp/altirra_screenshot.import.log; then
+        rc=0
+        [ -n "$CROP" ] && convert "$OUT" -crop "$CROP" +repage "$OUT" 2>/dev/null
+    fi
+fi
+
+wineserver -k 2>/dev/null
+wait 2>/dev/null
+
+if [ "$rc" = 0 ] && [ -s "$OUT" ]; then
+    echo "== captured -> $OUT ($(identify -format '%wx%h' "$OUT" 2>/dev/null)) =="
+    exit 0
+fi
+echo "NO screenshot captured. See /tmp/altirra_screenshot.log; xex=$XEX_WIN; win=${WID:-none}" >&2
+exit 1


### PR DESCRIPTION
The atari_hw_test background-color DLI is fixed, and I addressed both of your side-requests along the way.

### Root cause
A regression from commit 81e9617 ("make multiplexed sprites work"). It added Platform::hal::disable_raster() at the top of frame_service(), turning raster interrupts off for the whole deferred-VBI service and only re-arming at the end (prepare_chain). The service overruns vertical blank into the visible region — even for the light 2-sprite demo — so the beam crosses the row-12 color-split scanline while the DLI is disabled. The hook fired exactly once (armed at init, before the first service) then never again.

I proved it on Altirra: with the split handler counting its own runs, DLIC was stuck at 1; removing the disable made it climb (272) and the green split reappear.

### Fix ([engine/core.h](vscode-webview://1h26r4d6oc7g5p03lg54nhlc0vj805fkrrmlng6lhmihrpg9bjt4/engine/core.h), 1 file)
Gate raster interrupts off only around the chain rewrite (build_raster_hooks + prepare_chain), and only when the chain actually carries raw zone-boundary multiplex hooks (zone_count > 1, or dynamic hooks still live from last frame). The multiplexer — which the disable was protecting from a mid-rewrite read — stays protected; a single-zone (≤4 sprites) or static-only chain is never gated, so user raster hooks fire even when the service overruns.

### Verified

- atari_hw_test (1 zone): green color split restored — screenshot confirmed.
- multiplex_demo (ZONES:3 SPRITES:9): multiplexer still correct — no regression.
- mos-sim tests: 27/27 (incl. test_sprites, test_core, test_interrupt, test_atari_core).
- Committed as 9870d8e on fix_atari_hw_test_demo.

### Side-requests (both handled)

- Altirra screenshot capability — built scripts/altirra_screenshot.sh (boots a .xex headless under wine on DISPLAY=:0, grabs the window via ImageMagick, crops to the Atari display, always tears down with wineserver -k so it's never left parked in the debugger). Committed as d08dd01 with docs in PLATFORM_ATARI.md.
- Persisted to memory so I won't need reminding — updated atari-impl-testing-emulators (and the index) with the exact recipe, including that /debug …/debugcmd:g is required to clear the startup false-crash and that the script self-terminates.

One note on the debug-mode stickiness you flagged: the harness uses /debugcmd:g to auto-resume past the startup break (no manual UI step) and always kills the emulator after the grab — so it doesn't leave Altirra stuck. The debugger panes still draw, but the default crop hides them.

This pull request introduces a new script for automated screenshot capture of Atari emulator demos, clarifies documentation for demo workflows, and improves the handling of raster interrupts in the core engine logic. The main focus is to enable headless, unattended PNG capture of emulator output for demos, and to fix a regression in raster interrupt gating that affected user-defined raster hooks.

**New demo screenshot tooling:**

* Added a new script, `scripts/altirra_screenshot.sh`, which boots an Atari `.xex` file in Altirra (via Wine) and captures a PNG screenshot of the emulator window. The script is fully headless, uses ImageMagick and wmctrl to identify and crop the emulator window, and always cleans up the emulator process using `wineserver -k`. It is configurable via environment variables and supports a warm-up delay for demo rendering.

* Updated the documentation in `documents/PLATFORM_ATARI.md` to describe the new screenshot script, including usage examples and its role in capturing output from demo programs.

**Raster interrupt logic improvements:**

* Refined the raster interrupt gating logic in the core engine (`engine/core.h`): now, raster interrupts are only disabled during the raster hook chain rewrite, and only if raw zone-boundary raster hooks are present (i.e., when the multiplexer splits sprites across multiple zones). This prevents suppression of user raster hooks in single-zone or static chains, fixing a regression where user hooks (such as color splits) were missed if the service overran into the visible region. [[1]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaR462-R482) [[2]](diffhunk://#diff-206505cf25759d2961595596309f0cdb6e9ad1777ecb1f48f6574395104334eaL395-R398)