### PR TITLE
Atart native graphics primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,41 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-24
+
+### Added
+- **Native (ANTIC bitmap) primitive-drawing demo (`native_gfx`).** The baseline
+  (stock ANTIC/GTIA, no VBXE) counterpart to `atari_vbxe_gfx`: the same portable
+  bitmap primitives (`clear` / `fill_rect` / `hline` / `vline` / `line` / `plot` /
+  `blit`) drawn through a software `BitmapRegionView`, exercising the `gfx::Baseline`
+  path the blitter demo doesn't. **FIRE cycles three native bitmap modes that share
+  ONE screen buffer** — ANTIC D (GR.7, 160×96 4-colour, 3840 B), ANTIC E (160×192
+  4-colour, 7680 B), and ANTIC F (GR.8, 320×192 hi-res, 7680 B); D uses half the
+  buffer, E/F use all of it. A row of 1/2/3 squares tags the active mode. The first
+  demo to exercise a baseline bitmap display list. Altirra-verified for all three
+  modes.
+
+### Changed
+- **Baseline `BitmapRegionView` coordinates widened to `u16`.** The software bitmap
+  view (and the `BitmapOps` baseline path) addressed pixels with `u8` x, capping the
+  canvas at 255 px, so a 320-wide hi-res mode (ANTIC F) left its right ~64 px blank.
+  Coordinates are now `u16` — matching the already-`u16` public `BitmapOps` API — and
+  the truncating casts are gone, so native bitmaps draw to their full width. Source-
+  compatible: `u8` args still promote and no mode ≤ 255 px changes behaviour.
+
 ### Fixed
+- **Baseline bitmap 4K scan-boundary straddle (full-screen native bitmaps).** A
+  screen buffer larger than one 4K page (e.g. a 192-line, 7680-byte Mode E/F bitmap)
+  crosses a `$x000` scan boundary, and the one mode line whose bytes straddle it had
+  its tail fetched from the page start — the scan-address counter wraps within a page,
+  and the per-line LMS reload only fixes lines that *start* in the new page, so the
+  straddling line stayed corrupt. No base alignment removes it (4096 is not a multiple
+  of the 40-byte line). `DisplayLayout::canvas_pad(page)` (= `page % bytes_per_line`)
+  plus a page-aligned buffer now front-shift each screen's canvas
+  (`ScreenManager::canvas_base<S>()`, used by `dl.build`, the view bind, and the
+  `core.h` gfx attach) so the boundary lands exactly on a mode-line start and nothing
+  straddles. Guarded so platforms with no scan boundary (alignment ≤ 1) never pad. New
+  regression test `test_canvas_pad_alignment`; Altirra-verified corrupt-row-free.
 - **Arena demo — play-screen crash, colour-split flicker/flash, and a 1-row colour
   bleed.** Entering the play screen could freeze the machine (a wild jump into zero
   page → `KIL`), and the HUD/play colour split flickered or dropped out during
@@ -508,5 +542,6 @@ any custom backend implementing the display-traits contract.
   CMake, surfaced in the demo HUD, and stamped across the documentation.
 
 [Unreleased]: https://github.com/
+[0.7.0]: https://github.com/
 [0.2.0]: https://github.com/
 [0.1.0]: https://github.com/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,25 @@ if(EDGE_BUILD_DEMO)
     target_link_options(atari_vbxe_gfx PRIVATE
         "LINKER:--Map=$<TARGET_FILE_DIR:atari_vbxe_gfx>/atari_vbxe_gfx.map")
 
+    # Native (ANTIC bitmap) primitive-drawing demo — the baseline counterpart to
+    # atari_vbxe_gfx. One source, two .xex: BITMAP_E (4-colour) and BITMAP_F (hi-res).
+    add_executable(native_gfx demo/native_gfx.cpp)
+    target_compile_options(native_gfx PRIVATE
+        -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra)
+    target_include_directories(native_gfx PRIVATE ${CMAKE_SOURCE_DIR})
+    set_target_properties(native_gfx PROPERTIES OUTPUT_NAME "native_gfx.xex")
+    target_link_options(native_gfx PRIVATE
+        "LINKER:--Map=$<TARGET_FILE_DIR:native_gfx>/native_gfx.map")
+
+    add_executable(native_gfx_hires demo/native_gfx.cpp)
+    target_compile_options(native_gfx_hires PRIVATE
+        -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra)
+    target_compile_definitions(native_gfx_hires PRIVATE NATIVE_GFX_HIRES)
+    target_include_directories(native_gfx_hires PRIVATE ${CMAKE_SOURCE_DIR})
+    set_target_properties(native_gfx_hires PROPERTIES OUTPUT_NAME "native_gfx_hires.xex")
+    target_link_options(native_gfx_hires PRIVATE
+        "LINKER:--Map=$<TARGET_FILE_DIR:native_gfx_hires>/native_gfx_hires.map")
+
     # VBXE 80-column text-mode demo — independent .xex.
     add_executable(atari_vbxe_text demo/vbxe_text.cpp)
     target_compile_options(atari_vbxe_text PRIVATE
@@ -505,6 +524,8 @@ if(EDGE_BUILD_DEMO)
         atari_tank_demo
         atari_vbxe_bringup
         atari_vbxe_gfx
+        native_gfx
+        native_gfx_hires
         atari_vbxe_text
         atari_vbxe_sprites
         multiplex_demo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,7 +377,8 @@ if(EDGE_BUILD_DEMO)
         "LINKER:--Map=$<TARGET_FILE_DIR:atari_vbxe_gfx>/atari_vbxe_gfx.map")
 
     # Native (ANTIC bitmap) primitive-drawing demo — the baseline counterpart to
-    # atari_vbxe_gfx. One source, two .xex: BITMAP_E (4-colour) and BITMAP_F (hi-res).
+    # atari_vbxe_gfx. FIRE cycles three native bitmap modes (ANTIC D/E/F) sharing one
+    # screen buffer.
     add_executable(native_gfx demo/native_gfx.cpp)
     target_compile_options(native_gfx PRIVATE
         -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra)
@@ -385,15 +386,6 @@ if(EDGE_BUILD_DEMO)
     set_target_properties(native_gfx PROPERTIES OUTPUT_NAME "native_gfx.xex")
     target_link_options(native_gfx PRIVATE
         "LINKER:--Map=$<TARGET_FILE_DIR:native_gfx>/native_gfx.map")
-
-    add_executable(native_gfx_hires demo/native_gfx.cpp)
-    target_compile_options(native_gfx_hires PRIVATE
-        -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra)
-    target_compile_definitions(native_gfx_hires PRIVATE NATIVE_GFX_HIRES)
-    target_include_directories(native_gfx_hires PRIVATE ${CMAKE_SOURCE_DIR})
-    set_target_properties(native_gfx_hires PROPERTIES OUTPUT_NAME "native_gfx_hires.xex")
-    target_link_options(native_gfx_hires PRIVATE
-        "LINKER:--Map=$<TARGET_FILE_DIR:native_gfx_hires>/native_gfx_hires.map")
 
     # VBXE 80-column text-mode demo — independent .xex.
     add_executable(atari_vbxe_text demo/vbxe_text.cpp)
@@ -525,7 +517,6 @@ if(EDGE_BUILD_DEMO)
         atari_vbxe_bringup
         atari_vbxe_gfx
         native_gfx
-        native_gfx_hires
         atari_vbxe_text
         atari_vbxe_sprites
         multiplex_demo

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EDGE (Eight-bit Damned! Game Engine)
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
 
 EDGE is a C++20 game engine for constrained 6502-class systems, built around a small, deterministic, compile-time configured API instead of a heavy runtime.
 The project is Atari-first today, but its architecture is intended to support additional 6502-family platforms over time. Game code is written against portable engine subsystems while hardware details live behind a platform HAL and compile-time capability profiles.

--- a/demo/README.md
+++ b/demo/README.md
@@ -217,6 +217,35 @@ complete), ~5.6 KB on the wire. `EDGE_TANK_NET_HOST`/`PORT` are baked into the R
 The live build still has no collision/terrain/bullets/realtime-lane/gameplay
 networking; the session is only used to load assets before gameplay.
 
+# Native bitmap primitive-drawing demo (`native_gfx.xex` / `native_gfx_hires.xex`)
+
+The baseline (stock ANTIC/GTIA, no VBXE) counterpart to `atari_vbxe_gfx`. It draws
+a static picture through the **same** portable `Game::gfx()` API, but the canvas is
+an ANTIC `BitmapRegion` drawn by its software `BitmapRegionView` — so this exercises
+the `gfx::Baseline` path that the VBXE demo's blitter path does not. One source
+([`native_gfx.cpp`](native_gfx.cpp)) builds two `.xex` (mode chosen by a macro):
+
+- **`native_gfx`** — `BITMAP_E`: 160×192, 4 colours (2bpp).
+- **`native_gfx_hires`** (`-DNATIVE_GFX_HIRES`) — `BITMAP_F`: 320×192, hi-res 2-colour
+  (1bpp). The view addresses pixels with `u8` x, so only x ≤ 255 is reachable — the
+  right ~64px stay blank by design.
+
+```sh
+cmake --build build-atari --target native_gfx        # -> native_gfx.xex
+cmake --build build-atari --target native_gfx_hires  # -> native_gfx_hires.xex
+```
+
+Run with BASIC disabled. Needs **no VBXE**.
+
+| Observation | Proves |
+|---|---|
+| Framed safe-area border | `hline` / `vline` (software, packed write) |
+| Colour-bar rectangles down the left (3 colours / 1 in hi-res) | `fill_rect` |
+| Two crossing diagonals on the right | `line` (software Bresenham via `plot`) |
+| Dotted accent line across the lower band | `plot` |
+| Small chequered 16×16 image | `blit` of a source packed at the region bpp |
+| Steady picture, no corrupt row across the 192-line field | the screen manager front-aligns the >4KB canvas so no mode line straddles the 4K scan boundary |
+
 # VBXE demos
 
 Four additional demos exercise the VBXE (`atari::gfx::VBXE<...>`) graphics path —

--- a/demo/README.md
+++ b/demo/README.md
@@ -238,8 +238,8 @@ at each screen's front-aligned canvas (`Game::gfx()` binds a single packing).
 cmake --build build-atari --target native_gfx        # -> native_gfx.xex
 ```
 
-Run with BASIC disabled. Needs **no VBXE**. The software view addresses pixels with
-`u8` x, so ANTIC F's 320-wide field is only drawn to x ≤ 255 (right ~64px blank).
+Run with BASIC disabled. Needs **no VBXE**. All three modes draw to their full
+width (the software `BitmapRegionView` uses `u16` x, so ANTIC F reaches x = 319).
 
 | Observation | Proves |
 |---|---|

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Hardware validation demo (`atari_hw_test.xex`)
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 A minimal Atari 8-bit program that drives every engine subsystem at once, so
 the engine's live ANTIC path can be confirmed on real hardware / emulators

--- a/demo/README.md
+++ b/demo/README.md
@@ -217,34 +217,39 @@ complete), ~5.6 KB on the wire. `EDGE_TANK_NET_HOST`/`PORT` are baked into the R
 The live build still has no collision/terrain/bullets/realtime-lane/gameplay
 networking; the session is only used to load assets before gameplay.
 
-# Native bitmap primitive-drawing demo (`native_gfx.xex` / `native_gfx_hires.xex`)
+# Native bitmap primitive-drawing demo (`native_gfx.xex`)
 
-The baseline (stock ANTIC/GTIA, no VBXE) counterpart to `atari_vbxe_gfx`. It draws
-a static picture through the **same** portable `Game::gfx()` API, but the canvas is
-an ANTIC `BitmapRegion` drawn by its software `BitmapRegionView` — so this exercises
-the `gfx::Baseline` path that the VBXE demo's blitter path does not. One source
-([`native_gfx.cpp`](native_gfx.cpp)) builds two `.xex` (mode chosen by a macro):
+The baseline (stock ANTIC/GTIA, no VBXE) counterpart to `atari_vbxe_gfx`. It draws a
+picture with the **same** portable bitmap primitives the VBXE demo uses, but the
+canvas is an ANTIC `BitmapRegion` drawn by its software `BitmapRegionView` — the
+`gfx::Baseline` path the blitter demo doesn't exercise. **Press FIRE to cycle three
+native bitmap modes that all share ONE screen buffer:**
 
-- **`native_gfx`** — `BITMAP_E`: 160×192, 4 colours (2bpp).
-- **`native_gfx_hires`** (`-DNATIVE_GFX_HIRES`) — `BITMAP_F`: 320×192, hi-res 2-colour
-  (1bpp). The view addresses pixels with `u8` x, so only x ≤ 255 is reachable — the
-  right ~64px stay blank by design.
+- **ANTIC D** (GR.7) — 160×96 4-colour, 2 scanlines/line → full height, **3840 B**
+- **ANTIC E** — 160×192 4-colour, 1 scanline/line → **7680 B**
+- **ANTIC F** (GR.8) — 320×192 hi-res 2-colour, 1 scanline/line → **7680 B**
+
+The shared buffer is sized for the largest screen (E/F, 7680 B); ANTIC D uses only
+the first half. A row of 1/2/3 squares at the top tags the current mode. Each mode
+packs pixels differently, so the demo keeps one `engine::BitmapOps` per mode pointed
+at each screen's front-aligned canvas (`Game::gfx()` binds a single packing).
 
 ```sh
 cmake --build build-atari --target native_gfx        # -> native_gfx.xex
-cmake --build build-atari --target native_gfx_hires  # -> native_gfx_hires.xex
 ```
 
-Run with BASIC disabled. Needs **no VBXE**.
+Run with BASIC disabled. Needs **no VBXE**. The software view addresses pixels with
+`u8` x, so ANTIC F's 320-wide field is only drawn to x ≤ 255 (right ~64px blank).
 
 | Observation | Proves |
 |---|---|
 | Framed safe-area border | `hline` / `vline` (software, packed write) |
-| Colour-bar rectangles down the left (3 colours / 1 in hi-res) | `fill_rect` |
+| Colour-bar rectangles down the left (3 colours; 1 in hi-res F) | `fill_rect` |
 | Two crossing diagonals on the right | `line` (software Bresenham via `plot`) |
 | Dotted accent line across the lower band | `plot` |
 | Small chequered 16×16 image | `blit` of a source packed at the region bpp |
-| Steady picture, no corrupt row across the 192-line field | the screen manager front-aligns the >4KB canvas so no mode line straddles the 4K scan boundary |
+| FIRE swaps mode/resolution; 1/2/3 tag squares track it | runtime `set_screen` between bitmap modes over a shared buffer |
+| Steady picture, no corrupt row across the 192-line E/F field | the screen manager front-aligns the >4KB canvas so no mode line straddles the 4K scan boundary |
 
 # VBXE demos
 

--- a/demo/native_gfx.cpp
+++ b/demo/native_gfx.cpp
@@ -1,0 +1,143 @@
+// demo/native_gfx.cpp — Edge engine native (ANTIC bitmap) primitive-drawing demo.
+//
+// The baseline counterpart to demo/vbxe_gfx.cpp. It draws a static picture into a
+// stock-hardware ANTIC bitmap region using the SAME portable gfx API
+// (Game::gfx()): clear, fill_rect, hline/vline, line (Bresenham), plot and blit.
+// No VBXE — this is pure ANTIC/GTIA, so the canvas is a baseline `BitmapRegion`
+// drawn through its software `BitmapRegionView` (engine/display.h), and the gfx
+// dispatch selects the software path (has_blitter == false).
+//
+// Two builds from this one source (mode chosen by NATIVE_GFX_HIRES):
+//   * default          → BITMAP_E : 160×192, 4 colours (2bpp).  →  native_gfx.xex
+//   * -DNATIVE_GFX_HIRES → BITMAP_F : 320×192, hi-res 2-colour (1bpp).  → native_gfx_hires.xex
+//
+// Expected result: a framed safe-area border, a column of colour-bar rectangles
+// (one bar in the hi-res build), two crossing diagonals, a dotted accent line and
+// a small chequered image — all steady (drawn once; nothing redraws it).
+//
+// ── Setup notes ───────────────────────────────────────────────────────────
+//  * Needs no VBXE. Run with BASIC DISABLED so the demo owns RAM. NTSC.
+//  * The view addresses pixels with u8 x/y, so a 320-wide mode (BITMAP_F) can only
+//    reach x ≤ 255 through the API — the hi-res build leaves the right ~64px blank.
+
+#include <stdint.h>
+
+#include <engine/core.h>
+#include <engine/platform/atari/platform.h>
+
+using engine::u8;
+using engine::u16;
+namespace M = atari;
+
+// ── Mode selection ─────────────────────────────────────────────────────────
+#ifdef NATIVE_GFX_HIRES
+constexpr auto kMode   = M::Mode::BITMAP_F;  // 320×192, 1bpp (hi-res, 2-colour)
+constexpr u8   kRight  = 255;                // u8 view x: cannot reach the full 320
+constexpr u8   kBpp    = 1;
+// Hi-res is 1bpp: every "ink" colour collapses to pixel value 1.
+constexpr u8   cInkA = 1, cInkB = 1, cInkC = 1;
+#else
+constexpr auto kMode   = M::Mode::BITMAP_E;  // 160×192, 2bpp (4-colour)
+constexpr u8   kRight  = 159;
+constexpr u8   kBpp    = 2;
+// 2bpp pixel values map to playfield registers: 1→COLPF0, 2→COLPF1, 3→COLPF2.
+constexpr u8   cInkA = 1, cInkB = 2, cInkC = 3;
+#endif
+// Full screen height. The 192-line buffer (7680 B) crosses a 4K scan boundary; the
+// engine's screen manager front-aligns the canvas so no mode line straddles it.
+constexpr u8 kHeight = 192;
+constexpr u8 kBottom = kHeight - 1;          // 191
+
+// ── Platform + game configuration ──────────────────────────────────────────
+//
+// Baseline graphics axis (no blitter). The gfx canvas is the screen's bitmap
+// region; GameConfig::bitmap_region gives Game::gfx() its software view type, and
+// set_screen() binds the view to the region's screen-memory slice.
+using Platform = M::Platform<
+    M::Machine::XL,
+    M::RAM::Baseline,
+    M::gfx::Baseline,
+    M::Sound::Mono,
+    M::TV::NTSC>;
+
+struct ScreenBitmap {
+    using display = engine::DisplayLayout<engine::BitmapRegion<kMode, kHeight>>;
+};
+struct GameConfig {
+    using screens        = engine::ScreenSet<ScreenBitmap>;
+    using bitmap_region  = engine::BitmapRegion<kMode, kHeight>;
+    static constexpr u8 max_sprites    = 1;   // pure bitmap; sprites unused
+    static constexpr u8 sound_channels = 1;
+};
+using Game = engine::Core<Platform, GameConfig>;
+
+// ── Palette ────────────────────────────────────────────────────────────────
+//
+// set_color_pf field map: 0-3 = COLPF0-3, 4 = COLBK. Writes the OS colour shadow
+// the VBI copies to the hardware registers each frame.
+static void load_palette() {
+#ifdef NATIVE_GFX_HIRES
+    // ANTIC hi-res (mode F): lit pixels take their LUMINANCE from COLPF1 and their
+    // HUE from the background. Black background + high-luminance COLPF1 ⇒ crisp
+    // white ink. Set COLBK and COLPF2 (both candidate backgrounds) to black so the
+    // field is black regardless of the GTIA hi-res quirk.
+    Platform::hal::set_color_pf(4, 0x00);   // COLBK  : black field
+    Platform::hal::set_color_pf(2, 0x00);   // COLPF2 : black (hi-res background hue)
+    Platform::hal::set_color_pf(1, 0x0E);   // COLPF1 : white ink (luminance)
+#else
+    Platform::hal::set_color_pf(4, 0x90);   // COLBK  : dark blue field   (value 0)
+    Platform::hal::set_color_pf(0, 0x0E);   // COLPF0 : white             (value 1)
+    Platform::hal::set_color_pf(1, 0x1A);   // COLPF1 : gold              (value 2)
+    Platform::hal::set_color_pf(2, 0x44);   // COLPF2 : red               (value 3)
+#endif
+}
+
+int main() {
+    Game::init();          // baseline bring-up; set_screen binds the gfx canvas
+    load_palette();
+
+    auto& g = Game::gfx();
+
+    g.clear(0);            // background (pixel value 0)
+
+    // A framed border, inset into the NTSC-safe area.
+    constexpr u8 L = 4, R = kRight - 4, T = 6, B = kBottom - 6;
+    g.hline(L, R, T, cInkA);
+    g.hline(L, R, B, cInkA);
+    g.vline(L, T, B, cInkA);
+    g.vline(R, T, B, cInkA);
+
+    // Colour-bar rectangles down the left (fill_rect). In the 4-colour build the
+    // three bars cycle the playfield registers; in hi-res there is one ink bar.
+    const u8 bars[3] = { cInkA, cInkB, cInkC };
+    for (u8 i = 0; i < 3; ++i)
+        g.fill_rect(12, static_cast<u16>(T + 14 + i * 52), 40, 28, bars[i]);
+
+    // Two crossing diagonals on the right half (software Bresenham via plot).
+    const u8 dx0 = static_cast<u8>(kRight - 90), dx1 = static_cast<u8>(kRight - 12);
+    g.line(dx0, static_cast<u8>(T + 6), dx1, static_cast<u8>(B - 6), cInkB);
+    g.line(dx1, static_cast<u8>(T + 6), dx0, static_cast<u8>(B - 6), cInkC);
+
+    // A dotted accent line across the lower band (plot every few pixels).
+    for (u8 x = L + 4; x < R - 4; x = static_cast<u8>(x + 6))
+        g.plot(x, static_cast<u8>(B - 4), cInkA);
+
+    // A small 16×16 chequered image, packed at the region's bpp, then blitted.
+    // blit() expects source rows packed ceil(w / pixels_per_byte) bytes each, with
+    // the leftmost pixel in the high bits of a byte (BitmapRegionView::blit).
+    constexpr u8 IMG_W = 16, IMG_H = 16;
+    constexpr u8 ppb    = static_cast<u8>(8 / kBpp);
+    constexpr u8 mask   = static_cast<u8>((1u << kBpp) - 1);
+    constexpr u8 stride = static_cast<u8>((IMG_W + ppb - 1) / ppb);
+    u8 img[IMG_H * 4] = {0};               // 4 = max stride (BITMAP_E); F uses 2
+    for (u8 y = 0; y < IMG_H; ++y)
+        for (u8 x = 0; x < IMG_W; ++x) {
+            const u8 v  = static_cast<u8>(((x ^ y) >> 2) & mask);   // chequer
+            const u8 sh = static_cast<u8>((ppb - 1 - (x % ppb)) * kBpp);
+            img[y * stride + x / ppb] = static_cast<u8>(img[y * stride + x / ppb] | (v << sh));
+        }
+    g.blit(static_cast<u8>(R - 26), 26, img, IMG_W, IMG_H);
+
+    // Idle — the picture is static and persists (no sprites, nothing redraws it).
+    Game::run([](const auto&) {});
+}

--- a/demo/native_gfx.cpp
+++ b/demo/native_gfx.cpp
@@ -22,8 +22,8 @@
 //
 // ── Setup notes ───────────────────────────────────────────────────────────
 //  * Needs no VBXE. Run with BASIC DISABLED so the demo owns RAM. NTSC.
-//  * The software view addresses pixels with u8 x, so the 320-wide F mode can only
-//    reach x ≤ 255 — its right ~64px stay blank by design.
+//  * All three modes draw to their full width (the software view uses u16 x, so the
+//    320-wide F mode reaches x = 319 like D/E fill their 160).
 
 #include <stdint.h>
 
@@ -85,8 +85,10 @@ static void palette_hires() {
 // the ink pixel values (in hi-res all three collapse to 1). `tag` (1..3) marks the
 // mode with that many small squares.
 template <typename G>
-static void draw_scene(G& g, u8 right, u8 bottom, u8 bpp, u8 a, u8 b, u8 c, u8 tag) {
-    const u8 L = 4, R = static_cast<u8>(right - 4), T = 6, B = static_cast<u8>(bottom - 6);
+static void draw_scene(G& g, u16 right, u8 bottom, u8 bpp, u8 a, u8 b, u8 c, u8 tag) {
+    // x is u16 so ANTIC F (320 wide) fills its full width like D/E fill theirs.
+    const u16 L = 4, R = static_cast<u16>(right - 4);
+    const u8  T = 6, B = static_cast<u8>(bottom - 6);
 
     g.clear(0);
 
@@ -104,12 +106,12 @@ static void draw_scene(G& g, u8 right, u8 bottom, u8 bpp, u8 a, u8 b, u8 c, u8 t
         g.fill_rect(12, static_cast<u16>(T + 4 + i * span), 40, barH, inks[i]);
 
     // Two crossing diagonals on the right (software Bresenham via plot).
-    const u8 d0 = static_cast<u8>(right - 90), d1 = static_cast<u8>(right - 12);
+    const u16 d0 = static_cast<u16>(right - 90), d1 = static_cast<u16>(right - 12);
     g.line(d0, static_cast<u8>(T + 6), d1, static_cast<u8>(B - 6), b);
     g.line(d1, static_cast<u8>(T + 6), d0, static_cast<u8>(B - 6), c);
 
     // Dotted accent across the lower band (plot every few pixels).
-    for (u8 x = static_cast<u8>(L + 4); x < static_cast<u8>(R - 4); x = static_cast<u8>(x + 6))
+    for (u16 x = static_cast<u16>(L + 4); x < static_cast<u16>(R - 4); x = static_cast<u16>(x + 6))
         g.plot(x, static_cast<u8>(B - 4), a);
 
     // A 16×16 chequer, packed at this mode's bpp, then blitted near the right.
@@ -124,7 +126,7 @@ static void draw_scene(G& g, u8 right, u8 bottom, u8 bpp, u8 a, u8 b, u8 c, u8 t
             const u8 sh = static_cast<u8>((ppb - 1 - (x % ppb)) * bpp);
             img[y * stride + x / ppb] = static_cast<u8>(img[y * stride + x / ppb] | (v << sh));
         }
-    g.blit(static_cast<u8>(R - 26), static_cast<u8>(T + 8), img, IMG_W, IMG_H);
+    g.blit(static_cast<u16>(R - 26), static_cast<u8>(T + 8), img, IMG_W, IMG_H);
 
     // Mode tag: `tag` small squares along the top (1 = D, 2 = E, 3 = F).
     for (u8 i = 0; i < tag; ++i)
@@ -153,7 +155,7 @@ static void activate(u8 mode) {
             Game::set_screen<ScreenF>([] {});
             palette_hires();
             gF.attach(Game::screen.canvas_base<ScreenF>());
-            draw_scene(gF, 255, 191, 1, 1, 1, 1, 3);
+            draw_scene(gF, 319, 191, 1, 1, 1, 1, 3);        // full 320-wide extent
             break;
     }
 }

--- a/demo/native_gfx.cpp
+++ b/demo/native_gfx.cpp
@@ -1,58 +1,45 @@
 // demo/native_gfx.cpp — Edge engine native (ANTIC bitmap) primitive-drawing demo.
 //
-// The baseline counterpart to demo/vbxe_gfx.cpp. It draws a static picture into a
-// stock-hardware ANTIC bitmap region using the SAME portable gfx API
-// (Game::gfx()): clear, fill_rect, hline/vline, line (Bresenham), plot and blit.
-// No VBXE — this is pure ANTIC/GTIA, so the canvas is a baseline `BitmapRegion`
-// drawn through its software `BitmapRegionView` (engine/display.h), and the gfx
-// dispatch selects the software path (has_blitter == false).
+// The baseline counterpart to demo/vbxe_gfx.cpp. It draws the same picture with the
+// portable engine bitmap primitives (clear, fill_rect, hline/vline, line, plot,
+// blit) on stock ANTIC/GTIA hardware — no VBXE. Press FIRE to cycle three native
+// bitmap modes that all share ONE screen buffer:
 //
-// Two builds from this one source (mode chosen by NATIVE_GFX_HIRES):
-//   * default          → BITMAP_E : 160×192, 4 colours (2bpp).  →  native_gfx.xex
-//   * -DNATIVE_GFX_HIRES → BITMAP_F : 320×192, hi-res 2-colour (1bpp).  → native_gfx_hires.xex
+//   ANTIC D  (GR.7) : 160×96  4-colour, 2 scanlines/line → full height, 3840 bytes
+//   ANTIC E         : 160×192 4-colour, 1 scanline/line             → 7680 bytes
+//   ANTIC F  (GR.8) : 320×192 hi-res 2-colour, 1 scanline/line      → 7680 bytes
 //
-// Expected result: a framed safe-area border, a column of colour-bar rectangles
-// (one bar in the hi-res build), two crossing diagonals, a dotted accent line and
-// a small chequered image — all steady (drawn once; nothing redraws it).
+// The shared buffer is sized for the largest screen (E/F, 7680 B); D uses only the
+// first half of it. A small row of 1/2/3 squares at the top tags the current mode.
+//
+// Each mode packs pixels differently (D/E are 2bpp, F is 1bpp), so Game::gfx() —
+// which binds ONE region type — can't serve all three. Instead the demo keeps one
+// engine::BitmapOps per mode and points each at its screen's canvas base; the
+// software primitive path (has_blitter == false) does the mode-correct packing.
+//
+// The 192-line E/F buffers (7680 B) cross a 4K scan boundary; the screen manager
+// front-aligns each canvas so no mode line straddles it (see engine/screen.h).
 //
 // ── Setup notes ───────────────────────────────────────────────────────────
 //  * Needs no VBXE. Run with BASIC DISABLED so the demo owns RAM. NTSC.
-//  * The view addresses pixels with u8 x/y, so a 320-wide mode (BITMAP_F) can only
-//    reach x ≤ 255 through the API — the hi-res build leaves the right ~64px blank.
+//  * The software view addresses pixels with u8 x, so the 320-wide F mode can only
+//    reach x ≤ 255 — its right ~64px stay blank by design.
 
 #include <stdint.h>
 
 #include <engine/core.h>
+#include <engine/gfx.h>
 #include <engine/platform/atari/platform.h>
 
 using engine::u8;
 using engine::u16;
 namespace M = atari;
 
-// ── Mode selection ─────────────────────────────────────────────────────────
-#ifdef NATIVE_GFX_HIRES
-constexpr auto kMode   = M::Mode::BITMAP_F;  // 320×192, 1bpp (hi-res, 2-colour)
-constexpr u8   kRight  = 255;                // u8 view x: cannot reach the full 320
-constexpr u8   kBpp    = 1;
-// Hi-res is 1bpp: every "ink" colour collapses to pixel value 1.
-constexpr u8   cInkA = 1, cInkB = 1, cInkC = 1;
-#else
-constexpr auto kMode   = M::Mode::BITMAP_E;  // 160×192, 2bpp (4-colour)
-constexpr u8   kRight  = 159;
-constexpr u8   kBpp    = 2;
-// 2bpp pixel values map to playfield registers: 1→COLPF0, 2→COLPF1, 3→COLPF2.
-constexpr u8   cInkA = 1, cInkB = 2, cInkC = 3;
-#endif
-// Full screen height. The 192-line buffer (7680 B) crosses a 4K scan boundary; the
-// engine's screen manager front-aligns the canvas so no mode line straddles it.
-constexpr u8 kHeight = 192;
-constexpr u8 kBottom = kHeight - 1;          // 191
-
-// ── Platform + game configuration ──────────────────────────────────────────
+// ── Platform + screens ─────────────────────────────────────────────────────
 //
-// Baseline graphics axis (no blitter). The gfx canvas is the screen's bitmap
-// region; GameConfig::bitmap_region gives Game::gfx() its software view type, and
-// set_screen() binds the view to the region's screen-memory slice.
+// Baseline graphics axis (no blitter). Three pure-bitmap screens share the buffer;
+// GameConfig declares no bitmap_region, so Core's own Game::gfx() stays unbound and
+// the demo drives its own per-mode BitmapOps below.
 using Platform = M::Platform<
     M::Machine::XL,
     M::RAM::Baseline,
@@ -60,84 +47,131 @@ using Platform = M::Platform<
     M::Sound::Mono,
     M::TV::NTSC>;
 
-struct ScreenBitmap {
-    using display = engine::DisplayLayout<engine::BitmapRegion<kMode, kHeight>>;
-};
+struct ScreenD { using display = engine::DisplayLayout<engine::BitmapRegion<M::Mode::BITMAP_D, 96>>;  };
+struct ScreenE { using display = engine::DisplayLayout<engine::BitmapRegion<M::Mode::BITMAP_E, 192>>; };
+struct ScreenF { using display = engine::DisplayLayout<engine::BitmapRegion<M::Mode::BITMAP_F, 192>>; };
+
 struct GameConfig {
-    using screens        = engine::ScreenSet<ScreenBitmap>;
-    using bitmap_region  = engine::BitmapRegion<kMode, kHeight>;
-    static constexpr u8 max_sprites    = 1;   // pure bitmap; sprites unused
+    using screens = engine::ScreenSet<ScreenD, ScreenE, ScreenF>;
+    static constexpr u8 max_sprites    = 1;   // unused; Core needs a non-zero sprite set
     static constexpr u8 sound_channels = 1;
 };
 using Game = engine::Core<Platform, GameConfig>;
 
-// ── Palette ────────────────────────────────────────────────────────────────
-//
-// set_color_pf field map: 0-3 = COLPF0-3, 4 = COLBK. Writes the OS colour shadow
-// the VBI copies to the hardware registers each frame.
-static void load_palette() {
-#ifdef NATIVE_GFX_HIRES
-    // ANTIC hi-res (mode F): lit pixels take their LUMINANCE from COLPF1 and their
-    // HUE from the background. Black background + high-luminance COLPF1 ⇒ crisp
-    // white ink. Set COLBK and COLPF2 (both candidate backgrounds) to black so the
-    // field is black regardless of the GTIA hi-res quirk.
+// One software bitmap-ops per mode (each owns only a view pointer).
+static engine::BitmapOps<Platform, engine::BitmapRegion<M::Mode::BITMAP_D, 96>>  gD;
+static engine::BitmapOps<Platform, engine::BitmapRegion<M::Mode::BITMAP_E, 192>> gE;
+static engine::BitmapOps<Platform, engine::BitmapRegion<M::Mode::BITMAP_F, 192>> gF;
+
+// ── Palettes (set_color_pf field map: 0-3 = COLPF0-3, 4 = COLBK) ───────────
+static void palette_4colour() {
+    Platform::hal::set_color_pf(4, 0x90);   // COLBK  : dark blue field  (value 0)
+    Platform::hal::set_color_pf(0, 0x0E);   // COLPF0 : white            (value 1)
+    Platform::hal::set_color_pf(1, 0x1A);   // COLPF1 : gold             (value 2)
+    Platform::hal::set_color_pf(2, 0x44);   // COLPF2 : red              (value 3)
+}
+static void palette_hires() {
+    // ANTIC hi-res (mode F): lit pixels take luminance from COLPF1 and hue from the
+    // background; black background + high-luminance COLPF1 ⇒ crisp white ink.
     Platform::hal::set_color_pf(4, 0x00);   // COLBK  : black field
     Platform::hal::set_color_pf(2, 0x00);   // COLPF2 : black (hi-res background hue)
     Platform::hal::set_color_pf(1, 0x0E);   // COLPF1 : white ink (luminance)
-#else
-    Platform::hal::set_color_pf(4, 0x90);   // COLBK  : dark blue field   (value 0)
-    Platform::hal::set_color_pf(0, 0x0E);   // COLPF0 : white             (value 1)
-    Platform::hal::set_color_pf(1, 0x1A);   // COLPF1 : gold              (value 2)
-    Platform::hal::set_color_pf(2, 0x44);   // COLPF2 : red               (value 3)
-#endif
+}
+
+// ── The picture ────────────────────────────────────────────────────────────
+//
+// Drawn with whichever mode's BitmapOps is active; geometry scales to the region's
+// height (`bottom`) and width (`right`). `bpp` packs the blit source; a, b, c are
+// the ink pixel values (in hi-res all three collapse to 1). `tag` (1..3) marks the
+// mode with that many small squares.
+template <typename G>
+static void draw_scene(G& g, u8 right, u8 bottom, u8 bpp, u8 a, u8 b, u8 c, u8 tag) {
+    const u8 L = 4, R = static_cast<u8>(right - 4), T = 6, B = static_cast<u8>(bottom - 6);
+
+    g.clear(0);
+
+    // Framed border, inset into the NTSC-safe area.
+    g.hline(L, R, T, a);
+    g.hline(L, R, B, a);
+    g.vline(L, T, B, a);
+    g.vline(R, T, B, a);
+
+    // Three colour bars down the left, spaced to the region height.
+    const u8 inks[3] = { a, b, c };
+    const u8 span = static_cast<u8>((B - T - 8) / 3);
+    const u8 barH = static_cast<u8>(span - 6);
+    for (u8 i = 0; i < 3; ++i)
+        g.fill_rect(12, static_cast<u16>(T + 4 + i * span), 40, barH, inks[i]);
+
+    // Two crossing diagonals on the right (software Bresenham via plot).
+    const u8 d0 = static_cast<u8>(right - 90), d1 = static_cast<u8>(right - 12);
+    g.line(d0, static_cast<u8>(T + 6), d1, static_cast<u8>(B - 6), b);
+    g.line(d1, static_cast<u8>(T + 6), d0, static_cast<u8>(B - 6), c);
+
+    // Dotted accent across the lower band (plot every few pixels).
+    for (u8 x = static_cast<u8>(L + 4); x < static_cast<u8>(R - 4); x = static_cast<u8>(x + 6))
+        g.plot(x, static_cast<u8>(B - 4), a);
+
+    // A 16×16 chequer, packed at this mode's bpp, then blitted near the right.
+    constexpr u8 IMG_W = 16, IMG_H = 16;
+    const u8 ppb    = static_cast<u8>(8 / bpp);
+    const u8 mask   = static_cast<u8>((1u << bpp) - 1);
+    const u8 stride = static_cast<u8>((IMG_W + ppb - 1) / ppb);
+    u8 img[IMG_H * 4] = {0};                // 4 = max stride (2bpp); 1bpp uses 2
+    for (u8 y = 0; y < IMG_H; ++y)
+        for (u8 x = 0; x < IMG_W; ++x) {
+            const u8 v  = static_cast<u8>(((x ^ y) >> 2) & mask);
+            const u8 sh = static_cast<u8>((ppb - 1 - (x % ppb)) * bpp);
+            img[y * stride + x / ppb] = static_cast<u8>(img[y * stride + x / ppb] | (v << sh));
+        }
+    g.blit(static_cast<u8>(R - 26), static_cast<u8>(T + 8), img, IMG_W, IMG_H);
+
+    // Mode tag: `tag` small squares along the top (1 = D, 2 = E, 3 = F).
+    for (u8 i = 0; i < tag; ++i)
+        g.fill_rect(static_cast<u16>(72 + i * 12), static_cast<u16>(T + 4), 8, 8, a);
+}
+
+// ── Mode activation ────────────────────────────────────────────────────────
+//
+// Switch the display to the screen for `mode`, set its palette, bind that mode's
+// BitmapOps to the screen's (front-aligned) canvas base, and draw the picture.
+static void activate(u8 mode) {
+    switch (mode) {
+        case 0:                                            // ANTIC D — 4-colour, half buffer
+            Game::set_screen<ScreenD>([] {});
+            palette_4colour();
+            gD.attach(Game::screen.canvas_base<ScreenD>());
+            draw_scene(gD, 159, 95, 2, 1, 2, 3, 1);
+            break;
+        case 1:                                            // ANTIC E — 4-colour, full buffer
+            Game::set_screen<ScreenE>([] {});
+            palette_4colour();
+            gE.attach(Game::screen.canvas_base<ScreenE>());
+            draw_scene(gE, 159, 191, 2, 1, 2, 3, 2);
+            break;
+        default:                                           // ANTIC F — hi-res, full buffer
+            Game::set_screen<ScreenF>([] {});
+            palette_hires();
+            gF.attach(Game::screen.canvas_base<ScreenF>());
+            draw_scene(gF, 255, 191, 1, 1, 1, 1, 3);
+            break;
+    }
+}
+
+static u8   g_mode      = 0;       // 0 = D, 1 = E, 2 = F
+static bool g_prev_fire = false;
+
+static void frame(const engine::Input& in) {
+    const bool fire = in.fire();
+    if (fire && !g_prev_fire) {                 // rising edge: advance to the next mode
+        g_mode = static_cast<u8>((g_mode + 1) % 3);
+        activate(g_mode);
+    }
+    g_prev_fire = fire;
 }
 
 int main() {
-    Game::init();          // baseline bring-up; set_screen binds the gfx canvas
-    load_palette();
-
-    auto& g = Game::gfx();
-
-    g.clear(0);            // background (pixel value 0)
-
-    // A framed border, inset into the NTSC-safe area.
-    constexpr u8 L = 4, R = kRight - 4, T = 6, B = kBottom - 6;
-    g.hline(L, R, T, cInkA);
-    g.hline(L, R, B, cInkA);
-    g.vline(L, T, B, cInkA);
-    g.vline(R, T, B, cInkA);
-
-    // Colour-bar rectangles down the left (fill_rect). In the 4-colour build the
-    // three bars cycle the playfield registers; in hi-res there is one ink bar.
-    const u8 bars[3] = { cInkA, cInkB, cInkC };
-    for (u8 i = 0; i < 3; ++i)
-        g.fill_rect(12, static_cast<u16>(T + 14 + i * 52), 40, 28, bars[i]);
-
-    // Two crossing diagonals on the right half (software Bresenham via plot).
-    const u8 dx0 = static_cast<u8>(kRight - 90), dx1 = static_cast<u8>(kRight - 12);
-    g.line(dx0, static_cast<u8>(T + 6), dx1, static_cast<u8>(B - 6), cInkB);
-    g.line(dx1, static_cast<u8>(T + 6), dx0, static_cast<u8>(B - 6), cInkC);
-
-    // A dotted accent line across the lower band (plot every few pixels).
-    for (u8 x = L + 4; x < R - 4; x = static_cast<u8>(x + 6))
-        g.plot(x, static_cast<u8>(B - 4), cInkA);
-
-    // A small 16×16 chequered image, packed at the region's bpp, then blitted.
-    // blit() expects source rows packed ceil(w / pixels_per_byte) bytes each, with
-    // the leftmost pixel in the high bits of a byte (BitmapRegionView::blit).
-    constexpr u8 IMG_W = 16, IMG_H = 16;
-    constexpr u8 ppb    = static_cast<u8>(8 / kBpp);
-    constexpr u8 mask   = static_cast<u8>((1u << kBpp) - 1);
-    constexpr u8 stride = static_cast<u8>((IMG_W + ppb - 1) / ppb);
-    u8 img[IMG_H * 4] = {0};               // 4 = max stride (BITMAP_E); F uses 2
-    for (u8 y = 0; y < IMG_H; ++y)
-        for (u8 x = 0; x < IMG_W; ++x) {
-            const u8 v  = static_cast<u8>(((x ^ y) >> 2) & mask);   // chequer
-            const u8 sh = static_cast<u8>((ppb - 1 - (x % ppb)) * kBpp);
-            img[y * stride + x / ppb] = static_cast<u8>(img[y * stride + x / ppb] | (v << sh));
-        }
-    g.blit(static_cast<u8>(R - 26), 26, img, IMG_W, IMG_H);
-
-    // Idle — the picture is static and persists (no sprites, nothing redraws it).
-    Game::run([](const auto&) {});
+    Game::init();        // baseline bring-up (initial screen is ScreenD)
+    activate(g_mode);    // draw the first mode
+    Game::run(frame);
 }

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -1,6 +1,6 @@
 # API Design
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 The user-facing API for the engine. This document describes what
 a game author writes. Internal engine implementation details are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 System design, component relationships, and the abstraction
 boundaries that make the engine portable across 6502 platforms

--- a/docs/CONSTRAINTS.md
+++ b/docs/CONSTRAINTS.md
@@ -1,6 +1,6 @@
 # Constraints
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Hardware budgets, platform targets, and non-negotiable rules that
 every design decision must respect.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Decisions made during design, with rationale. These explain the
 "why" behind architectural choices and document tradeoffs.

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # EDGE API Reference
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This reference is organized in two layers:
 

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -1,6 +1,6 @@
 # EDGE Atari Platform Guide
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This document describes the first concrete EDGE backend: the Atari 8-bit family.
 

--- a/documents/QUICK_START.md
+++ b/documents/QUICK_START.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This guide introduces EDGE from the engine author's point of view first, then shows the current concrete setup using the Atari backend.
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 # EDGE Engine Documentation
 
-> **Applies to EDGE v0.6.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 EDGE is a C++ engine for building games and interactive applications on constrained 6502-class systems.
 

--- a/engine/core.h
+++ b/engine/core.h
@@ -350,7 +350,7 @@ public:
             using Layout = typename S::display;
             constexpr u8 bidx = Layout::bitmap_region_index();
             if constexpr (bidx < Layout::region_count)
-                gfx_.attach(screen.buffer() + Layout::offset(bidx));
+                gfx_.attach(screen.template canvas_base<S>() + Layout::offset(bidx));
         }
     }
 

--- a/engine/display.h
+++ b/engine/display.h
@@ -348,6 +348,38 @@ struct DisplayLayout {
         return acc;
     }
 
+    // Front-pad (bytes) to insert before region 0's data so that, when the shared
+    // buffer is aligned to `page`, every `page`-sized scan boundary the screen data
+    // crosses lands exactly on a mode-line edge.
+    //
+    // The display hardware's scan-address counter can wrap within a `page`, so a mode
+    // line whose own bytes straddle a boundary fetches its tail from the page start —
+    // corruption a per-line address reload can't fix (it only reloads at line starts;
+    // the straddling line is already wrong). Shifting the canvas by this pad makes the
+    // boundary fall on a line start instead, so no line straddles. The page size and
+    // the reload mechanism are platform specifics supplied by the backend (the caller
+    // passes caps::screen_buffer_alignment). Returns 0 when no non-scroll screen
+    // region crosses a boundary:
+    // scroll regions reload the full address every line (crossings are moot) and
+    // overlay regions hold no screen bytes. Assumes a region crosses at most the
+    // first boundary after its start (true for buffers up to 2 pages — the baseline
+    // bitmap maximum). Used only when the buffer exceeds one page (single-page
+    // buffers are aligned to >= their size and never cross).
+    static constexpr u16 canvas_pad(u16 page) {
+        u16 off = 0;
+        for (u8 i = 0; i < region_count; ++i) {
+            const u16 ram = region_ram[i];
+            if (!region_is_overlay[i] && !region_is_scroll[i]) {
+                const u16 bpl = region_bytes_per_line[i];
+                const u16 b   = static_cast<u16>((off / page + 1) * page);  // first boundary > off
+                if (bpl != 0 && b < static_cast<u16>(off + ram))           // region straddles it
+                    return static_cast<u16>((page - (off % page)) % bpl);
+            }
+            off = static_cast<u16>(off + ram);
+        }
+        return 0;
+    }
+
     // The N-th region descriptor type, and its view type.
     template <u8 N>
     using region_at = pack_element_t<N, Regions...>;

--- a/engine/display.h
+++ b/engine/display.h
@@ -85,7 +85,10 @@ struct BitmapRegionView {
     static constexpr u8  bpp             = tr::bits_per_pixel(Mode);
     static constexpr u8  pixels_per_byte = static_cast<u8>(8 / bpp);
     static constexpr u8  pixel_mask      = static_cast<u8>((1u << bpp) - 1);
-    static constexpr u8  width           = bytes_per_line * pixels_per_byte;
+    // u16: a 1bpp mode is 8*bytes_per_line pixels wide (320 for a 40-byte line),
+    // which overflows u8. Coordinates are u16 to match the public BitmapOps API and
+    // to address the full width of the widest modes.
+    static constexpr u16 width           = static_cast<u16>(bytes_per_line) * pixels_per_byte;
     static constexpr u8  height          = Lines;
     static constexpr u16 length          = static_cast<u16>(bytes_per_line) * Lines;
 
@@ -93,15 +96,15 @@ struct BitmapRegionView {
     const u16* row_table = nullptr;   // null => shift-and-add row addressing
 
     // Byte offset of the start of scanline `y`.
-    u16 row_base(u8 y) const {
+    u16 row_base(u16 y) const {
         return row_table ? row_table[y]
-                         : static_cast<u16>(y) * bytes_per_line;
+                         : static_cast<u16>(y * bytes_per_line);
     }
 
     // Set one pixel to `color` (0..pixel_mask). Read-modify-write of the packed
     // byte; the leftmost pixel of a byte occupies the high bits.
-    void plot(u8 x, u8 y, u8 color) const {
-        u16 idx   = row_base(y) + (x / pixels_per_byte);
+    void plot(u16 x, u16 y, u8 color) const {
+        u16 idx   = static_cast<u16>(row_base(y) + x / pixels_per_byte);
         u8  shift = static_cast<u8>((pixels_per_byte - 1 - (x % pixels_per_byte)) * bpp);
         u8  keep  = static_cast<u8>(~(pixel_mask << shift));
         ptr[idx]  = static_cast<u8>((ptr[idx] & keep) |
@@ -109,8 +112,8 @@ struct BitmapRegionView {
     }
 
     // Read one pixel's colour value.
-    u8 point(u8 x, u8 y) const {
-        u16 idx   = row_base(y) + (x / pixels_per_byte);
+    u8 point(u16 x, u16 y) const {
+        u16 idx   = static_cast<u16>(row_base(y) + x / pixels_per_byte);
         u8  shift = static_cast<u8>((pixels_per_byte - 1 - (x % pixels_per_byte)) * bpp);
         return static_cast<u8>((ptr[idx] >> shift) & pixel_mask);
     }
@@ -127,9 +130,9 @@ struct BitmapRegionView {
     // Horizontal line from x1..x2 inclusive on scanline y. Pixel-wise for
     // correctness; a whole-byte run with masked endpoints is a future
     // optimisation (API_DESIGN.md "Bitmap Drawing").
-    void hline(u8 x1, u8 x2, u8 y, u8 color) const {
-        if (x2 < x1) { u8 t = x1; x1 = x2; x2 = t; }
-        for (u8 x = x1; ; ++x) {
+    void hline(u16 x1, u16 x2, u16 y, u8 color) const {
+        if (x2 < x1) { u16 t = x1; x1 = x2; x2 = t; }
+        for (u16 x = x1; ; ++x) {
             plot(x, y, color);
             if (x == x2) break;
         }
@@ -137,14 +140,14 @@ struct BitmapRegionView {
 
     // Blit a w×h block of packed source pixels (same bpp as this mode) to
     // (x, y). `src` rows are packed ceil(w / pixels_per_byte) bytes each.
-    void blit(u8 x, u8 y, const u8* src, u8 w, u8 h) const {
+    void blit(u16 x, u16 y, const u8* src, u8 w, u8 h) const {
         const u8 src_stride = static_cast<u8>((w + pixels_per_byte - 1) / pixels_per_byte);
         for (u8 r = 0; r < h; ++r) {
             const u8* srow = src + static_cast<u16>(r) * src_stride;
             for (u8 c = 0; c < w; ++c) {
                 u8 sh = static_cast<u8>((pixels_per_byte - 1 - (c % pixels_per_byte)) * bpp);
                 u8 col = static_cast<u8>((srow[c / pixels_per_byte] >> sh) & pixel_mask);
-                plot(static_cast<u8>(x + c), static_cast<u8>(y + r), col);
+                plot(static_cast<u16>(x + c), static_cast<u16>(y + r), col);
             }
         }
     }

--- a/engine/gfx.h
+++ b/engine/gfx.h
@@ -76,7 +76,7 @@ public:
             Platform::hal::overlay_bitmap_plot(x, y, color);
         } else {
             static_assert(has_software_view, "baseline BitmapOps needs a bitmap Region");
-            view_.plot(static_cast<u8>(x), static_cast<u8>(y), color);
+            view_.plot(x, y, color);
         }
     }
 
@@ -88,8 +88,7 @@ public:
             Platform::hal::overlay_bitmap_fill_rect(lo, y, len, 1, color);
         } else {
             static_assert(has_software_view, "baseline BitmapOps needs a bitmap Region");
-            view_.hline(static_cast<u8>(x1), static_cast<u8>(x2),
-                        static_cast<u8>(y), color);
+            view_.hline(x1, x2, y, color);
         }
     }
 
@@ -102,7 +101,7 @@ public:
         } else {
             static_assert(has_software_view, "baseline BitmapOps needs a bitmap Region");
             for (u16 y = lo; y < static_cast<u16>(lo + len); ++y)
-                view_.plot(static_cast<u8>(x), static_cast<u8>(y), color);
+                view_.plot(x, y, color);
         }
     }
 
@@ -113,8 +112,8 @@ public:
         } else {
             static_assert(has_software_view, "baseline BitmapOps needs a bitmap Region");
             for (u16 r = 0; r < h; ++r)
-                view_.hline(static_cast<u8>(x), static_cast<u8>(x + w - 1),
-                            static_cast<u8>(y + r), color);
+                view_.hline(x, static_cast<u16>(x + w - 1),
+                            static_cast<u16>(y + r), color);
         }
     }
 
@@ -153,8 +152,7 @@ public:
             Platform::hal::overlay_bitmap_blit(x, y, src, w, h);
         } else {
             static_assert(has_software_view, "baseline BitmapOps needs a bitmap Region");
-            view_.blit(static_cast<u8>(x), static_cast<u8>(y), src,
-                       static_cast<u8>(w), static_cast<u8>(h));
+            view_.blit(x, y, src, static_cast<u8>(w), static_cast<u8>(h));
         }
     }
 

--- a/engine/screen.h
+++ b/engine/screen.h
@@ -156,12 +156,31 @@ public:
         while (p < n && p < caps::screen_buffer_alignment) p <<= 1;
         return p;
     }
-    static constexpr u16 buffer_align =
-        buffer_size <= caps::screen_buffer_alignment ? pow2_ceil(buffer_size) : u16{1};
-    // A single-page buffer aligned to >= its own size cannot straddle a boundary.
+    // A multi-page buffer cannot fit in one alignment boundary, so it WILL cross. We
+    // page-align it (to the alignment boundary) and front-shift each screen's canvas
+    // by DisplayLayout::canvas_pad so the crossing lands on a mode-line edge — see
+    // crosses_page / canvas_pad_for below. Single-page buffers are aligned to >= their
+    // own size and never cross, so they keep the smallest such power-of-two alignment.
+    // A platform with alignment <= 1 declares no scan boundary, so nothing straddles
+    // (the per-line reload alone suffices); only a real boundary that the buffer
+    // exceeds forces a crossing.
+    static constexpr bool crosses_page =
+        caps::screen_buffer_alignment > 1 && buffer_size > caps::screen_buffer_alignment;
+    static constexpr u16  buffer_align =
+        crosses_page ? caps::screen_buffer_alignment : pow2_ceil(buffer_size);
     static_assert(buffer_size > caps::screen_buffer_alignment || buffer_align >= buffer_size,
                   "single-page screen buffer must be aligned to >= its size to keep "
                   "every mode line within one screen-buffer alignment boundary");
+
+    // Per-screen front pad that aligns this screen's 4K crossing(s) to mode-line
+    // edges (0 unless the shared buffer spans multiple pages). The buffer reserves
+    // `pad_slack` spare bytes at the front so the shifted canvas still fits.
+    template <typename S>
+    static constexpr u16 canvas_pad_for =
+        crosses_page ? S::display::canvas_pad(caps::screen_buffer_alignment) : u16{0};
+    // Pad is (alignment % bytes_per_line) < bytes_per_line; every baseline mode line
+    // is <= 64 bytes, so 64 spare bytes always cover it.
+    static constexpr u16 pad_slack = crosses_page ? u16{64} : u16{0};
 
     // Switch to screen S: build its display program against the real buffer base
     // (the backend builder inserts any backend-specific reload instructions),
@@ -175,10 +194,11 @@ public:
         // so bind_scroll_map()/apply_scroll() patch the same program the display
         // hardware executes.
         auto& dl = program_for<S>();
-        dl.build(addr(screen_buffer_), addr(&dl.bytes[0]));
+        u8* const canvas = canvas_base<S>();
+        dl.build(addr(canvas), addr(&dl.bytes[0]));
 
         // Rebind this screen's region views to their buffer slices.
-        views_.template for_screen<S>().set_base(screen_buffer_);
+        views_.template for_screen<S>().set_base(canvas);
 
         // Program the display. Blank DMA and install the program in all cases.
         Platform::hal::display_dma_disable();
@@ -311,6 +331,13 @@ public:
     u16       active_dl_size() const { return active_dl_size_; }
     u8*       buffer()               { return screen_buffer_; }
 
+    // Base of screen S's canvas: the buffer base front-shifted by its page-crossing
+    // alignment pad (0 unless the shared buffer spans multiple pages). set_screen()
+    // builds the display list and binds the views against this; the gfx attach in
+    // engine/core.h must use it too so its writes match what the hardware fetches.
+    template <typename S>
+    u8* canvas_base() { return screen_buffer_ + canvas_pad_for<S>; }
+
 private:
     static u16 addr(const void* p) {
         return static_cast<u16>(reinterpret_cast<uintptr_t>(p));
@@ -334,7 +361,7 @@ private:
         static_cast<DP*>(p)->patch_scroll(base, width, col, row);
     }
 
-    alignas(buffer_align) u8 screen_buffer_[buffer_size] = {};
+    alignas(buffer_align) u8 screen_buffer_[buffer_size + pad_slack] = {};
     typename detail::screen_views_of<screens>::type views_;
 
     u8*       active_dl_      = nullptr;   // last built list (points into a static)

--- a/engine/version.h
+++ b/engine/version.h
@@ -10,8 +10,8 @@
 // EDGE follows Semantic Versioning (https://semver.org/): MAJOR.MINOR.PATCH.
 
 #define EDGE_VERSION_MAJOR 0
-#define EDGE_VERSION_MINOR 6
+#define EDGE_VERSION_MINOR 7
 #define EDGE_VERSION_PATCH 0
-#define EDGE_VERSION_STRING "0.6.0"
+#define EDGE_VERSION_STRING "0.7.0"
 
 #endif // ENGINE_VERSION_H

--- a/tests/backends/atari/test_atari_display.cpp
+++ b/tests/backends/atari/test_atari_display.cpp
@@ -139,6 +139,36 @@ static void test_4k_crossing() {
     CHECK(read16(g_cross_dl.bytes, p1) == 0x5018);
 }
 
+// ── canvas_pad front-aligns a >4K bitmap so no mode line straddles a boundary ──
+//
+// The LMS above reloads the address at the line that ENTERS the new page, but the
+// PREVIOUS line ($4028-based: line 101 = $4FF0..$5017) straddles the boundary, and
+// the scan-address counter wraps within a page, so that line fetches its tail from
+// the page start — visible corruption a per-line reload cannot fix. The screen
+// manager front-shifts the canvas by DisplayLayout::canvas_pad so the boundary lands
+// on a line start instead. For Mode E (40 bytes/line) over a page-aligned buffer the
+// pad is 4096 % 40 = 16, putting line 102 exactly on $5000 (4096 = 102*40 + 16) and
+// leaving line 101 wholly inside page $4000. (Wired through ScreenManager::
+// canvas_base<S>(); exercised end-to-end on hardware by demo/native_gfx.cpp.)
+static atari::DisplayProgram<CrossLayout> g_aligned_dl;
+
+static void test_canvas_pad_alignment() {
+    constexpr u16 page = 4096;
+    CHECK(CrossLayout::canvas_pad(page) == 16);        // 4096 % 40
+    CHECK(TextLayout::canvas_pad(page) == 0);          // fits one page → no shift
+
+    // Page-aligned buffer, canvas front-shifted by the pad.
+    constexpr u16 canvas = static_cast<u16>(0x4000 + CrossLayout::canvas_pad(page));  // $4010
+    CHECK((0x5000 - canvas) % 40 == 0);                // boundary on a 40-byte edge
+
+    g_aligned_dl.build(canvas, canvas);
+    CHECK(g_aligned_dl.lms_count == 2);
+    CHECK(read16(g_aligned_dl.bytes, g_aligned_dl.region_lms_pos[0]) == canvas);
+    // Crossing LMS now reloads $5000 exactly — line 102's start — so the straddle
+    // that $5018 (the unaligned case above) implied for line 101 is gone.
+    CHECK(read16(g_aligned_dl.bytes, g_aligned_dl.lms_pos[1]) == 0x5000);
+}
+
 // ── No crossing when a region fits within a 4K page ────────────────────
 
 static atari::DisplayProgram<TextLayout> g_nocross_dl;
@@ -268,6 +298,7 @@ static void test_overlay_below_antic() {
 
 int main() {
     test_4k_crossing();
+    test_canvas_pad_alignment();
     test_no_crossing();
     test_set_screen_bytes();
     test_pure_overlay();


### PR DESCRIPTION
This pull request introduces EDGE v0.7.0, focusing on a major new demo for native ANTIC bitmap graphics, important baseline graphics fixes, and several documentation updates. The most significant addition is the `native_gfx` demo, which exercises the engine's software bitmap drawing primitives on stock ANTIC/GTIA hardware, supporting multiple bitmap modes over a shared buffer. The release also fixes a critical graphics alignment bug and updates documentation to reflect the new version.

**New Demo and Features:**

* Added a native (ANTIC bitmap) primitive-drawing demo, `native_gfx`, which demonstrates the engine’s software bitmap primitives (`clear`, `fill_rect`, `hline`, `vline`, `line`, `plot`, `blit`) on stock ANTIC/GTIA hardware, cycling through three native bitmap modes (ANTIC D/E/F) sharing one screen buffer. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R48) [[2]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cR220-R253) [[3]](diffhunk://#diff-4c3600e6ec6763f2a99e03628d20179e00a7d409dd65de6af9176e4a2d4127d1R1-R179) [[4]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR379-R389) [[5]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR519)

**Graphics System Improvements and Fixes:**

* Baseline `BitmapRegionView` coordinates are now widened to `u16`, allowing full-width drawing in 320-pixel-wide hi-res modes (ANTIC F) and removing previous truncation issues.
* Fixed a long-standing bug where full-screen native bitmaps (>4KB) could have a corrupt row due to scan-boundary straddle; screen buffers are now front-aligned to prevent this.

**Documentation and Versioning:**

* Updated all documentation and demo READMEs to reference EDGE v0.7.0. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL3-R3) [[3]](diffhunk://#diff-0237b3d7fe1c8fa8e17881af69a003519f78956a5040d9e04bdbc9017125e042L3-R3) [[4]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L3-R3) [[5]](diffhunk://#diff-5aa90ada9e14c6a3188620b196900b68fed5edc6e4e8f192a6e29d0384fd3c6dL3-R3) [[6]](diffhunk://#diff-1ea199fcea0d29740c9df691b542888c877d1c76a4fda36b130b92c9039f5433L3-R3) [[7]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cL3-R3) [[8]](diffhunk://#diff-38612f5904fb8c3dc3283d855aa486c7bc5ce02c15edd6b90be1e8424fcf0b99L3-R3) [[9]](diffhunk://#diff-b1b484de02794082600e79848bdf85fed4c26408fc1b36fb451beb48866d64d7L3-R3) [[10]](diffhunk://#diff-48492ab448322dc75b3414244c16ea64f9498bb9185bff4a0cb5c1d26c991306L3-R3)
* Added v0.7.0 to the changelog and updated the version links. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R48) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR545)

**Build System:**

* Integrated the new `native_gfx` demo into the CMake build, ensuring it is built and available alongside other demos. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR379-R389) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR519)

**Internal Engine Improvements:**

* Minor core API change: when attaching a bitmap region, now uses `canvas_base<S>()` for correct buffer alignment.

These changes together significantly improve the engine’s native graphics capabilities and correctness, and provide a concrete demonstration of baseline bitmap drawing on real hardware.