### PR TITLE
engine/scroll: flush fine scroll in the immediate VBI to fix top-band…

### DIFF
--- a/engine/core.h
+++ b/engine/core.h
@@ -389,6 +389,13 @@ public:
             Platform::hal::frame_consumed();
     }
 
+    // Called by the loop right after the game callback has committed this frame's
+    // scroll position, before it waits for the next frame boundary. Publishes the
+    // fine-scroll position so the backend latches THIS frame's value (keeping fine
+    // and coarse scroll coherent — see Screen::publish_fine_scroll). No-op unless a
+    // scroll map is bound.
+    static void publish_scroll() { screen.publish_fine_scroll(scroll); }
+
     // ── Per-frame service ──
     //
     // The backend's frame interrupt runs this once per frame in the

--- a/engine/loop.h
+++ b/engine/loop.h
@@ -47,6 +47,7 @@ template <typename Core, typename Cb>
         Core::frame_consumed();   // release the VBI guard now the frame is consumed
         sync_after_vbi();
         cb(Core::input);
+        Core::publish_scroll();   // latch THIS frame's fine scroll before the next frame service
         if (Core::hooks.post_render) Core::hooks.post_render();
     }
 }
@@ -60,6 +61,7 @@ void run_until(Cb cb) {
         Core::frame_consumed();   // release the VBI guard now the frame is consumed
         sync_after_vbi();
         const bool done = cb(Core::input);
+        Core::publish_scroll();   // latch THIS frame's fine scroll before the next frame service
         if (Core::hooks.post_render) Core::hooks.post_render();
         if (done) return;
     }

--- a/engine/platform/atari/hal.h
+++ b/engine/platform/atari/hal.h
@@ -98,6 +98,51 @@ edge_vbi_zp_save:
     .fill 32
 )");
 
+// ── Immediate-VBI fine-scroll flush ──────────────────────────────────
+//
+// The fine-scroll registers HSCROL ($D404) / VSCROL ($D405) move the whole picture
+// every frame, but the engine's frame service runs in the *deferred* VBI (VVBLKD,
+// above) — a heavy routine whose trampoline save-loop and input read can push the
+// register write a few scanlines into the visible region. The topmost scanlines
+// then display the previous frame's fine offset, which during horizontal motion
+// reads as a one-frame lag (jitter) at the top of the screen.
+//
+// Fix: flush the fine registers from the IMMEDIATE VBI (VVBLKI), which the OS NMI
+// reaches at the very top of vertical blank — before its own housekeeping and well
+// before the first visible scanline. HSCROL/VSCROL have no OS shadow, so this early
+// direct write is never overwritten. The deferred service no longer writes the
+// chip; it only stages the two computed bytes (set_fine_scroll_x/y below), and this
+// handler copies them out.
+//
+// This is a bare naked routine: two LDA abs / STA $D40x pairs and a chain-on. It
+// touches ONLY A (restored by the OS at the eventual XITVBV), uses NO llvm-mos soft
+// stack ($80-$9F) so it needs no save/restore, and deliberately does NOT consult
+// edge_vbi_busy — the flush is idempotent (re-flushing the same staged bytes during
+// a deferred overrun is visually identical) and must stay independent of the
+// deferred re-entry guard. It exits via JMP SYSVBV ($E45F), the immediate-VBI
+// continuation (NOT XITVBV — see os.h). Never executed under mos-sim (no NMI).
+extern "C" {
+[[gnu::naked]] void edge_imm_vbi_trampoline();
+extern volatile uint8_t edge_fine_hscrol;   // staged HSCROL, flushed by the immediate VBI
+extern volatile uint8_t edge_fine_vscrol;   // staged VSCROL
+}
+
+asm(R"(
+    .globl edge_imm_vbi_trampoline
+    .globl edge_fine_hscrol
+    .globl edge_fine_vscrol
+edge_imm_vbi_trampoline:
+    lda edge_fine_hscrol
+    sta $d404                  ; HSCROL — lands in VBLANK, before scanline 0
+    lda edge_fine_vscrol
+    sta $d405                  ; VSCROL
+    jmp $e45f                  ; SYSVBV: finish OS VBLANK, then JMP (VVBLKD)
+edge_fine_hscrol:
+    .byte 0
+edge_fine_vscrol:
+    .byte 0
+)");
+
 // All-static HAL (no instance state); the engine calls it via Platform::hal
 // (DECISIONS.md ADR-007 — static dispatch, never virtual).
 struct Hal {
@@ -114,8 +159,13 @@ struct Hal {
         *os::CHBAS  = v;
         *reg::CHBASE = v;
     }
-    static void set_fine_scroll_x(uint8_t v) { *reg::HSCROL = v; }
-    static void set_fine_scroll_y(uint8_t v) { *reg::VSCROL = v; }
+    // Stage the fine-scroll bytes rather than writing the chip directly: the
+    // immediate VBI (edge_imm_vbi_trampoline, above) flushes these to HSCROL/VSCROL
+    // at the top of vertical blank, before the first visible scanline, so the fine
+    // offset is live for the whole frame and the top of the screen no longer lags
+    // by a frame during horizontal scroll.
+    static void set_fine_scroll_x(uint8_t v) { edge_fine_hscrol = v; }
+    static void set_fine_scroll_y(uint8_t v) { edge_fine_vscrol = v; }
 
     // ── DLI dispatcher addresses ──
     //
@@ -407,11 +457,20 @@ struct Hal {
         const uint16_t t =
             static_cast<uint16_t>(reinterpret_cast<uintptr_t>(&edge_vbi_trampoline));
 
+        // Also point the OS immediate-VBI vector (VVBLKI) at the bare fine-scroll
+        // flush, so HSCROL/VSCROL land at the top of vertical blank ahead of the
+        // heavy deferred service. It chains on via SYSVBV, so the deferred VBI
+        // (VVBLKD, below) still fires every frame.
+        const uint16_t i =
+            static_cast<uint16_t>(reinterpret_cast<uintptr_t>(&edge_imm_vbi_trampoline));
+
         // NMIEN is write-only (reads return NMIST), so it can't be RMW'd: blank
-        // all NMIs while the two-byte os::VVBLKD vector is swapped to avoid a VBI
-        // firing on a half-written vector, then re-enable the VBI NMI. The DLI
+        // all NMIs while the two-byte os::VVBLKI/VVBLKD vectors are swapped to avoid
+        // a VBI firing on a half-written vector, then re-enable the VBI NMI. The DLI
         // NMI (nmien::DLI) is armed separately by code that installs a DLI.
         *reg::NMIEN = 0x00;                 // raw blank during the vector swap
+        os::VVBLKI[0] = static_cast<uint8_t>(i & 0xFF);
+        os::VVBLKI[1] = static_cast<uint8_t>(i >> 8);
         os::VVBLKD[0] = static_cast<uint8_t>(t & 0xFF);
         os::VVBLKD[1] = static_cast<uint8_t>(t >> 8);
         nmien_set(nmien::VBI);              // records the intended mask in the shadow

--- a/engine/platform/atari/os.h
+++ b/engine/platform/atari/os.h
@@ -57,8 +57,17 @@ EDGE_ATARI_OS(CHBAS,  0x02F4);   // shadow of CHBASE (character set base page)
 // XITVBV exits a deferred VBI handler (restores the OS-saved A/X/Y and RTIs);
 // SETVBV installs a VBI vector through the OS. Plain addresses (called, not
 // dereferenced as data).
-inline constexpr uint16_t XITVBV = 0xE462;   // deferred-VBI exit
+//
+// EXIT CONVENTION (contiguous triplet): an IMMEDIATE VBI handler (installed at
+// VVBLKI) runs at the very top of the VBLANK NMI, before the OS finishes its own
+// VBLANK processing, and must hand control back by JMP SYSVBV — NOT XITVBV. SYSVBV
+// finishes OS stage-1/stage-2 housekeeping and then JMP (VVBLKD), so the deferred
+// chain still fires. A DEFERRED handler (VVBLKD) instead exits via XITVBV (pull the
+// OS-saved A/X/Y and RTI). Using XITVBV from an immediate handler skips the rest of
+// the OS VBLANK and unwinds a frame that was never pushed → hang/crash.
 inline constexpr uint16_t SETVBV = 0xE45C;   // set VBI vector
+inline constexpr uint16_t SYSVBV = 0xE45F;   // immediate-VBI continuation (OS VBLANK → JMP (VVBLKD))
+inline constexpr uint16_t XITVBV = 0xE462;   // deferred-VBI exit
 
 } // namespace os
 } // namespace atari

--- a/engine/screen.h
+++ b/engine/screen.h
@@ -274,6 +274,20 @@ public:
         }
     }
 
+    // Publish only the fine-scroll position to the backend. Called from the game
+    // loop right after the game commits its frame (engine/loop.h), so the value the
+    // backend latches at the next frame boundary reflects THIS frame's position.
+    // The backend may latch the fine registers at a different point in the frame
+    // than the coarse load addresses (apply_scroll, run from the frame service); if
+    // the fine value were published only there it could lag the coarse offset by a
+    // frame and shear the picture during motion. write_fine() carries no display-
+    // program side effects, so it is safe to call outside the frame service.
+    template <typename ScrollT>
+    void publish_fine_scroll(ScrollT& scroll) {
+        if (!scroll_bound_ || !scroll.active() || scroll.suspended()) return;
+        scroll.write_fine();
+    }
+
     // Typed region view for region N of screen S (compile-time type safety:
     // text ops on a bitmap region, or vice versa, do not compile).
     template <typename S, u8 N>


### PR DESCRIPTION
… jitter

The horizontal fine-scroll registers (HSCROL/VSCROL) were written by ScrollManager::write_fine() inside Core::frame_service — the deferred VBI. That heavy service reaches the write a few scanlines into the visible region, so the top band displayed the previous frame's fine offset during E/W motion, reading as jitter at the top of the screen.

Flush the fine registers from the immediate VBI (VVBLKI) instead, which the OS NMI reaches at the very top of vertical blank, before any visible scanline. HSCROL/VSCROL have no OS shadow, so the early direct write is not overwritten. set_fine_scroll_x/y now stage two RAM bytes that a bare naked trampoline copies to $D404/$D405, chaining on via JMP SYSVBV ($E45F) — the immediate-VBI continuation, never XITVBV.

Fine and coarse must latch for the same frame: flushing fine in the immediate VBI while the coarse LMS patch stays in the deferred VBI desyncs them by a frame and shears the whole picture during motion. The game commits scroll in the main loop, so publish the fine value from the loop right after the callback (Core::publish_scroll -> Screen::publish_fine_scroll) before the next VBI. The immediate VBI then flushes this frame's fine, matching the coarse the deferred VBI patches from the same position — zero added latency.

Verified on Altirra (boot + interactive E/W scroll) and 33/33 host tests.