### PR TITLE
build: smooth the fresh-clone path to building/running demos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,27 @@ if(EDGE_BUILD_DEMO)
         OUTPUT_NAME "edge_net_realtime_meter.xex")
     target_link_options(edge_net_realtime_meter PRIVATE
         "LINKER:--Map=$<TARGET_FILE_DIR:edge_net_realtime_meter>/edge_net_realtime_meter.map")
+
+    # Aggregate convenience target: build every always-available demo .xex with
+    # one `cmake --build <dir> --target demos`. This is the stable name the
+    # scripts/build_demos.sh wrapper and the README point at. The network-only
+    # targets (fujinet_net_test, fujinet_session_validate) are intentionally
+    # excluded — they are conditionally defined and need an external fujinet-lib
+    # checkout. The default ALL target still builds whatever is enabled.
+    add_custom_target(demos DEPENDS
+        atari_hw_test
+        atari_scroll_test
+        atari_mode4_geometry_probe
+        atari_tank_demo
+        atari_vbxe_bringup
+        atari_vbxe_gfx
+        atari_vbxe_text
+        atari_vbxe_sprites
+        multiplex_demo
+        arena_native
+        arena_vbxe
+        net_dual_lane_demo
+        edge_net_realtime_meter)
     return()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,31 @@ For a fuller walkthrough, start with [`/documents/QUICK_START.md`](./documents/Q
 - **[Docker](https://www.docker.com/)** *(optional)* — runs the isolated UDP peer used
   in the Mode-B networking validation stack.
 
+## Getting started
+
+After cloning, three scripts take you from a bare checkout to a running demo:
+
+```sh
+scripts/setup.sh        # verify the toolchain is installed (read-only doctor)
+scripts/build_demos.sh  # build every Atari demo .xex into build-atari/
+scripts/run_tank_embedded.sh   # build + launch the tank demo in Altirra
+```
+
+`setup.sh` checks for the core tools (llvm-mos toolchains, CMake, Python) and
+prints the exact remedy for anything missing. `build_demos.sh` configures the
+Atari build and builds the aggregate `demos` target. The detailed
+[Requirements](#requirements) and [Build and test](#build-and-test) sections
+below cover the same ground manually.
+
+Useful environment knobs (all optional; sensible defaults):
+
+| Variable | Used by | Meaning |
+| --- | --- | --- |
+| `ALTIRRA_DIR` | `run_tank_*.sh`, `setup.sh` | Path to your Altirra install (else common locations are searched) |
+| `FUJINETLIB_ROOT` | `run_tank_networked.sh` | fujinet-lib (llvm-mos) checkout for the live networking demo |
+| `BUILD_DIR` | `build_demos.sh` | Build directory (default `build-atari`) |
+| `RECONF=1` | `build_demos.sh` | Force a fresh CMake configure |
+
 ## Build and test
 
 EDGE uses CMake and llvm-mos toolchains.

--- a/engine/platform/atari/fujinet.h
+++ b/engine/platform/atari/fujinet.h
@@ -61,7 +61,7 @@ struct NullNetwork {
 // - session_* : fujinet-lib / CIO N: TCP client nonblocking path
 struct FujinetNetwork {
 	// Realtime lane seam.
-	static NetStatus realtime_open_udp_seq(const char* host, u16 remote_port, u16 local_port) {
+	static NetStatus realtime_open_udp_seq(const char* host, u16 remote_port, [[maybe_unused]] u16 local_port) {
 #if defined(EDGE_ATARI_FUJINET_REALTIME_NETSTREAM)
 		return fujinet_netstream::NetstreamRealtimeAdapter::realtime_open_udp_seq(host, remote_port, local_port);
 #else
@@ -70,7 +70,7 @@ struct FujinetNetwork {
 		return NetStatus::Ok;
 #endif
 	}
-	static NetStatus realtime_bind_udp_seq(u16 local_port) {
+	static NetStatus realtime_bind_udp_seq([[maybe_unused]] u16 local_port) {
 #if defined(EDGE_ATARI_FUJINET_REALTIME_NETSTREAM)
 		return fujinet_netstream::NetstreamRealtimeAdapter::realtime_bind_udp_seq(local_port);
 #else

--- a/scripts/build_demos.sh
+++ b/scripts/build_demos.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# scripts/build_demos.sh — one command to build every Atari demo .xex.
+#
+# Configures a dedicated Atari build directory with the atari8-dos llvm-mos
+# toolchain and builds the aggregate `demos` target (every always-available
+# demo). The network-only demos (fujinet_net_test, fujinet_session_validate)
+# are not included — they need an external fujinet-lib checkout; see the README.
+#
+# Usage:  scripts/build_demos.sh
+#   BUILD_DIR=<dir>   build directory (default: build-atari)
+#   RECONF=1          force a fresh CMake configure even if the cache exists
+#
+# Run scripts/setup.sh first if you are unsure the toolchain is installed.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$REPO/build-atari}"
+
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ] || [ "${RECONF:-0}" = "1" ]; then
+    echo "== configuring Atari demo build in $BUILD_DIR =="
+    cmake -S "$REPO" -B "$BUILD_DIR" \
+        -DCMAKE_TOOLCHAIN_FILE="$REPO/cmake/atari-toolchain.cmake" \
+        -DEDGE_BUILD_DEMO=ON
+fi
+
+echo "== building all demos (target: demos) =="
+cmake --build "$BUILD_DIR" --target demos
+
+echo "== built .xex files in $BUILD_DIR =="
+ls -1 "$BUILD_DIR"/*.xex 2>/dev/null || {
+    echo "no .xex produced — check the build output above" >&2; exit 1; }

--- a/scripts/lib/atari_emu.sh
+++ b/scripts/lib/atari_emu.sh
@@ -1,0 +1,54 @@
+# scripts/lib/atari_emu.sh — shared Altirra/wine helpers for the run_* scripts.
+#
+# Source this (do not execute it):  source "$REPO/scripts/lib/atari_emu.sh"
+# It expects $REPO to be set by the caller (the repo root).
+#
+# Locating Altirra is deliberately layout-agnostic so a fresh clone works
+# without editing anything: set ALTIRRA_DIR to point at the install, otherwise
+# a list of common locations is searched. The original author's Dropbox path is
+# kept last for back-compat.
+
+# Echo the Altirra install directory (the dir containing Altirra64.exe), or
+# return non-zero with a message on stderr if none is found.
+edge_find_altirra() {
+    # 1. Explicit override always wins.
+    if [ -n "${ALTIRRA_DIR:-}" ]; then
+        if [ -d "$ALTIRRA_DIR" ]; then
+            printf '%s' "${ALTIRRA_DIR%/}"
+            return 0
+        fi
+        echo "ALTIRRA_DIR=$ALTIRRA_DIR is not a directory" >&2
+        return 2
+    fi
+
+    # 2. Search common locations (newest versioned dir wins within each glob).
+    local pat dir
+    for pat in \
+        "$REPO/third_party"/Altirra*/ \
+        "$HOME"/Altirra*/ \
+        /opt/Altirra*/ \
+        "$HOME"/Dropbox/Projects/Atari/Altirra/Altirra-*/
+    do
+        dir="$(ls -d $pat 2>/dev/null | sort -V | tail -n 1)"
+        if [ -n "$dir" ] && [ -d "$dir" ]; then
+            printf '%s' "${dir%/}"
+            return 0
+        fi
+    done
+
+    # 3. Altirra64.exe on PATH (e.g. a wrapper dir).
+    local onpath
+    onpath="$(command -v Altirra64.exe 2>/dev/null || true)"
+    if [ -n "$onpath" ]; then
+        printf '%s' "$(dirname "$onpath")"
+        return 0
+    fi
+
+    echo "Altirra not found; set ALTIRRA_DIR=/path/to/Altirra-install" >&2
+    return 2
+}
+
+# Convert a host path to the wine Z: drive form Altirra expects.
+edge_to_wine() {
+    printf 'Z:%s' "$(printf '%s' "$1" | tr '/' '\\')"
+}

--- a/scripts/run_tank_embedded.sh
+++ b/scripts/run_tank_embedded.sh
@@ -23,6 +23,7 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$REPO/scripts/lib/atari_emu.sh"
 BUILD_DIR="$REPO/build-atari-emb"
 XEX="$BUILD_DIR/atari_tank_demo.xex"
 
@@ -37,21 +38,14 @@ if [ ! -f "$XEX" ] || [ "${REBUILD:-0}" = "1" ]; then
 fi
 [ -f "$XEX" ] || { echo "build produced no .xex: $XEX" >&2; exit 1; }
 
-# ── Locate Altirra ───────────────────────────────────────────────────────────
-ALT_DIR="${ALTIRRA_DIR:-}"
-if [ -z "$ALT_DIR" ]; then
-    ALT_DIR="$(ls -d "$HOME"/Dropbox/Projects/Atari/Altirra/Altirra-*/ 2>/dev/null | sort -V | tail -n 1)"
-    ALT_DIR="${ALT_DIR%/}"
-fi
-[ -n "$ALT_DIR" ] && [ -d "$ALT_DIR" ] || {
-    echo "Altirra dir not found; set ALTIRRA_DIR=/path/to/Altirra-install" >&2; exit 2; }
+# ── Locate Altirra (ALTIRRA_DIR override, else common locations) ─────────────
+ALT_DIR="$(edge_find_altirra)" || exit 2
 
 export DISPLAY="${DISPLAY:-:0}"
 TV="${ALTIRRA_TV:-/ntsc}"
 read -r -a EXTRA <<< "${ALTIRRA_EXTRA:-}"
 
-to_wine() { printf 'Z:%s' "$(printf '%s' "$1" | tr '/' '\\')"; }
-XEX_WIN="$(to_wine "$(readlink -f "$XEX")")"
+XEX_WIN="$(edge_to_wine "$(readlink -f "$XEX")")"
 
 echo "== launching Embedded tank demo in Altirra (close the window to quit) =="
 echo "   xex: $XEX"

--- a/scripts/run_tank_networked.sh
+++ b/scripts/run_tank_networked.sh
@@ -19,7 +19,7 @@
 # checks and warns; it does not start them):
 #   * netsiohub bridge (UDP 9997)      — the NetSIO endpoint Altirra talks to
 #   * fujinet-pc firmware (TCP :8000)  — does the actual N:TCP to the server
-#     start with:  (cd ~/Projects.local/fujinet-firmware/build/dist && ./run-fujinet)
+#     start it from your fujinet-pc build's dist dir (its run-fujinet helper).
 # On real Atari hardware with a physical FujiNet, neither is needed.
 #
 # Controls + the /debug rationale + teardown caveat: see run_tank_embedded.sh.
@@ -27,12 +27,13 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$REPO/scripts/lib/atari_emu.sh"
 BUILD_DIR="$REPO/build-atari-live"
 XEX="$BUILD_DIR/atari_tank_demo.xex"
 
 NET_HOST="${NET_HOST:-$(hostname -I | awk '{print $1}')}"
 NET_PORT="${NET_PORT:-9000}"
-FUJINETLIB_ROOT="${FUJINETLIB_ROOT:-/home/brad/Dropbox/Projects/Atari/fujinetlib-llvm}"
+FUJINETLIB_ROOT="${FUJINETLIB_ROOT:-$REPO/third_party/fujinetlib-llvm}"
 LINGER="${LINGER:-10}"
 
 [ -f "$FUJINETLIB_ROOT/build/libfujinet.a" ] || {
@@ -62,23 +63,16 @@ fi
 ss -lun 2>/dev/null | grep -q ':9997' || \
     echo "WARNING: netsiohub (UDP 9997) not detected — the live load will stall." >&2
 ss -lnt 2>/dev/null | grep -q ':8000' || \
-    echo "WARNING: fujinet-pc firmware (:8000) not detected — start it with:
-         (cd ~/Projects.local/fujinet-firmware/build/dist && ./run-fujinet)" >&2
+    echo "WARNING: fujinet-pc firmware (:8000) not detected — start your fujinet-pc
+         build (its run-fujinet helper) before the live load, or the transfer stalls." >&2
 
-# ── Locate Altirra ───────────────────────────────────────────────────────────
-ALT_DIR="${ALTIRRA_DIR:-}"
-if [ -z "$ALT_DIR" ]; then
-    ALT_DIR="$(ls -d "$HOME"/Dropbox/Projects/Atari/Altirra/Altirra-*/ 2>/dev/null | sort -V | tail -n 1)"
-    ALT_DIR="${ALT_DIR%/}"
-fi
-[ -n "$ALT_DIR" ] && [ -d "$ALT_DIR" ] || {
-    echo "Altirra dir not found; set ALTIRRA_DIR=/path/to/Altirra-install" >&2; exit 2; }
+# ── Locate Altirra (ALTIRRA_DIR override, else common locations) ─────────────
+ALT_DIR="$(edge_find_altirra)" || exit 2
 
 export DISPLAY="${DISPLAY:-:0}"
 TV="${ALTIRRA_TV:-/ntsc}"
 read -r -a EXTRA <<< "${ALTIRRA_EXTRA:-}"
-to_wine() { printf 'Z:%s' "$(printf '%s' "$1" | tr '/' '\\')"; }
-XEX_WIN="$(to_wine "$(readlink -f "$XEX")")"
+XEX_WIN="$(edge_to_wine "$(readlink -f "$XEX")")"
 
 # ── Start the asset server; stop it (and Altirra) on exit ────────────────────
 SRV_LOG="$(mktemp /tmp/edge_tank_server.XXXXXX.log)"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# scripts/setup.sh — verify the EDGE build environment ("doctor").
+#
+# Read-only: this checks for the required toolchain and reports the exact remedy
+# for anything missing. It does NOT install anything — see the install link
+# below and the Requirements section of README.md.
+#
+# Exit status: 0 if every CORE tool is present, non-zero otherwise. Optional
+# tools (Altirra/Wine for hardware validation) only warn.
+
+set -uo pipefail
+
+SDK_URL="https://github.com/llvm-mos/llvm-mos-sdk"
+fail=0
+
+say()  { printf '%s\n' "$*"; }
+ok()   { printf '  \033[32mok\033[0m   %s\n' "$*"; }
+bad()  { printf '  \033[31mMISS\033[0m %s\n' "$*"; fail=1; }
+warn() { printf '  \033[33mwarn\033[0m %s\n' "$*"; }
+
+# Resolve a compiler either on PATH or in the conventional /usr/local/bin.
+have_tool() { command -v "$1" >/dev/null 2>&1 || [ -x "/usr/local/bin/$1" ]; }
+
+say "== EDGE environment check =="
+say ""
+say "Core (required to build or test):"
+
+# CMake >= 3.20
+if command -v cmake >/dev/null 2>&1; then
+    ver="$(cmake --version | head -n1 | awk '{print $3}')"
+    if [ "$(printf '%s\n3.20\n' "$ver" | sort -V | head -n1)" = "3.20" ]; then
+        ok "cmake $ver"
+    else
+        bad "cmake $ver is older than 3.20 — upgrade CMake (https://cmake.org/)"
+    fi
+else
+    bad "cmake not found — install CMake >= 3.20 (https://cmake.org/)"
+fi
+
+# Python 3 (host-side tooling)
+if command -v python3 >/dev/null 2>&1; then
+    ok "python3 $(python3 -c 'import platform; print(platform.python_version())')"
+else
+    bad "python3 not found — install Python 3 (https://www.python.org/)"
+fi
+
+# llvm-mos toolchains
+if have_tool mos-sim-clang++; then
+    ok "mos-sim-clang++ (unit-test simulator toolchain)"
+else
+    bad "mos-sim-clang++ not found — install the llvm-mos-sdk into /usr/local: $SDK_URL"
+fi
+
+if have_tool mos-atari8-dos-clang++; then
+    ok "mos-atari8-dos-clang++ (Atari .xex toolchain)"
+else
+    bad "mos-atari8-dos-clang++ not found — install the llvm-mos-sdk into /usr/local: $SDK_URL"
+fi
+
+say ""
+say "Optional (Atari hardware/VBXE validation in an emulator):"
+if command -v wine >/dev/null 2>&1; then ok "wine"; else warn "wine not found — needed to run Altirra on Linux"; fi
+if ALTIRRA_DIR="${ALTIRRA_DIR:-}" REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" \
+   bash -c 'source "$REPO/scripts/lib/atari_emu.sh"; edge_find_altirra >/dev/null 2>&1'; then
+    ok "Altirra located"
+else
+    warn "Altirra not found — set ALTIRRA_DIR or see README Requirements"
+fi
+
+say ""
+if [ "$fail" -eq 0 ]; then
+    say "All core tools present. Next:  scripts/build_demos.sh"
+else
+    say "Missing core tools above. After installing the llvm-mos-sdk into /usr/local, re-run this script."
+fi
+exit "$fail"


### PR DESCRIPTION
Add a guided first-steps path so a fresh clone goes from checkout to a running demo without machine-specific tweaks:

- scripts/setup.sh: read-only environment doctor (CMake/Python/llvm-mos toolchains, optional Altirra/Wine), prints the exact remedy for misses.
- scripts/build_demos.sh: one command to configure the Atari toolchain build and build all demos via a new aggregate `demos` CMake target.
- scripts/lib/atari_emu.sh: shared Altirra-locate/wine helper; the run_tank_* scripts now search common locations and use neutral, env-overridable defaults instead of the author's Dropbox layout.
- README: "Getting started" section + env-knob table.

Also silence two pre-existing unused-parameter warnings in the fujinet stub path ([[maybe_unused]] local_port).