### PR TITLE
engine+arena: fix play-screen DLI crash, flicker/flash, and colour bleed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,38 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+### Fixed
+- **Arena demo — play-screen crash, colour-split flicker/flash, and a 1-row colour
+  bleed.** Entering the play screen could freeze the machine (a wild jump into zero
+  page → `KIL`), and the HUD/play colour split flickered or dropped out during
+  motion. Root cause was the **C++ DLI dispatcher reading a stale chain index**: on
+  arena's heavy frame the service overran past the early split scanline before
+  `InterruptManager::prepare_chain` reset the walk index `current_`, so the
+  dispatcher fetched a one-past-end handler pointer (`$00` high byte) and `JSR`ed
+  into zero page. Three engine-wide robustness fixes plus one demo change:
+  - **`dli_dispatch.h`** — the C++ dispatcher now bounds-checks `current_` against
+    the live hook count; an out-of-range (stale) index re-syncs to the chain head
+    (`current_ = 0`) and delivers slot 0 instead of jumping through garbage. Fixes
+    the crash and the flicker.
+  - **`InterruptManager::rearm_delivery()` (interrupt.h / core.h)** — `frame_service`
+    now re-points the raster vector at the last-built chain head **in vertical
+    blank**, before any visible scanline. `prepare_chain` rebuilds the chain late in
+    a heavy service, by which point the beam may have passed an early hook's
+    scanline; re-arming up front guarantees an early hook (e.g. a high colour split)
+    fires every frame. Fixes the movement flash.
+  - **Arena raw colour-split DLI** — the play-area palette swap is now a hand-written
+    raw DLI (writes `COLBK`/`COLPF0-3` directly, no `$80-$9F` dispatcher save) that
+    chains through the engine's raster tail like the multiplexer's zone DLIs. The
+    shared C++ dispatcher's register-save overhead (~448 cycles) had delayed the
+    colour latch ~1 row, tinting the play area's top wall with the HUD palette; the
+    raw DLI latches inside the boundary's horizontal blank, with no bleed. The split
+    scanline is also decoupled from the sprite/collision origin so it can be tuned
+    without moving sprites.
+
+  Verified on Altirra (no crash through sustained play, no flash across movement
+  frames, clean colour boundary) with no regression to `atari_hw_test`, the
+  multiplexer demo (9 sprites / 3 zones), or the tank demo; 33/33 host tests pass.
+
 ## [0.6.0] - 2026-06-21
 
 ### Added

--- a/demo/arena/arena_native.cpp
+++ b/demo/arena/arena_native.cpp
@@ -73,23 +73,60 @@ EDGE_COLD static void set_hud_palette() {
 // Normally black; the death-flash (play_step) raises it to kFlashColor for a few frames.
 // A one-shot register write wouldn't survive — this DLI overwrites COLBK each frame — so
 // the flash flows through the same rendering path as the rest of the play palette.
-static u8 g_play_bg = 0x00;
+// `extern "C"` (C linkage) so the raw DLI below can read it by name; `volatile` because
+// it is written by the game loop and read by the DLI (an NMI).
+extern "C" volatile uint8_t g_play_bg = 0x00;
 
-// Play-area palette, applied mid-frame by the raster hook below.
-static void play_palette_split() {
-    engine::RasterContext<Platform> ctx{};
-    ctx.set_background_color(g_play_bg); // COLBK  : black (flashes white on a hit)
-    ctx.set_playfield_color<0>(0x96);   // COLPF0 : medium blue
-    ctx.set_playfield_color<1>(0x2A);   // COLPF1 : orange
-    ctx.set_playfield_color<2>(0x24);   // COLPF2 : brown
-    ctx.set_playfield_color<3>(0xC6);   // COLPF3 : green
+// Play-area palette split — a RAW display-list interrupt (no C++ dispatcher). The shared
+// C++ raster dispatcher saves the llvm-mos $80-$9F imaginary registers (~448 cycles)
+// before it calls a C++ hook; that delays the colour latch by ~1 row, tinting the play
+// area's top-wall row with the HUD palette (a visible "bleed"). This hand-written handler
+// writes the five colour registers directly — it saves only A/X/Y, NOT $80-$9F — so the
+// swap latches inside the boundary's horizontal blank, with no bleed. It chains through
+// the engine's raster-hook tail (edge_dli_op_curx2) exactly like the sprite multiplexer's
+// raw zone DLIs: that tail re-points VDSLST from the chain, advances the walk index,
+// restores A/X/Y, and RTIs. (COLBK $D01A, COLPF0-3 $D016-$D019 — the play palette that
+// play_step / play_enter set up; g_play_bg carries the death flash.)
+extern "C" {
+[[gnu::naked]] void play_palette_split();
+extern uint8_t edge_dli_op_curx2;   // engine raster-chain tail (platform/atari/dli_dispatch.h)
 }
+asm(R"(
+    .globl play_palette_split
+play_palette_split:
+    pha
+    txa
+    pha
+    tya
+    pha
+    lda g_play_bg
+    sta $d01a              ; COLBK  : play background (death-flash aware)
+    lda #$96
+    sta $d016              ; COLPF0 : medium blue
+    lda #$2a
+    sta $d017              ; COLPF1 : orange
+    lda #$24
+    sta $d018              ; COLPF2 : brown
+    lda #$c6
+    sta $d019              ; COLPF3 : green
+    jmp edge_dli_op_curx2
+)");
 
 // Boundary between region 0 (HUD) and region 1 (play): the display list opens
 // with 3 dl_blank(8) (24 scanlines), then the 1-row HUD (8 scanlines), so the
-// play area begins at scanline 24 + 1*8 = 32. (Same derivation as the row-12
-// split in atari_hw_test.cpp; tune on hardware if the seam is off.)
+// play area begins at scanline 24 + 1*8 = 32.
 static constexpr u8 kSplitScanline = 32;
+
+// Scanline that carries the play-area DLI. ANTIC raises the DLI on the LAST scanline
+// of the mode line holding the DLI bit, and the new colours latch on the NEXT line.
+// So to recolour starting at the play area's first row (kSplitScanline), the DLI must
+// sit one Mode-4 row (kCellH=8 scanlines) earlier — on the HUD row. With the DLI on
+// the play area's own first row instead, the swap latched one row late and the play
+// area's top wall + first row rendered in the HUD palette (the colour "bleed").
+// Kept separate from kSplitScanline so tuning the seam never moves the sprite/
+// collision origin (kPlayTopY), which derives from kSplitScanline below. Tune on
+// hardware if the seam is off.
+static constexpr u8 kSplitDli = kSplitScanline - 8;
 
 static constexpr u8 kFlashColor = 0x0E;  // white play-area flash on player damage (ANTIC COLBK)
 
@@ -344,7 +381,7 @@ EDGE_COLD static void play_enter() {
     // Colour split for the play area (removed again when we leave the screen). g_play_bg
     // is black now; the death-flash raises it briefly mid-round.
     g_play_bg = 0x00;
-    Game::interrupts.add_raster_hook(kSplitScanline, &play_palette_split);
+    Game::interrupts.add_raw_raster_hook(kSplitDli, &play_palette_split);
 
     player_init();
     // Draw the player up front so it's visible during the GET READY pause (player_update
@@ -573,7 +610,7 @@ int main() {
 
         Game::set_screen<PlayScreen>(&play_enter);
         Game::run_until(play_step);
-        Game::interrupts.remove_raster_hook(kSplitScanline);
+        Game::interrupts.remove_raster_hook(kSplitDli);
         Game::sprite_hide(0);   // don't carry the player onto title / game-over
         // Likewise hide every live enemy and empty the pool for the next round.
         enemies.for_each_indexed(

--- a/engine/core.h
+++ b/engine/core.h
@@ -408,6 +408,15 @@ public:
         //    after a few minutes of no console/keyboard input).
         Platform::hal::suppress_idle_dim();
 
+        // 0b. Re-arm raster delivery off the last-built chain NOW, in vertical blank,
+        //     before any visible scanline. The chain rebuild (step 6) runs late — a
+        //     heavy frame can have the beam already past an early hook's scanline by
+        //     then, leaving the raster vector at the terminal so that hook is skipped
+        //     for the frame (a flicker, e.g. a high colour split dropping out during
+        //     motion). This makes an early hook fire reliably every frame; step 6
+        //     rebuilds and re-arms again. No-op until the chain has been built once.
+        interrupts.rearm_delivery();
+
         // (Raster interrupts are gated off only around the chain rewrite in step 6,
         //  not for the whole service — see the comment there. Disabling for the
         //  whole service suppressed earlier user raster hooks every frame when the

--- a/engine/interrupt.h
+++ b/engine/interrupt.h
@@ -241,13 +241,31 @@ public:
         else                  Platform::hal::disable_raster();
     }
 
+    // Re-point the raster vector at the already-built chain head and reset the walk
+    // index — called from the frame service IN VERTICAL BLANK, before any visible
+    // scanline. prepare_chain rebuilds and re-arms the chain, but it runs late in a
+    // heavy frame service (after the sprite commit); by then the beam may already
+    // have passed an early hook's scanline, leaving the raster vector at the terminal
+    // so that hook is skipped for the frame — a visible flicker (e.g. a colour split
+    // high on the screen vanishing when the player moves). Re-arming here, every
+    // frame, guarantees an early hook fires off the last-built chain; prepare_chain
+    // then rebuilds it (for dynamic multiplex hooks) and re-arms again with the same
+    // machinery. No-op until the chain has been built once, or with no hooks (raster
+    // stays disabled). Carries no display-program side effects.
+    void rearm_delivery() {
+        if (last_prepared_count_ == 0xFF || total_count_ == 0) return;
+        current_ = 0;
+        Platform::hal::set_raster_vector(first_entry_);
+    }
+
     // One-time setup: patch the backend C++ raster dispatcher's operands with this
     // manager's table and current_ addresses (the single instance never moves, so
     // the addresses are stable). engine::Core::init calls this. Portable: the
     // backend-specific patching lives behind Platform::hal (Dependency Rule 2).
     void arm_dispatch() {
         Platform::hal::install_raster_dispatch(
-            addr(&current_), addr(handler_lo_), addr(handler_hi_),
+            addr(&current_), addr(&total_count_),
+            addr(handler_lo_), addr(handler_hi_),
             addr(next_lo_), addr(next_hi_));
     }
 

--- a/engine/platform/atari/dli_dispatch.h
+++ b/engine/platform/atari/dli_dispatch.h
@@ -55,6 +55,8 @@ extern "C" {
 // Patch-site labels: each sits on the first byte of an instruction whose operand
 // install_dispatch() rewrites. The operand begins at (label + 1).
 extern uint8_t edge_dli_op_curx;   // LDX current_            (abs, 2-byte operand)
+extern uint8_t edge_dli_op_cnt;    // CPX total_count_        (abs, 2-byte operand)
+extern uint8_t edge_dli_op_rst;    // STA current_ (=0 resync)(abs, 2-byte operand)
 extern uint8_t edge_dli_op_hlo;    // LDA handler_lo_,X       (abs, 2-byte operand)
 extern uint8_t edge_dli_op_hhi;    // LDA handler_hi_,X       (abs, 2-byte operand)
 extern uint8_t edge_dli_op_curx2;  // LDX current_ (reload)   (abs, 2-byte operand)
@@ -91,6 +93,8 @@ asm(R"(
     .globl edge_dli_dispatch
     .globl edge_dli_terminal
     .globl edge_dli_op_curx
+    .globl edge_dli_op_cnt
+    .globl edge_dli_op_rst
     .globl edge_dli_op_hlo
     .globl edge_dli_op_hhi
     .globl edge_dli_op_curx2
@@ -114,6 +118,23 @@ edge_dli_dispatch:
     bpl .Ledge_dli_save
 edge_dli_op_curx:
     ldx $ffff               ; X = current_  (abs operand patched)
+edge_dli_op_cnt:
+    cpx $ffff               ; compare current_ with total_count_ (abs operand patched)
+    bcc .Ledge_dli_inrange  ; current_ < live slot count → a real slot, dispatch it
+    ; Out of range: current_ is a stale one-past-end index left by a prior frame's
+    ; dispatch whose prepare_chain had not yet reset it to 0 when this DLI fired (a
+    ; heavy frame service can overrun past an early hook's scanline). Firing slot
+    ; current_ would JSR a garbage pointer; SKIPPING it would drop the hook for the
+    ; frame — a visible flicker (e.g. the colour split vanishing on heavy frames).
+    ; Instead re-sync to the chain head: reset current_ to 0 and dispatch slot 0
+    ; now. The first DLI of a frame is always the first (lowest-scanline) hook, so
+    ; slot 0 is the correct one; the tail then re-points VDSLST from next_[0] and
+    ; bumps current_, keeping the rest of the chain in step.
+    lda #0
+edge_dli_op_rst:
+    sta $ffff               ; current_ = 0  (abs operand patched)
+    tax                     ; X = 0 → dispatch slot 0
+.Ledge_dli_inrange:
 edge_dli_op_hlo:
     lda $ffff,x             ; handler_lo_[current_]  (operand patched)
     sta edge_dli_jsr+1
@@ -203,7 +224,7 @@ edge_mux_op_inc:
 // current_; the remaining arguments are the RAM addresses of the parallel tables.
 // Every patched site uses absolute (2-byte) addressing — current_ lives in BSS,
 // not a reserved zero-page byte, so it is addressed absolutely like the tables.
-inline void install_dispatch(uint16_t cur,
+inline void install_dispatch(uint16_t cur, uint16_t count,
                              uint16_t handler_lo, uint16_t handler_hi,
                              uint16_t next_lo, uint16_t next_hi) {
     // Absolute two-byte operands (little-endian).
@@ -212,6 +233,8 @@ inline void install_dispatch(uint16_t cur,
         opcode[2] = static_cast<uint8_t>(addr >> 8);
     };
     patch16(&edge_dli_op_curx,  cur);
+    patch16(&edge_dli_op_cnt,   count);
+    patch16(&edge_dli_op_rst,   cur);
     patch16(&edge_dli_op_curx2, cur);
     patch16(&edge_dli_op_inc,   cur);
     patch16(&edge_dli_op_hlo, handler_lo);

--- a/engine/platform/atari/hal.h
+++ b/engine/platform/atari/hal.h
@@ -184,10 +184,10 @@ struct Hal {
     // Patch the C++ DLI dispatcher's operands with the InterruptManager's table
     // and current_ addresses. Called once from engine::Core::init via
     // InterruptManager::arm_dispatch (the single manager instance never moves).
-    static void install_raster_dispatch(uint16_t cur,
+    static void install_raster_dispatch(uint16_t cur, uint16_t count,
                                      uint16_t handler_lo, uint16_t handler_hi,
                                      uint16_t next_lo, uint16_t next_hi) {
-        install_dispatch(cur, handler_lo, handler_hi, next_lo, next_hi);
+        install_dispatch(cur, count, handler_lo, handler_hi, next_lo, next_hi);
     }
 
     // The raw zone-boundary handler the sprite multiplexer registers as its

--- a/tests/backends/atari/test_atari_core.cpp
+++ b/tests/backends/atari/test_atari_core.cpp
@@ -74,7 +74,7 @@ struct MockHal {
     static void set_raster_vector(u16) {}
     static void enable_raster()  {}
     static void disable_raster() {}
-    static void install_raster_dispatch(u16, u16, u16, u16, u16) {}
+    static void install_raster_dispatch(u16, u16, u16, u16, u16, u16) {}
     static void mux_noop() {}
     static void (*multiplex_dli())() { return &mux_noop; }
     static void install_multiplex_dli(u16, u16) {}

--- a/tests/generic/test_core.cpp
+++ b/tests/generic/test_core.cpp
@@ -84,7 +84,7 @@ struct MockHal {
     static void set_raster_vector(u16) {}
     static void enable_raster()  {}
     static void disable_raster() {}
-    static void install_raster_dispatch(u16, u16, u16, u16, u16) {}
+    static void install_raster_dispatch(u16, u16, u16, u16, u16, u16) {}
     static void mux_noop() {}
     static void (*multiplex_dli())() { return &mux_noop; }
     static void install_multiplex_dli(u16, u16) {}

--- a/tests/generic/test_interrupt.cpp
+++ b/tests/generic/test_interrupt.cpp
@@ -37,10 +37,12 @@ struct MockHal {
 
     // Dispatcher install — record the args so arm_dispatch's wiring is observable.
     static bool dispatch_armed;
-    static u16  arm_cur, arm_hlo, arm_hhi, arm_nlo, arm_nhi;
-    static void install_raster_dispatch(u16 cur, u16 hlo, u16 hhi, u16 nlo, u16 nhi) {
+    static u16  arm_cur, arm_cnt, arm_hlo, arm_hhi, arm_nlo, arm_nhi;
+    static void install_raster_dispatch(u16 cur, u16 count, u16 hlo, u16 hhi,
+                                        u16 nlo, u16 nhi) {
         dispatch_armed = true;
-        arm_cur = cur; arm_hlo = hlo; arm_hhi = hhi; arm_nlo = nlo; arm_nhi = nhi;
+        arm_cur = cur; arm_cnt = count;
+        arm_hlo = hlo; arm_hhi = hhi; arm_nlo = nlo; arm_nhi = nhi;
     }
 
     // RasterContext stores — stubbed (RasterContext is compiled, not exercised).
@@ -58,8 +60,8 @@ u8   MockHal::last_colpf0    = 0;
 u16  MockHal::raster_vector         = 0;
 bool MockHal::raster_enabled    = false;
 bool MockHal::dispatch_armed = false;
-u16  MockHal::arm_cur = 0, MockHal::arm_hlo = 0, MockHal::arm_hhi = 0,
-     MockHal::arm_nlo = 0, MockHal::arm_nhi = 0;
+u16  MockHal::arm_cur = 0, MockHal::arm_cnt = 0, MockHal::arm_hlo = 0,
+     MockHal::arm_hhi = 0, MockHal::arm_nlo = 0, MockHal::arm_nhi = 0;
 
 struct MockPlatform {
     using hal = MockHal;
@@ -226,8 +228,10 @@ static void test_arm_dispatch() {
     IM im;
     im.arm_dispatch();
     CHECK(MockHal::dispatch_armed);
-    // The handler/next table bases and current_ are distinct, real addresses.
+    // The handler/next table bases, current_, and total_count_ are distinct addrs.
     CHECK(MockHal::arm_cur != 0);
+    CHECK(MockHal::arm_cnt != 0);
+    CHECK(MockHal::arm_cnt != MockHal::arm_cur);   // total_count_ vs current_
     CHECK(MockHal::arm_hlo != 0);
     CHECK(MockHal::arm_hlo != MockHal::arm_hhi);   // handler_lo_ vs handler_hi_
     CHECK(MockHal::arm_nlo != MockHal::arm_nhi);   // next_lo_   vs next_hi_


### PR DESCRIPTION
Entering arena's play screen could freeze the machine with a wild jump into zero page (KIL), and the HUD/play colour split flickered or dropped out during motion. Root cause: the C++ DLI dispatcher read a stale one-past-end chain index (current_) on a heavy frame whose prepare_chain had not yet reset it before an early DLI fired, so it fetched a garbage handler pointer ($00 high byte) and JSRed into zero page.

Engine-wide robustness fixes:
- dli_dispatch.h: bounds-check current_ against the live hook count; an out-of-range (stale) index re-syncs to the chain head (current_=0) and delivers slot 0 instead of jumping through garbage. Fixes crash + flicker. Threads the live count (total_count_) through install_raster_dispatch.
- interrupt.h / core.h: InterruptManager::rearm_delivery() re-points the raster vector at the last-built chain head in vertical blank, before any visible scanline. prepare_chain rebuilds the chain late in a heavy service, after the beam may have passed an early hook's scanline; the up-front re-arm guarantees an early hook fires every frame. Fixes the movement flash.

Arena demo:
- The play-area colour split is now a raw DLI (writes COLBK/COLPF0-3 directly, no $80-$9F dispatcher save) that chains through the engine's raster tail like the multiplexer's zone DLIs. The C++ dispatcher's register-save overhead (~448 cycles) delayed the colour latch ~1 row, tinting the play area's top-wall row with the HUD palette; the raw DLI latches inside the boundary HBLANK, no bleed. The split scanline is decoupled from the sprite/collision origin so it tunes independently.

Verified on Altirra (no crash through sustained play, 0 flash across movement frames, clean colour boundary); no regression to atari_hw_test, the multiplexer demo (9 sprites/3 zones), or tank; 33/33 host tests pass.