### PR TITLE
Uber tank net demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
   [`docs/HANDOFF_netstream_downstream_pacing.md`](docs/HANDOFF_netstream_downstream_pacing.md).
 - **Realtime Netstream lane validated on physical FujiNet hardware** (2026-06-27, via
   the `tank_net` demo) — previously emulator-only. ADR-033 and the platform docs updated.
+  The networked demo **requires fujinet-firmware v1.6.2 or greater** (whole-frame-aligned
+  drop-oldest; older firmware desyncs the unframed stream under load).
 
 ## [0.7.0] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+### Added
+- **Per-demo realtime packet size** (`GameConfig::realtime_packet_bytes`, default 16)
+  and a **build-overridable netstream nominal baud** (`EDGE_NETSTREAM_NOMINAL_BAUD`,
+  default 31250 → AUDF3=21; e.g. 49700 selects the ~49.7k row). The Atari netstream HAL
+  now honours any packet size up to the 128-byte NS ring (was a fixed 16).
+
+### Changed
+- **`tank_net` packs all adversaries into one 32-byte realtime packet per tick**
+  (downstream rate `--hz` instead of `3 × --hz`) — the mitigation for a downstream
+  pacing/backpressure issue, paired with a fujinet-firmware frame-aligned drop-oldest +
+  `netstream_rx_depth` fix. Diagnosed with a seq-echo timing instrument; see
+  [`docs/HANDOFF_netstream_downstream_pacing.md`](docs/HANDOFF_netstream_downstream_pacing.md).
+- **Realtime Netstream lane validated on physical FujiNet hardware** (2026-06-27, via
+  the `tank_net` demo) — previously emulator-only. ADR-033 and the platform docs updated.
+
 ## [0.7.0] - 2026-06-24
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,11 @@ if(EDGE_BUILD_DEMO)
     if(DEFINED EDGE_NET_PEER_PORT)
         target_compile_definitions(atari_tank_net_demo PRIVATE EDGE_NET_PEER_PORT=${EDGE_NET_PEER_PORT})
     endif()
+    # Realtime-lane nominal baud override (must be an exact BaudTable nominal); default
+    # 31250. e.g. -DEDGE_NETSTREAM_NOMINAL_BAUD=49700 selects the ~49.7k row (AUDF3=11).
+    if(DEFINED EDGE_NETSTREAM_NOMINAL_BAUD)
+        target_compile_definitions(atari_tank_net_demo PRIVATE EDGE_NETSTREAM_NOMINAL_BAUD=${EDGE_NETSTREAM_NOMINAL_BAUD})
+    endif()
 
     # Aggregate convenience target: build every always-available demo .xex with
     # one `cmake --build <dir> --target demos`. This is the stable name the

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Networking (`engine/net.h`):
 - **Realtime lane** (`Game::net.realtime`) wired to the FujiNet Netstream path
   (EDGE-owned assembly, fixed 16-byte packets, no wire framing — the consumer
   reassembles units from the byte stream). The data path is validated against the
-  fujinet-pc emulator stack (NetSIO + Altirra + Docker UDP peer, Mode B); it is
-  **not yet validated on physical FujiNet hardware** (see `docs/DECISIONS.md` ADR-033)
+  fujinet-pc emulator stack (NetSIO + Altirra + Docker UDP peer, Mode B) **and on
+  physical FujiNet hardware** (2026-06-27, via the `tank_net` demo; see
+  `docs/DECISIONS.md` ADR-033)
 - a build-time TX-clock override `EDGE_NETSTREAM_FLAGS` exists for hardware bring-up
   (default `0x26` external clock = emulator-validated; `0x22` = internal/local POKEY
   clock, **experimental, not yet validated**)
@@ -77,9 +78,9 @@ Networking (`engine/net.h`):
 Planned or intentionally deferred:
 
 - broader non-Atari backends
-- physical FujiNet hardware validation of the realtime lane
 - realtime-lane wire framing / resync / checksum / sequence (boundaries are
-  currently implicit and cannot recover from lost bytes)
+  currently implicit and cannot recover from lost bytes — so firmware drops must be
+  whole-frame aligned, as validated with the tank_net demo)
 - a real gameplay demo over the realtime lane
 
 ## Example program shape

--- a/demo/README.md
+++ b/demo/README.md
@@ -217,41 +217,48 @@ complete), ~5.6 KB on the wire. `EDGE_TANK_NET_HOST`/`PORT` are baked into the R
 The live build still has no collision/terrain/bullets/realtime-lane/gameplay
 networking; the session is only used to load assets before gameplay.
 
-# Networked two-tank demo (`atari_tank_net_demo.xex`)
+# Networked multi-tank demo (`atari_tank_net_demo.xex`)
 
 A "bigger tank demo" ([`tank_net/`](tank_net/)): the same Stage-4 joystick tank
-(local player) **plus a second, network-driven adversary tank** whose authoritative
+(local player) **plus three network-driven adversary tanks** whose authoritative
 state (world position, heading, speed) is streamed from a Python UDP server at
-**~10 Hz over the realtime lane** (`Game::net.realtime`, fixed 16-byte packets). The
+**~10 Hz over the realtime lane** (`Game::net.realtime`). The
 link is **bidirectional** — the Atari streams its own tank state back so the
-server's adversary AI can **react (chase / avoid)**. It reuses the original tank's
-motion/camera/shapes/assets verbatim (no fork); only the network glue and the second
-sprite are new.
+server's adversary AI can **react (chase / avoid / patrol)**. It reuses the original
+tank's motion/camera/shapes/assets verbatim (no fork); only the network glue and the
+extra sprites are new.
 
-Between the 10 Hz snapshots the client **dead-reckons** the adversary forward with
+All three adversaries are packed into **one 32-byte packet per tick** (status bits
+mark which records are live), so the downstream packet rate is `--hz`, not `3 × --hz`
+— the mitigation for a firmware pacing/backpressure issue that surfaced at higher
+rates (the lane carries a per-demo 32-byte frame via `GameConfig::realtime_packet_bytes`;
+see [`docs/HANDOFF_netstream_downstream_pacing.md`](../docs/HANDOFF_netstream_downstream_pacing.md)).
+
+Between the 10 Hz snapshots the client **dead-reckons** every adversary forward with
 its last-known heading + speed (the same Q12.4 motion table the player uses) and
 **snaps** to each new authoritative position (ADR-015: the host sends state, not
 input). The server mirrors that motion model, so the snaps are visually invisible.
 The snap site is the marked seam for a future ease-in interpolation.
 
-**Two tanks, no multiplexer.** The player (slot 0) and adversary (slot 1) are pinned
-to dedicated hardware players via the engine **direct-bind** mode
+**Four tanks, no multiplexer.** The player (slot 0) and the three adversaries (slots
+1–3) are pinned to dedicated hardware players via the engine **direct-bind** mode
 (`GameConfig::sprite_binding = engine::SpriteBinding::Direct`; see
-[`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) "Sprites"). A chasing adversary
-crosses the player in Y constantly; the multiplexer's per-frame Y-sort would swap
-their players/colours for a frame, so direct binding (fixed slot→player) is required
-here, not the multiplexer.
+[`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) "Sprites"). 1 player + 3 adversaries
+== the 4 hardware players, so direct-bind stays a single zone. Chasing adversaries
+cross the player in Y constantly; the multiplexer's per-frame Y-sort would swap their
+players/colours for a frame, so direct binding (fixed slot→player) is required here,
+not the multiplexer.
 
-The local player starts in the **upper-right** of the world; the adversary starts
-**lower-left** (the server's `--start`). The player has **wall collision**: GTIA
+The local player starts in the **upper-right** of the world; the adversaries start in
+the other corners (the server's `--starts`). The player has **wall collision**: GTIA
 player→playfield collision (P0PF) is read each frame, and a hit on the white wall
 colour (COLPF0) snaps the player back to its last wall-free position. This is
 reliable specifically because of direct binding — logical slot 0 is always hardware
-player 0, so the P0PF mask is never reassigned by a multiplexer. (The adversary is
-not wall-collided; its motion is the server's authority.)
+player 0, so the P0PF mask is never reassigned by a multiplexer. (The adversaries are
+not wall-collided; their motion is the server's authority.)
 
-> The realtime lane is **emulator-validated only** (Altirra + NetSIO + Docker peer),
-> not yet physical-FujiNet validated — this demo is a prototype for that environment.
+> The realtime lane is validated on the emulator stack (Altirra + NetSIO + Docker peer)
+> **and on physical FujiNet hardware** (2026-06-27, this demo).
 
 ## Build
 
@@ -269,11 +276,15 @@ Without `EDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON` the realtime HAL is the **stu
 ## Server (Python stdlib only)
 
 ```sh
-python3 tools/net/edge_tank_adversary.py --mode chase --hz 10 --start 8,376 --decode
-#   --mode chase|avoid|patrol   --speed <steps/frame>   --speed-scale <EDGE_TANK_SPEED_SCALE>
+python3 tools/net/edge_tank_adversary.py --hz 10 --decode
+#   --count <N>                 number of adversaries (default 3 = the demo's kAdvCount)
+#   --modes chase,avoid,patrol  per-adversary AI (falls back to --mode for extras)
+#   --starts 8,376;624,376;624,16   per-adversary start x,y (falls back to --start)
+#   --speed <steps/frame>   --speed-scale <EDGE_TANK_SPEED_SCALE>
 ```
 
-The server learns the Atari's address from its first inbound packet (or pass
+By default the three adversaries run **mixed AI** (chase / avoid / patrol) from three
+corners. The server learns the Atari's address from its first inbound packet (or pass
 `--target-host/--target-port`). Keep `--speed-scale` equal to the demo's
 `EDGE_TANK_SPEED_SCALE` (default 3) so the server's motion matches the client's
 dead reckoning. See [`tools/net/README.md`](../tools/net/README.md) and the Mode B
@@ -284,13 +295,13 @@ network at `172.30.0.2:9000`).
 
 | Observation | Proves |
 |---|---|
-| Two distinctly-coloured tanks (brassy player, red adversary) | direct-bind: slot 0→player 0, slot 1→player 1 |
-| The adversary moves under server control, smooth between the 10 Hz updates | dead-reckon fills the ~6 inter-packet frames |
-| Its silhouette matches its heading as it turns | heading→silhouette on the received state |
-| Driving the player makes the adversary chase/avoid | bidirectional link (server consumes the Atari's TX) |
-| The adversary crosses the player in Y with **no colour flip** | direct binding, not the Y-sort multiplexer |
+| Four distinctly-coloured tanks (brassy player; pink/purple/cyan adversaries) | direct-bind: slot i→player i for slots 0–3 |
+| Each adversary moves under server control, smooth between the 10 Hz updates | per-adversary dead-reckon fills the ~6 inter-packet frames |
+| Their silhouettes match their headings as they turn | heading→silhouette on each received state |
+| Driving the player makes the adversaries chase/avoid/patrol | bidirectional link + per-adversary AI (server consumes the Atari's TX) |
+| Adversaries cross the player (and each other) in Y with **no colour flip** | direct binding, not the Y-sort multiplexer |
 | Driving the player into a wall stops it; it never passes through | GTIA P0PF wall collision (white/COLPF0) + revert |
-| Adversary leaves the viewport → hidden; re-enters at the right spot | drawn in the player's camera frame |
+| An adversary leaves the viewport → hidden; re-enters at the right spot | each drawn in the player's camera frame |
 | Red border when built without the netstream flag / with no peer | stub-HAL / no-transport indication |
 
 # Native bitmap primitive-drawing demo (`native_gfx.xex`)

--- a/demo/README.md
+++ b/demo/README.md
@@ -259,6 +259,11 @@ not wall-collided; their motion is the server's authority.)
 
 > The realtime lane is validated on the emulator stack (Altirra + NetSIO + Docker peer)
 > **and on physical FujiNet hardware** (2026-06-27, this demo).
+>
+> **Requires fujinet-firmware v1.6.2 or greater** — the downstream path depends on the
+> firmware's whole-frame-aligned drop-oldest (added in 1.6.2). Older firmware drops
+> individual bytes from the unframed stream and permanently desyncs the fixed-size
+> deframer under load.
 
 ## Build
 

--- a/demo/tank_net/adversary_net.h
+++ b/demo/tank_net/adversary_net.h
@@ -24,32 +24,45 @@ using engine::u8;
 using engine::u16;
 using engine::i16;
 
-// ── Wire packet — fixed 16 bytes, the realtime lane's opaque unit ──────────────
+// ── Wire packet — fixed 32 bytes, the realtime lane's opaque unit ──────────────
 //
-// The demo's private interpretation of the lane's fixed 16-byte packet (NOT the
-// EDGE Netstream wire format). Explicit u8 fields => no padding, no alignment or
-// endianness assumptions; multi-byte fields are little-endian byte pairs. ONE
-// layout, two directions distinguished by `type`:
-//   type 0  server -> client : adversary state snapshot
-//   type 1  client -> server : local-player state (so the server's adversary AI
-//                              can react — chase/avoid — and learn our address)
-struct TankPacket16 {
-    u8 magic;            //  0  0xAD — reject foreign UDP
-    u8 version;          //  1  0x01
-    u8 type;             //  2  0 = adversary (S->C), 1 = player (C->S)
-    u8 status;           //  3  bit0 have_state / alive
-    u8 seq_lo, seq_hi;   //  4..5  u16 LE sequence (loss / reorder / stale detect)
-    u8 x_lo, x_hi;       //  6..7  world_x nominal px, u16 LE (0..639)
-    u8 y_lo, y_hi;       //  8..9  world_y nominal px, u16 LE (0..383)
-    u8 heading;          // 10     0..15 (drives silhouette + motion vector)
-    u8 speed;            // 11     dead-reckon move steps per frame (0 = stopped)
-    u8 reserved[3];      // 12..14
-    u8 pattern;          // 15     0x5A sanity
+// The demo's private interpretation of the lane's fixed 32-byte packet (NOT the
+// EDGE Netstream wire format; the demo widens the lane via
+// GameConfig::realtime_packet_bytes). Explicit u8 fields => no padding, no alignment
+// or endianness assumptions; multi-byte fields are little-endian byte pairs.
+//
+// ONE combined packet per tick carries ALL adversaries — this packs 3 adversaries
+// into a single S->C packet (10 pkt/s) instead of one packet each (30 pkt/s), the
+// downstream-overload mitigation. ONE layout, two directions by `type`:
+//   type 0  server -> client : up to kMaxAdv adversary records; `status` bit i = rec[i] live.
+//   type 1  client -> server : local-player state in rec[0] (status bit0 = have_state),
+//                              plus the timing-echo fields (see make_player_packet).
+struct AdvRecord {       // 6 bytes — one tank's authoritative state
+    u8 x_lo, x_hi;       //  world_x nominal px, u16 LE (0..639)
+    u8 y_lo, y_hi;       //  world_y nominal px, u16 LE (0..383)
+    u8 heading;          //  0..15 (drives silhouette + motion vector)
+    u8 speed;            //  dead-reckon move steps per frame (0 = stopped)
 };
-static_assert(sizeof(TankPacket16) == 16, "TankPacket16 must be exactly 16 bytes");
+static_assert(sizeof(AdvRecord) == 6, "AdvRecord must be exactly 6 bytes");
+
+inline constexpr u8 kMaxAdv = 3;          // adversary records per combined packet
+
+struct TankPacket32 {
+    u8 magic;                  //  0      0xAD — reject foreign UDP
+    u8 version;                //  1      0x02 (combined-packet format)
+    u8 type;                   //  2      0 = adversary (S->C), 1 = player (C->S)
+    u8 status;                 //  3      S->C: bit i = rec[i] live; C->S: bit0 have_state
+    u8 seq_lo, seq_hi;         //  4..5   u16 LE sequence (loss / reorder / stale detect)
+    AdvRecord rec[kMaxAdv];    //  6..23  adversary records (C->S: rec[0] = player)
+    u8 echo_seq_lo, echo_seq_hi;  // 24..25  C->S: adv[0] last-applied seq (timing echo)
+    u8 echo_flags;             // 26     C->S: client health byte (RX-overflow events)
+    u8 reserved[4];            // 27..30
+    u8 pattern;                // 31     0x5A sanity
+};
+static_assert(sizeof(TankPacket32) == 32, "TankPacket32 must be exactly 32 bytes");
 
 inline constexpr u8 kMagic   = 0xAD;
-inline constexpr u8 kVersion = 0x01;
+inline constexpr u8 kVersion = 0x02;
 inline constexpr u8 kPattern = 0x5A;
 inline constexpr u8 kTypeAdversary = 0;   // server -> client
 inline constexpr u8 kTypePlayer    = 1;   // client -> server
@@ -72,37 +85,49 @@ inline i16 seq_delta(u16 a, u16 b) {
 struct Adversary {
     tank::TankState s;      // reuse hull-centre Q12.4 world pos + heading
     u8  speed;              // last-known dead-reckon speed (steps/frame)
-    u16 last_seq;           // last accepted snapshot sequence
     u8  have_state;         // 0 until the first valid snapshot
 };
 
-// Apply an authoritative snapshot: validate, drop stale/foreign, else SNAP the
-// adversary onto the server's position and adopt its heading + speed.
+// Shared packet-level sequence gate. ONE combined packet now carries all adversaries,
+// so stale/dup detection is per-PACKET (not per-adversary): the whole snapshot is
+// accepted or dropped together.
+struct AdvRxState {
+    u16 last_seq;           // last accepted combined-packet sequence
+    u8  have_state;         // 0 until the first valid packet
+};
+
+// Apply a combined authoritative snapshot: validate, drop stale/foreign, else SNAP
+// each LIVE adversary (status bit i) onto the server's position and adopt heading +
+// speed. Returns true if the packet was applied (seq strictly newer).
 //
 // SNAP rationale (prototype): cheap and deterministic (no 6502 divide); if the
 // server's speed/heading match this client's motion_vector magnitudes, the snap
 // only corrects accumulated rounding, not a visible teleport.
-// TODO(interp): to hide snap jumps under packet loss, instead of writing world_*_q4
-// directly here, store a correction TARGET and ease world_*_q4 toward it over the
-// next ~6 frames in adv_dead_reckon (needs a per-frame fractional delta = a divide).
-inline bool adv_apply_packet(Adversary& adv, const TankPacket16& p) {
+inline bool adv_apply_packet(Adversary* adv, u8 count, AdvRxState& rx,
+                             const TankPacket32& p) {
     if (p.magic != kMagic || p.type != kTypeAdversary) return false;
     const u16 seq = rd16(p.seq_lo, p.seq_hi);
-    if (adv.have_state && seq_delta(seq, adv.last_seq) <= 0) return false;  // stale/dup
+    if (rx.have_state && seq_delta(seq, rx.last_seq) <= 0) return false;  // stale/dup
 
-    const u16 x = rd16(p.x_lo, p.x_hi);
-    const u16 y = rd16(p.y_lo, p.y_hi);
-    adv.s.world_x_q4 = static_cast<i16>(static_cast<i16>(x) << 4);   // SNAP (interp seam)
-    adv.s.world_y_q4 = static_cast<i16>(static_cast<i16>(y) << 4);
-    adv.s.heading    = static_cast<u8>(p.heading & 15);
-    adv.speed        = p.speed;
-    tank::clamp_world(adv.s);
-    adv.last_seq   = seq;
-    adv.have_state = 1;
+    const u8 n = (count < kMaxAdv) ? count : kMaxAdv;
+    for (u8 i = 0; i < n; ++i) {
+        if (!(p.status & (1u << i))) continue;             // adversary not live this packet
+        const AdvRecord& r = p.rec[i];
+        const u16 x = rd16(r.x_lo, r.x_hi);
+        const u16 y = rd16(r.y_lo, r.y_hi);
+        adv[i].s.world_x_q4 = static_cast<i16>(static_cast<i16>(x) << 4);   // SNAP
+        adv[i].s.world_y_q4 = static_cast<i16>(static_cast<i16>(y) << 4);
+        adv[i].s.heading    = static_cast<u8>(r.heading & 15);
+        adv[i].speed        = r.speed;
+        tank::clamp_world(adv[i].s);
+        adv[i].have_state = 1;
+    }
+    rx.last_seq   = seq;
+    rx.have_state = 1;
     return true;
 }
 
-// Advance the adversary one frame between snapshots: step `speed` times along the
+// Advance one adversary one frame between snapshots: step `speed` times along the
 // last-known heading via the shared ROM motion table + world clamp (same cadence
 // as the local tank, so DR closely tracks the authoritative path).
 inline void adv_dead_reckon(Adversary& adv) {
@@ -110,18 +135,29 @@ inline void adv_dead_reckon(Adversary& adv) {
     for (u8 i = 0; i < adv.speed; ++i) tank::move_tank(adv.s, static_cast<engine::i8>(1));
 }
 
-// Build the local-player snapshot the client streams back to the server (type 1).
-inline TankPacket16 make_player_packet(const tank::TankState& s, u8 speed, u16 seq) {
-    TankPacket16 p{};
+// Build the local-player snapshot the client streams back to the server (type 1):
+// player state in rec[0], status bit0 = have_state.
+//
+// TIMING ECHO (diagnostic): the C->S packet piggybacks what the client has actually
+// applied — `echo_adv_seq` is adv[0]'s last accepted snapshot sequence and
+// `echo_flags` is a small client-side health byte (a saturating RX-overflow-event
+// count). The server compares echo_adv_seq against the seq it most recently SENT to
+// measure end-to-end lag in packets (≈ ms via the known send rate) and whether it
+// grows over time.
+inline TankPacket32 make_player_packet(const tank::TankState& s, u8 speed, u16 seq,
+                                       u16 echo_adv_seq, u8 echo_flags) {
+    TankPacket32 p{};
     p.magic   = kMagic;
     p.version = kVersion;
     p.type    = kTypePlayer;
     p.status  = kStatusHaveState;
     wr16(p.seq_lo, p.seq_hi, seq);
-    wr16(p.x_lo, p.x_hi, static_cast<u16>(tank::world_x_nominal(s)));
-    wr16(p.y_lo, p.y_hi, static_cast<u16>(tank::world_y_nominal(s)));
-    p.heading = static_cast<u8>(s.heading & 15);
-    p.speed   = speed;
+    wr16(p.rec[0].x_lo, p.rec[0].x_hi, static_cast<u16>(tank::world_x_nominal(s)));
+    wr16(p.rec[0].y_lo, p.rec[0].y_hi, static_cast<u16>(tank::world_y_nominal(s)));
+    p.rec[0].heading = static_cast<u8>(s.heading & 15);
+    p.rec[0].speed   = speed;
+    wr16(p.echo_seq_lo, p.echo_seq_hi, echo_adv_seq);  // adv[0] last-applied seq
+    p.echo_flags = echo_flags;                         // client health byte
     p.pattern = kPattern;
     return p;
 }

--- a/demo/tank_net/atari_tank_net_demo.cpp
+++ b/demo/tank_net/atari_tank_net_demo.cpp
@@ -1,20 +1,21 @@
-// demo/tank_net/atari_tank_net_demo.cpp — EDGE networked two-tank demo.
+// demo/tank_net/atari_tank_net_demo.cpp — EDGE networked multi-tank demo.
 //
-// A "bigger tank demo": the Stage-4 joystick tank (local player) PLUS a second
-// "adversary" tank whose authoritative state (world position, heading, speed) is
+// A "bigger tank demo": the Stage-4 joystick tank (local player) PLUS three
+// "adversary" tanks whose authoritative state (world position, heading, speed) is
 // streamed from a Python UDP server at ~10 Hz over the EDGE realtime lane. The
 // link is bidirectional — the Atari streams its own tank state back so the
-// server's adversary AI can react (chase/avoid). Between the 10 Hz snapshots the
-// client dead-reckons the adversary forward and snaps on each new packet.
+// server's adversary AI can react (chase/avoid/patrol). Between the 10 Hz snapshots
+// the client dead-reckons each adversary forward and snaps on its new packets.
 //
 // Reuses demo/tank's motion/camera/shapes/assets verbatim (added to the include
-// path by CMake); only the network glue + the second sprite are new.
+// path by CMake); only the network glue + the extra sprites are new.
 //
-// SPRITES: two tanks on DEDICATED hardware players via the engine direct-bind mode
-// (GameConfig::sprite_binding = Direct) — slot 0 -> player 0 (local), slot 1 ->
-// player 1 (adversary), fixed for the whole frame. NOT the multiplexer: a chasing
-// adversary crosses the player in Y constantly, which would make the multiplexer's
-// per-frame Y-sort swap players/colours for a frame.
+// SPRITES: four tanks on DEDICATED hardware players via the engine direct-bind mode
+// (GameConfig::sprite_binding = Direct) — slot 0 -> player 0 (local), slots 1..3 ->
+// players 1..3 (adversaries 0..2), fixed for the whole frame. 1 player + 3
+// adversaries == the 4 hardware players, so the direct-bind path stays a single zone.
+// NOT the multiplexer: chasing adversaries cross the player in Y constantly, which
+// would make the multiplexer's per-frame Y-sort swap players/colours for a frame.
 //
 // REALTIME LANE: this lane is EMULATOR-validated only (Altirra + NetSIO + Docker
 // peer), not yet physical-FujiNet validated. This demo is a prototype for that
@@ -65,14 +66,23 @@ struct PlayScreen {
         engine::ScrollRegion<engine::TextRegion<M::Mode::MODE_4, 24>,
                              G::physical_width, G::physical_height>>;
 };
+// Number of network-driven adversaries. 1 local player + kAdvCount adversaries must
+// stay <= the 4 hardware players for direct-bind (kPlayers); 3 fills it exactly.
+static constexpr u8 kAdvCount = 3;
+
 struct GameConfig {
     using screens = engine::ScreenSet<PlayScreen>;
-    static constexpr u8 max_sprites    = 2;     // local player + adversary
+    static constexpr u8 max_sprites    = 1 + kAdvCount;   // local player + adversaries
     static constexpr u8 sound_channels = 1;
-    // No multiplexer: pin slot 0 -> player 0, slot 1 -> player 1 for the whole
-    // frame so the two tanks never swap players/colours when they cross in Y.
+    // No multiplexer: pin slot i -> player i for the whole frame so the tanks never
+    // swap players/colours when they cross in Y.
     static constexpr engine::SpriteBinding sprite_binding = engine::SpriteBinding::Direct;
+    // Widen the realtime frame so ONE packet carries all kAdvCount adversaries per tick
+    // (10 pkt/s) instead of one packet each (30 pkt/s) — the downstream-overload
+    // mitigation. 32 bytes holds the header + kMaxAdv 6-byte records + the timing echo.
+    static constexpr u16 realtime_packet_bytes = sizeof(tanknet::TankPacket32);
 };
+static_assert(tanknet::kMaxAdv >= kAdvCount, "combined packet must hold every adversary");
 using Game = engine::Core<Platform, GameConfig>;
 
 static tank::PhysicalMap g_map;
@@ -82,7 +92,10 @@ static_assert(Platform::capabilities::screen_buffer_alignment == tank::kScanWrap
 static constexpr u8 kFps        = Platform::capabilities::frames_per_second;
 static constexpr u8 kTurnPeriod = (kFps >= 60) ? 7 : 6;
 static constexpr u8 kPlayerColor = 0x1E;   // brassy (matches the original tank)
-static constexpr u8 kAdvColor    = 0x46;   // red — visually distinct adversary
+// One vivid colour per adversary, each a hue NOT used by the playfield palette
+// (grey 0x0e, brick-red 0x32, green 0xc6, blue 0x84) or the gold player (0x1e), so
+// no adversary is camouflaged against a wall/tile: pink, purple, cyan.
+static constexpr u8 kAdvColors[kAdvCount] = { 0x48, 0x68, 0x98 };
 
 // Send the local player's snapshot at ~10 Hz (every ~6 frames at 60 fps / 5 at 50).
 static constexpr u8 kTxPeriod = (kFps >= 60) ? 6 : 5;
@@ -109,11 +122,13 @@ static constexpr u8 kWallColpfMask = 0x01;
 // (volatile alone does not prevent promotion; see the tank demo's SimFeed/LiveState
 // bundling). The padding keeps the struct comfortably above the zp-promotion size.
 struct GameState {
-    tanknet::Adversary adv;          // network-driven adversary
+    tanknet::Adversary adv[kAdvCount];   // network-driven adversaries
+    tanknet::AdvRxState adv_rx;      // shared packet-level seq gate (combined snapshot)
     tank::TankState    tank_safe;    // last position player 0 was NOT touching a wall
     u8  player_speed;                // 1 while the player is moving (for the TX packet)
     u16 tx_seq;
     u8  tx_frame;
+    u8  rx_overflow_count;           // saturating RX-overflow events since last TX (echoed)
     u8  bss_anchor[24];              // force .bss placement (main RAM is plentiful)
 };
 static GameState g_st = {};
@@ -161,11 +176,11 @@ static void submit_tank(u8 slot, const tank::TankState& s, u16 cam_cc, u16 cam_s
     }
 }
 
-// ── Sprite submission: local player (slot 0) + adversary (slot 1) ───────────
+// ── Sprite submission: local player (slot 0) + adversaries (slots 1..kAdvCount) ─
 //
-// The camera follows the LOCAL player; the adversary is drawn in that same camera
+// The camera follows the LOCAL player; each adversary is drawn in that same camera
 // frame (so it scrolls correctly and hides when it leaves the viewport).
-static void submit_two_sprites() {
+static void submit_sprites() {
     const i16 pwx = tank::world_x_nominal(g_tank);
     const i16 pwy = tank::world_y_nominal(g_tank);
     const u16 cam_cc = tank::camera_scroll_x_for_world_x(pwx);
@@ -173,8 +188,11 @@ static void submit_two_sprites() {
     Game::scroll.set(cam_cc, cam_sl);
 
     submit_tank(0, g_tank, cam_cc, cam_sl);     // local player (always on-screen)
-    if (g_st.adv.have_state) submit_tank(1, g_st.adv.s, cam_cc, cam_sl);
-    else                  Game::sprite_hide(1);
+    for (u8 i = 0; i < kAdvCount; ++i) {
+        const u8 slot = static_cast<u8>(i + 1);
+        if (g_st.adv[i].have_state) submit_tank(slot, g_st.adv[i].s, cam_cc, cam_sl);
+        else                        Game::sprite_hide(slot);
+    }
 }
 
 // ── Per-frame step ──────────────────────────────────────────────────────────
@@ -183,12 +201,18 @@ static void submit_two_sprites() {
 static void frame_step(const engine::Input& in) {
     if (Game::net.realtime.active()) {
         Game::net.realtime.poll();
-        // 1. Drain authoritative adversary snapshots (last accepted wins; snaps state).
-        tanknet::TankPacket16 pkt{};
-        while (Game::net.realtime.recv(pkt)) tanknet::adv_apply_packet(g_st.adv, pkt);
-        (void)Game::net.realtime.consume_rx_overflowed();
-        // 2. Dead-reckon the adversary forward between snapshots.
-        tanknet::adv_dead_reckon(g_st.adv);
+        // 1. Drain authoritative snapshots. ONE combined packet carries all adversaries;
+        //    the seq gate keeps the newest (older/dup packets are dropped wholesale).
+        tanknet::TankPacket32 pkt{};
+        while (Game::net.realtime.recv(pkt)) {
+            tanknet::adv_apply_packet(g_st.adv, kAdvCount, g_st.adv_rx, pkt);
+        }
+        // Track RX-ring overflow events (oldest-dropped) so the server can see the
+        // client falling behind; saturate the echo byte at 255.
+        if (Game::net.realtime.consume_rx_overflowed() && g_st.rx_overflow_count < 255)
+            ++g_st.rx_overflow_count;
+        // 2. Dead-reckon every adversary forward between snapshots.
+        for (u8 i = 0; i < kAdvCount; ++i) tanknet::adv_dead_reckon(g_st.adv[i]);
     }
 
     // 2b. GTIA wall collision for player 0. The engine latched P0PF from last
@@ -217,21 +241,28 @@ static void frame_step(const engine::Input& in) {
     // 4. Stream our own state back to the server (bidirectional; all-or-nothing TX).
     if (Game::net.realtime.active() && ++g_st.tx_frame >= kTxPeriod) {
         g_st.tx_frame = 0;
+        // Echo the last-applied combined-packet seq + the overflow accumulator so the
+        // server can measure end-to-end lag; reset the accumulator once it is reported.
         Game::net.realtime.send(
-            tanknet::make_player_packet(g_tank, g_st.player_speed, g_st.tx_seq++));
+            tanknet::make_player_packet(g_tank, g_st.player_speed, g_st.tx_seq++,
+                                        g_st.adv_rx.last_seq, g_st.rx_overflow_count));
+        g_st.rx_overflow_count = 0;
     }
 
-    // 5. Draw both tanks.
-    submit_two_sprites();
+    // 5. Draw all tanks.
+    submit_sprites();
 }
 
 // ── Entry point ────────────────────────────────────────────────────────────
 int main() {
     g_st.tank_safe = g_tank;    // seed the wall-free fallback to the spawn position
     Platform::hal::set_player_size(0, M::sizep::NORMAL);
-    Platform::hal::set_player_size(1, M::sizep::NORMAL);
     Game::sprite_color(0, kPlayerColor);
-    Game::sprite_color(1, kAdvColor);
+    for (u8 i = 0; i < kAdvCount; ++i) {
+        const u8 slot = static_cast<u8>(i + 1);
+        Platform::hal::set_player_size(slot, M::sizep::NORMAL);
+        Game::sprite_color(slot, kAdvColors[i]);
+    }
 
     Game::init(tank::tileset);
     set_palette();
@@ -249,6 +280,6 @@ int main() {
         Platform::hal::set_color_pf(4, 0x34);    // "NO NET" — red border/background
     }
 
-    submit_two_sprites();
+    submit_sprites();
     Game::run(frame_step);
 }

--- a/demo/tank_net/atari_tank_net_demo.cpp
+++ b/demo/tank_net/atari_tank_net_demo.cpp
@@ -19,8 +19,14 @@
 //
 // REALTIME LANE: validated on PHYSICAL FujiNet hardware (2026-06-27) via this demo
 // (open_udp_seq + bidirectional UDP-seq streaming on a real Atari + FujiNet), in
-// addition to the Altirra + NetSIO + Docker-peer emulator stack. Build the real
-// adapter with -DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON;
+// addition to the Altirra + NetSIO + Docker-peer emulator stack.
+//
+// REQUIRES fujinet-firmware v1.6.2 or greater. The downstream netstream path relies on
+// the firmware's whole-frame-aligned drop-oldest + configurable depth (added in 1.6.2);
+// older firmware drops individual bytes from the unframed stream, which permanently
+// desyncs the fixed-size deframer (no resync marker) and corrupts the adversaries.
+//
+// Build the real adapter with -DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON;
 // otherwise the realtime HAL is a stub (open_udp_seq -> Unsupported) and the
 // adversary never appears — the border turns red ("NO NET") to make that obvious.
 

--- a/demo/tank_net/atari_tank_net_demo.cpp
+++ b/demo/tank_net/atari_tank_net_demo.cpp
@@ -17,9 +17,10 @@
 // NOT the multiplexer: chasing adversaries cross the player in Y constantly, which
 // would make the multiplexer's per-frame Y-sort swap players/colours for a frame.
 //
-// REALTIME LANE: this lane is EMULATOR-validated only (Altirra + NetSIO + Docker
-// peer), not yet physical-FujiNet validated. This demo is a prototype for that
-// environment. Build the real adapter with -DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON;
+// REALTIME LANE: validated on PHYSICAL FujiNet hardware (2026-06-27) via this demo
+// (open_udp_seq + bidirectional UDP-seq streaming on a real Atari + FujiNet), in
+// addition to the Altirra + NetSIO + Docker-peer emulator stack. Build the real
+// adapter with -DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON;
 // otherwise the realtime HAL is a stub (open_udp_seq -> Unsupported) and the
 // adversary never appears — the border turns red ("NO NET") to make that obvious.
 

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -1287,8 +1287,8 @@ receive state. The API is dual-lane (see ADR-032, ADR-033): the
 fujinet-lib at configure time, and the **realtime lane** (fixed
 16-byte packets, no wire framing) is wired to an EDGE-owned FujiNet
 Netstream path. The realtime data path is validated against the
-fujinet-pc emulator stack (NetSIO + Altirra + Docker UDP peer);
-it is **not yet validated on physical FujiNet hardware**. The
+fujinet-pc emulator stack (NetSIO + Altirra + Docker UDP peer)
+**and on physical FujiNet hardware** (2026-06-27, tank_net demo). The
 `edge_net_realtime_meter` demo (public `Game::net.realtime` only) and the
 `tools/net/edge_realtime_peer.py` host peer exercise and measure the lane; the
 stream is unframed, so the consumer reassembles the fixed 16-byte units.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -518,8 +518,8 @@ Netstream assembly path (no fujinet-lib, no per-byte CIO) that moves
 adapter adds **no wire framing** (boundaries are implicit, every 16 bytes, so the
 consumer reassembles units from the byte stream).
 Implementation status: realtime lane wired and validated against the
-fujinet-pc emulator stack (NetSIO + Altirra + Docker UDP peer, Mode B); **not
-yet validated on physical FujiNet hardware**. The `edge_net_realtime_meter` demo
+fujinet-pc emulator stack (NetSIO + Altirra + Docker UDP peer, Mode B) **and on
+physical FujiNet hardware** (2026-06-27, tank_net demo). The `edge_net_realtime_meter` demo
 (public API only) plus the `tools/net/edge_realtime_peer.py` host peer exercise and
 measure the lane end to end.
 

--- a/docs/CONSTRAINTS.md
+++ b/docs/CONSTRAINTS.md
@@ -111,7 +111,7 @@ parameter, not a linear tier progression.
   - Realtime lane (fixed 16-byte packets, no wire framing; unframed stream, so
     the consumer reassembles units): wired to an EDGE-owned FujiNet Netstream
     path; validated against the fujinet-pc emulator stack (NetSIO + Altirra +
-    Docker UDP peer); **not** validated on physical FujiNet hardware. Exercised by
+    Docker UDP peer) **and on physical FujiNet hardware** (2026-06-27, tank_net demo). Exercised by
     the `edge_net_realtime_meter` demo + `tools/net/edge_realtime_peer.py` peer; a
     build-time TX-clock override (`EDGE_NETSTREAM_FLAGS`) is available for hardware
     bring-up (internal-clock value experimental, default external clock unchanged)

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1666,13 +1666,16 @@ with the external clock matches the proven upstream reference
   STREAM-IN `50..5F`; adapter open/active/send/recv/close all passed; the TX IRQ
   diagnostic showed the handler count advancing and the ring draining; production
   `.bss` remained 359.
-- **NOT physical FujiNet hardware validated.** All Mode-B evidence is from the
-  emulator/FujiNet-PC stack.
+- **Physical FujiNet hardware validated (2026-06-27).** The `tank_net` demo ran the
+  realtime lane (open_udp_seq + bidirectional UDP-seq streaming) on a real Atari +
+  FujiNet, in addition to the emulator/FujiNet-PC stack. Downstream pacing was tuned in
+  the fujinet-firmware (frame-aligned drop-oldest + `netstream_rx_depth`); see
+  `docs/HANDOFF_netstream_downstream_pacing.md`.
 
 **Risks / future work:**
-- Physical FujiNet hardware validation is pending.
-- The fixed 16-byte boundaries are *implicit*: if bytes are lost on the stream,
-  the receiver desynchronizes and cannot recover on its own (no resync marker).
+- The fixed packet boundaries are *implicit*: if bytes are lost on the stream, the
+  receiver desynchronizes and cannot recover on its own (no resync marker). Drops must
+  therefore be whole-frame aligned (validated end-to-end with the firmware change).
 - Wire framing / resync / checksum / sequence is separate future work.
 - A real gameplay demo over the realtime lane is still needed; `net_dual_lane_demo`
   only illustrates the API shape.

--- a/docs/HANDOFF_netstream_downstream_pacing.md
+++ b/docs/HANDOFF_netstream_downstream_pacing.md
@@ -157,3 +157,35 @@ adding constant latency. The demo's real operating rate (10 Hz) is unaffected �
 keep the inbound buffer **shallow** instead of letting it fill — drain `rx_ring` to the
 freshest bytes each service pass, shrink `NETSTREAM_RX_RING_SIZE`, or drop-oldest
 sooner. The goal is to turn the hz=30/60 "bounded but ~2 s" into "bounded and small."
+
+## Receive path / backpressure (the Atari is NOT the limiter)
+
+A natural question is whether the Atari reads too slowly and causes the backpressure.
+It does not. The EDGE receive path has two stages, neither gated at the 10 Hz
+send rate:
+
+1. **Wire → NS input ring: IRQ-driven, per byte.** `SerialInputIrqHandler` (VSERIN
+   `$020A`, in `fujinet_netstream_handler.S`) pulls every byte off POKEY SERIN the
+   instant it arrives, asynchronously — already as-fast-as-possible, independent of the
+   main loop.
+2. **NS ring → app: once per frame (~60 Hz NTSC), full drain.** `frame_step` calls
+   `poll()` then `while (recv(pkt))`; both drain to `WouldBlock`, so every frame empties
+   the 128-byte NS input ring into the engine ring and then the engine ring into the app.
+
+So the Atari accepts bytes at **full wire speed and applies no backpressure on the
+wire** — it pulls everything the firmware sends, when it sends it. The firmware
+`rx_ring` fills purely because UDP-in > `pace_to_atari`-out, and that pace is a *fixed
+timer* (520 µs/byte) **upstream of the SIO wire**. The Atari is downstream of the pace,
+emits no credit upstream, and so cannot drain that buffer faster. "Read faster to
+relieve backpressure" is a credit/flow-control idea; this link is timer-paced, not
+demand-paced — hence the fix is firmware-side.
+
+**The one read-side risk — only under a future fast firmware.** The main-loop drain
+just has to keep the **128-byte NS input ring** (4 × 32-byte frames) from overflowing
+between 60 Hz polls; if it overflows, the RX IRQ drops bytes → **byte misalignment** →
+the fixed-32-byte deframer desyncs (see "Drop alignment" — the EDGE Atari receiver has
+no resync marker). At the current pace (~32 B ≈ 1 frame per 16.6 ms) there is ~4×
+margin, so no risk today. **But if a firmware fix makes downstream much faster or
+burstier, ensure a burst cannot exceed ~128 bytes between the Atari's 60 Hz drains** —
+otherwise pace the burst, enlarge the Atari NS ring, or poll more than once per frame on
+the EDGE side.

--- a/docs/HANDOFF_netstream_downstream_pacing.md
+++ b/docs/HANDOFF_netstream_downstream_pacing.md
@@ -1,7 +1,10 @@
 # Handoff: Netstream downstream pacing / growing delay
 
-**Date:** 2026-06-27 · **Status:** EDGE-side mitigation landed (packet packing); the
-**root fix is expected in fujinet-firmware** and is the subject of this handoff.
+**Date:** 2026-06-27 · **Status: RESOLVED + physical-hardware validated.** EDGE packing
+mitigation landed; the firmware root fix (frame-aligned drop-oldest + `netstream_rx_depth`)
+landed and was verified (see "Bufferbloat fix VERIFIED" below); the tank_net demo then ran
+the realtime lane on a **real Atari + FujiNet** (2026-06-27). This doc is retained as the
+record of the investigation. (Original framing below: a handoff to the firmware effort.)
 
 **Repro pinned at:** EDGE repo `/home/brad/Dropbox/Projects/Atari/edge`, branch
 `uber_tank_net_demo` @ `b0805a0` (the packing + seq-echo instrument) — rebuild the demo

--- a/docs/HANDOFF_netstream_downstream_pacing.md
+++ b/docs/HANDOFF_netstream_downstream_pacing.md
@@ -218,3 +218,22 @@ one-time startup sync), i.e. the deframer never desynced even while dropping fra
 
 **Status: resolved.** `netstream_rx_depth=2` is a safe tightest-latency default; `4` is
 equally fine for the demo (10 Hz is ~100 ms either way).
+
+## Baud headroom check — ~49.7k (2026-06-27)
+
+Cranked the lane to the closest-to-50k BaudTable row via build flag
+`EDGE_NETSTREAM_NOMINAL_BAUD=49700` (AUDF3=11 → ~49716 bps; firmware confirmed
+`NETSTREAM baud: 49716 (AUDF3=11 NTSC)`), `rx_depth=2`:
+
+| `--hz` | 31250 (~31960 bps) | 49700 (~49716 bps) |
+|---|---|---|
+| 10 | ~1 | ~1 |
+| 20 | ~9 (max 11) | ~7-8 (max 10) |
+| 30 | ~13 (max 15) | ~11 (max 15) |
+| 60 | ~26 (max 30) | ~22 (max 30) |
+
++55 % bandwidth bought only ~1-4 packets, clean throughout (`ovf/bad/stale=0`, `resync`
+flat). This **confirms bandwidth was never the limiter** — the floor is the echo
+round-trip + frame-depth buffer, not wire speed; higher baud (57600+) would show the
+same diminishing pattern. **Default stays 31250** (proven/validated); 49700 is available
+via the build flag (`EDGE_NETSTREAM_NOMINAL_BAUD`, must be an exact BaudTable nominal).

--- a/docs/HANDOFF_netstream_downstream_pacing.md
+++ b/docs/HANDOFF_netstream_downstream_pacing.md
@@ -1,0 +1,131 @@
+# Handoff: Netstream downstream pacing / growing delay
+
+**Date:** 2026-06-27 · **Status:** EDGE-side mitigation landed (packet packing); the
+**root fix is expected in fujinet-firmware** and is the subject of this handoff.
+
+**Repro pinned at:** EDGE repo `/home/brad/Dropbox/Projects/Atari/edge`, branch
+`uber_tank_net_demo` @ `b0805a0` (the packing + seq-echo instrument) — rebuild the demo
+and run the server from there to reproduce the `lag=` measurement below.
+
+## TL;DR
+
+The tank_net demo streams small UDP "netstream" packets bidirectionally through
+FujiNet over NetSIO. **Downstream (server→Atari) packets accumulate unbounded delay**
+when the rate is high; the link's raw baud is not the limit. Evidence points at the
+firmware's `pace_to_atari()` byte pacing and the blocking SIO service loop in
+`fujinet-firmware`. The EDGE demo now packs all adversaries into one packet/tick to
+stay under the ceiling, but a fresh effort should fix the pacing in the firmware so the
+lane sustains higher downstream rates.
+
+## The problem & how it was measured
+
+- **Demo:** `demo/tank_net` (EDGE repo). 1 local tank + 3 server-driven "adversary"
+  tanks. A Python server (`tools/net/edge_tank_adversary.py`) streams authoritative
+  adversary STATE at ~10 Hz; the Atari streams its player state back.
+- **Transport chain:** Altirra (Atari emu) ⇄ `netsio.atdevice` ⇄ **netsiohub**
+  (`python -m netsiohub`, UDP 9997) ⇄ **fujinet-pc firmware** ⇄ real UDP socket ⇄
+  Python server (run as a Docker peer at `172.30.0.2:9000`, separate IP so it doesn't
+  collide with the firmware's own `:9000` bind).
+- **Instrument:** the C→S player packet echoes back the last adversary sequence the
+  Atari has applied + an RX-overflow counter; the server computes
+  `lag = seq_delta(sent_seq, echoed_seq)` (in packets) and prints it. See
+  `tools/net/edge_tank_adversary.py` (`--decode --stats-interval`) and the echo fields
+  in `demo/tank_net/adversary_net.h`.
+
+### Findings (Altirra + NetSIO + fujinet-pc, emulator)
+
+| Downstream rate | Lag over a ~50 s run |
+|---|---|
+| 30 pkt/s (3 adv × 10 Hz, one packet each) | grows without bound → **953** packets |
+| 6 pkt/s (3 adv × 2 Hz) | **flat at 0** (max 1) |
+
+- **`ovf=0` throughout** ⇒ the EDGE engine RX ring (8×packet, drop-oldest) never
+  overflowed, so the backlog accumulates **below the engine** — in the FujiNet/NetSIO
+  inbound→SIO path.
+- **Baud is not the limit.** The lane runs `kNetstreamNominalBaud=31250` → AUDF3=21 →
+  **~31960 bps** (`1789790/(2*(AUDF3+7))`, confirmed by Altirra `NetSIO to Atari @
+  31960`). That carries ~3100 B/s; the 30-pkt/s load is ~480 B/s, ~5× headroom. A host
+  test now guards 31250→AUDF3=21 (`tests/backends/atari/test_netstream_init_prepare.cpp`).
+- Conclusion: the limit is **per-packet / pacing**, not bandwidth. Likely substantially
+  an emulator NetSIO external-clock characteristic, but the *unbounded growth* is a real
+  producer/consumer mismatch worth fixing in the firmware.
+
+## Firmware suspects (fujinet-firmware: `/home/brad/Projects.local/fujinet-firmware`)
+
+Primary file: **`lib/device/sio/netstream.cpp`** (class `sioNetStream`; header
+`netstream.h`). Concurrent/streaming SIO ("Mode B"), enabled by Fuji command `0xF0`
+(`FUJICMD_ENABLE_UDPSTREAM`, `include/fujiCommandID.h`).
+
+1. **`pace_to_atari(min_gap_us)`** (≈ netstream.cpp:112-128) feeds the Atari **one byte
+   at a time with a fixed inter-byte gap** and caps at **16 bytes per call**
+   (`send_count < 16`). Gaps: `NETSTREAM_MIN_GAP_US_SIO=520µs` (~19.2 k),
+   `NETSTREAM_MIN_GAP_US_MIDI=320µs` (~31.25 k). **Check the gap actually matches the
+   negotiated 31250 baud** — a 520µs gap throttles to ~1923 B/s regardless of the real
+   line rate, and the 16-byte cap bounds burst drain.
+2. **`sio_handle_netstream()`** (≈ netstream.cpp:217-410) is entered from the SIO
+   service loop (`lib/bus/sio/sio.cpp` `systemBus::service()`, which does `return;`
+   after dispatching to it) and **blocks the whole loop** while active. Its inbound
+   branch (`pace_to_atari`) competes with the outbound Atari→Net branch
+   (`SYSTEM_BUS.available()` handling); under bidirectional traffic the outbound branch
+   can **starve** `pace_to_atari`, so the 2048-byte `rx_ring` (drop-oldest) backs up.
+3. **`rx_ring[NETSTREAM_RX_RING_SIZE=2048]`** is the inbound queue; on overflow it drops
+   the oldest byte. Watch `rx_drop_count`.
+4. **NetSIO transport:** `lib/bus/sio/NetSIO.cpp` (UDP to netsiohub :9997); baud changes
+   via `NETSIO_SPEED_CHANGE`. Credit/flow-control messages exist
+   (`NETSIO_CREDIT_*`) — worth checking whether they pace downstream delivery.
+
+### Candidate fixes to evaluate (firmware)
+- Make the `pace_to_atari` inter-byte gap track the **negotiated baud** (31250), not a
+  fixed 19.2 k assumption.
+- **Interleave** `pace_to_atari` fairly with the outbound branch so upstream traffic
+  can't starve inbound draining (or drain inbound to empty before/while batching out).
+- Raise or remove the **16-byte-per-call** cap so a backlog can catch up.
+- Sanity-check that nothing re-paces or re-frames each UDP datagram (per-datagram
+  overhead would explain why *packet count*, not bytes, drove the lag).
+
+## Reproduce & rebuild
+
+**Stack (leave the user's running stack alone where possible):**
+- netsiohub: `python -m netsiohub` (UDP 9997) — usually already running.
+- fujinet-pc: `cd build/dist && ./run-fujinet` (TCP 8000; reconnects to netsiohub).
+  ⚠️ **Never `fuser -k 9000/udp`** — the firmware binds `:9000` for the netstream peer
+  and it shares the port; killing it takes the firmware down.
+- Server peer (Docker, separate IP):
+  ```
+  docker network create --subnet 172.30.0.0/24 --gateway 172.30.0.1 nspeer   # once
+  docker run -d --name adv-srv --network nspeer --ip 172.30.0.2 \
+    -v <edge>/tools/net:/app:ro python:3-slim \
+    python3 -u /app/edge_tank_adversary.py --host 0.0.0.0 --port 9000 \
+    --hz 10 --stats-interval 0.5 --decode
+  docker logs -f adv-srv          # watch the lag= trend
+  ```
+- Demo (EDGE repo): build with the realtime adapter ON, peer = the Docker IP:
+  ```
+  cmake -S . -B build-atari -DCMAKE_TOOLCHAIN_FILE=cmake/atari-toolchain.cmake \
+    -DEDGE_BUILD_DEMO=ON -DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON \
+    -DEDGE_NET_PEER_HOST=172.30.0.2 -DEDGE_NET_PEER_PORT=9000
+  cmake --build build-atari --target atari_tank_net_demo
+  ```
+  Launch headless in Altirra (Mode B keeps the netsio device):
+  ```
+  cd <Altirra dir> && wine Altirra64.exe /ntsc /nobasic /tempprofile \
+    /debug /debugbrkrun /debugcmd:g /run Z:\<path>\atari_tank_net_demo.xex
+  ```
+  Tear down with `wineserver -k` + `docker rm -f adv-srv` (don't touch fujinet).
+
+**Firmware rebuild:** `cd /home/brad/Projects.local/fujinet-firmware && ./build.sh -p`
+(PC build) → `build/dist/fujinet` + `run-fujinet`. (See `fujinet_pc.cmake`,
+`build.sh`.) ESP32 differs; the PC path uses `lib/hardware/TTYChannel` / NetSIO.
+
+**The measurement tool is the seq-echo server** above — a fix should turn the
+`lag=` trend from "rises without bound at high `--hz`" into "stays flat." Sweep
+`--hz 10/20/30` to find the new ceiling after a firmware change.
+
+## EDGE-side mitigation already landed (context, not the fix)
+
+To keep the demo usable now, EDGE packs all adversaries into **one 32-byte packet per
+tick** (10 pkt/s instead of 30) — see `demo/tank_net/adversary_net.h` (`TankPacket32`),
+the per-demo `GameConfig::realtime_packet_bytes`, and the relaxed Atari HAL size guard
+(`engine/platform/atari/fujinet_netstream_realtime.h`). This reduces downstream packet
+count and total bytes but does **not** raise the firmware's per-byte pacing ceiling —
+which is what this handoff is about.

--- a/docs/HANDOFF_netstream_downstream_pacing.md
+++ b/docs/HANDOFF_netstream_downstream_pacing.md
@@ -129,3 +129,31 @@ the per-demo `GameConfig::realtime_packet_bytes`, and the relaxed Atari HAL size
 (`engine/platform/atari/fujinet_netstream_realtime.h`). This reduces downstream packet
 count and total bytes but does **not** raise the firmware's per-byte pacing ceiling —
 which is what this handoff is about.
+
+## Throughput results AFTER the firmware fix (2026-06-27)
+
+Re-ran the seq-echo sweep against the updated firmware (combined 32-byte packet, so
+downstream pkt/s = `--hz`). All runs held `tx` at the full rate, `ovf=0`, no
+`bad`/`stale`:
+
+| `--hz` | downstream | steady-state lag | behavior |
+|---|---|---|---|
+| 10 | 10 pkt/s, ~320 B/s | **~1 pkt (~100 ms)**, flat | buffer stays shallow ✅ |
+| 30 | 30 pkt/s, ~960 B/s | ~75 pkt (~2.5 s), **bounded** | inbound buffers full |
+| 60 | 60 pkt/s, ~1920 B/s | ~90 pkt (~1.5 s), **bounded** | inbound buffers full |
+
+**Win — runaway eliminated.** The 30 pkt/s case that previously grew *unbounded to
+953* now **plateaus and stays bounded**, even pushed to 60 pkt/s / ~1920 B/s. The lane
+no longer falls behind without limit.
+
+**Remaining issue — bufferbloat at high rates.** The plateau is a roughly *fixed packet
+depth* (~75–90 packets ≈ the firmware `rx_ring` + engine/NS buffers running FULL), not
+a rate-dependent latency: note the time-latency is *lower* at hz=60 (1.5 s) than hz=30
+(2.5 s) for the same ~80-packet depth. So at high rates the inbound buffers sit full,
+adding constant latency. The demo's real operating rate (10 Hz) is unaffected — flat
+~100 ms.
+
+**Next firmware lead (optional, gated on whether low-latency-at-high-rate matters):**
+keep the inbound buffer **shallow** instead of letting it fill — drain `rx_ring` to the
+freshest bytes each service pass, shrink `NETSTREAM_RX_RING_SIZE`, or drop-oldest
+sooner. The goal is to turn the hz=30/60 "bounded but ~2 s" into "bounded and small."

--- a/docs/HANDOFF_netstream_downstream_pacing.md
+++ b/docs/HANDOFF_netstream_downstream_pacing.md
@@ -189,3 +189,32 @@ margin, so no risk today. **But if a firmware fix makes downstream much faster o
 burstier, ensure a burst cannot exceed ~128 bytes between the Atari's 60 Hz drains** —
 otherwise pace the burst, enlarge the Atari NS ring, or poll more than once per frame on
 the EDGE side.
+
+## Bufferbloat fix VERIFIED (frame-aligned drop-oldest + `netstream_rx_depth`, 2026-06-27)
+
+The firmware was changed to drop **whole 32-byte frames** (not bytes) when the inbound
+ring is full, with a configurable depth `netstream_rx_depth` (`[Network]` in
+`fnconfig.ini`; `0`/absent = firmware default `NETSTREAM_RX_MAX_FRAMES=4`, min 2). The
+seq-echo sweep confirms it — every cell `ovf=0 bad=0 stale=0`, `resync` flat at 8 B (the
+one-time startup sync), i.e. the deframer never desynced even while dropping frames:
+
+| `--hz` | pre-fix (bufferbloat) | depth=4 | depth=2 |
+|---|---|---|---|
+| 10 | ~1 / ~100 ms | ~1 / ~100 ms | ~1 / ~100 ms |
+| 20 | — | ~10 / ~500 ms | ~9 / ~450 ms |
+| 30 | ~75 / **~2.5 s** | ~15 / ~500 ms | ~13 / ~430 ms |
+| 60 | ~90 / **~1.5 s** | ~26 / ~430 ms | ~26 / ~430 ms |
+
+- **Runaway → bounded → shallow.** The deep ~2.5 s buffer at 30 Hz collapsed to ~0.5 s;
+  60 Hz from ~1.5 s to ~0.43 s. The demo's real 10 Hz operating point is ~100 ms.
+- **Frame-aligned drops verified at the shallowest depth (2).** No corruption signal at
+  any rate — confirms the whole-datagram drop policy (the EDGE Atari receiver has no
+  resync marker, so byte-level drops would have been fatal; see "Drop alignment").
+- **`depth=2` is marginally tighter than 4** (peak lag −2-3 pkt at hz=20/30, ~flat at
+  60). Diminishing returns below ~4 because the residual high-rate lag is dominated by
+  the **measurement round-trip** (echo returns on the Atari's 10 Hz player TX + wire
+  RTT, ≈ ~17-26 "packets" at 60 pkt/s), not `rx_ring` depth. The round-trip is the
+  floor; buffer depth can't go below it.
+
+**Status: resolved.** `netstream_rx_depth=2` is a safe tightest-latency default; `4` is
+equally fine for the demo (10 Hz is ~100 ms either way).

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -704,9 +704,10 @@ are available.
 > - **Realtime lane** — wired to an EDGE-owned FujiNet Netstream path (fixed
 >   16-byte packets, all-or-nothing TX/RX, **no wire framing**; no fujinet-lib).
 >   The data path is validated against the fujinet-pc emulator stack
->   (NetSIO + Altirra + Docker UDP peer, Mode B); it is **not yet validated on
->   physical FujiNet hardware**. Packet boundaries are implicit and cannot
->   recover from lost bytes. See `docs/DECISIONS.md` ADR-033.
+>   (NetSIO + Altirra + Docker UDP peer, Mode B) **and on physical FujiNet
+>   hardware** (2026-06-27, tank_net demo). Packet boundaries are implicit and cannot
+>   recover from lost bytes (so firmware drops must be whole-frame aligned).
+>   See `docs/DECISIONS.md` ADR-033.
 > - `net_dual_lane_demo` compiles and illustrates the intended flow; it does
 >   not perform real network I/O unless the session option is enabled, and no
 >   real-gameplay realtime demo exists yet.

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -448,7 +448,7 @@ using Platform = atari::FullUpgrade;   // XL, U1MB, VBXE<>, PokeyMax, NTSC, Fuji
 | Lane | Backend | Status |
 |---|---|---|
 | `Game::net.session` | fujinet-lib / CIO `N:` TCP client | **Optional** — see below |
-| `Game::net.realtime` | EDGE-owned FujiNet Netstream / UDP-seq | **Wired** — emulator-validated; not physical-HW validated |
+| `Game::net.realtime` | EDGE-owned FujiNet Netstream / UDP-seq | **Wired** — emulator- AND physical-FujiNet validated (2026-06-27, tank_net demo) |
 
 #### Session lane — optional fujinet-lib wiring
 
@@ -546,11 +546,12 @@ the confirmed port byte order all remain. Example:
 `cmake --build build-ns --target edge_net_realtime_meter` after configuring with
 `-DEDGE_NETSTREAM_FLAGS=0x22` (or pass it directly to the demo compile).
 
-**Remaining risks / future work:** physical FujiNet hardware validation is
-pending; implicit 16-byte boundaries desync on lost bytes (no resync); wire
-framing / resync / checksum / sequence is separate future work; a real gameplay
-demo over the realtime lane is still needed; physical Atari/SIO timing may differ
-from the emulator/FujiNet-PC stack (settle and baud may need retuning on HW).
+**Remaining risks / future work:** implicit packet boundaries desync on lost bytes
+(no resync) — so firmware drops must be whole-frame aligned (validated with the
+tank_net demo + the fujinet-firmware frame-aligned drop-oldest change); wire
+framing / resync / checksum / sequence is separate future work. Physical FujiNet
+hardware validation is DONE (2026-06-27, tank_net demo): open/send/recv/close +
+bidirectional streaming on a real Atari + FujiNet, settle/baud (31250) held.
 
 #### Hardware / emulator validation checklist
 
@@ -563,8 +564,9 @@ from the emulator/FujiNet-PC stack (settle and baud may need retuning on HW).
       Netstream; flags `0x26`; AUDF3 `21`; baud `31250`; STREAM-OUT `A0..AF`;
       STREAM-IN `50..5F`; open/active/send/recv/close passed; TX IRQ diagnostic
       showed handler count advancing + ring draining; production `.bss` 359
-- [ ] **physical FujiNet hardware** (open/send/recv/close on a real device)
-- [ ] real gameplay demo over the realtime lane
+- [x] **physical FujiNet hardware** (2026-06-27): tank_net demo — open/send/recv/close
+      + bidirectional UDP-seq streaming on a real Atari + FujiNet
+- [x] real gameplay demo over the realtime lane (tank_net: networked multi-tank)
 
 **Session lane** — before relying on it in production, validate against real
 hardware or an emulator with a FujiNet device:
@@ -616,7 +618,7 @@ Validated end-to-end over fujinet-pc + NetSIO + Altirra + a Docker UDP peer
 (Mode B): after reassembly the forward path measures 0% loss / 0 corruption; the
 packet *rate* is capped by the emulated NetSIO external clock stalling the CPU (an
 emulation-stack characteristic, not loss or EDGE code, and not real-hardware
-behaviour). **Not** validated on physical FujiNet hardware.
+behaviour). Validated on physical FujiNet hardware (2026-06-27, tank_net demo).
 
 ### Usage pattern
 
@@ -703,9 +705,9 @@ The script paths assume Altirra 4.50 at the location in `$ALTIRRA_DIR`; adjust f
 
 The FujiNet **Netstream** realtime data path is validated end-to-end against a real FujiNet
 responder — the **fujinet-pc firmware** bridged to Altirra by the **NetSIO hub** — plus a UDP
-**echo peer**. This is *emulator / FujiNet-PC* validation, **not** physical FujiNet hardware
-(which remains future work; see Current Limits). Stage 9R.3 proved a byte-perfect bidirectional
-round trip this way.
+**echo peer**. This is the *emulator / FujiNet-PC* validation; physical FujiNet hardware was
+since validated separately (2026-06-27, tank_net demo). Stage 9R.3 proved a byte-perfect
+bidirectional round trip this way.
 
 The stack (Atari side → network):
 
@@ -745,6 +747,6 @@ with `EDGE_NETSTREAM_TEST_HOOKS`) dumps the serial-IRQ counters if the TX path r
 - display layouts still use the Atari mode enum (`atari::Mode`) as the concrete backend token, supplied
   through the `engine::display::traits` seam; a second backend would add its own mode type and traits
 - the first backend is Atari, so some examples necessarily use Atari terminology
-- the Atari FujiNet session lane is optionally wired to fujinet-lib (OFF by default); the realtime lane is wired to the EDGE-owned Netstream path, emulator-validated (fujinet-pc/NetSIO/Altirra/Docker peer) but not yet validated on physical FujiNet hardware
+- the Atari FujiNet session lane is optionally wired to fujinet-lib (OFF by default); the realtime lane is wired to the EDGE-owned Netstream path, validated on the emulator stack (fujinet-pc/NetSIO/Altirra/Docker peer) AND on physical FujiNet hardware (2026-06-27, tank_net demo)
 
 That is expected at this stage of the project. The docs in this folder are organized so the general engine shape stays clear even where the concrete implementation is currently Atari-first.

--- a/documents/README.md
+++ b/documents/README.md
@@ -61,7 +61,7 @@ Subsystems with partial backend wiring today:
   platform the **session lane** is optionally wired to fujinet-lib (OFF by
   default) and the **realtime lane** is wired to an EDGE-owned FujiNet Netstream
   path, validated against the fujinet-pc emulator stack (NetSIO + Altirra +
-  Docker UDP peer) but **not yet on physical FujiNet hardware**, and exercised by
-  the `edge_net_realtime_meter` demo + `tools/net/edge_realtime_peer.py` peer. The
+  Docker UDP peer) **and on physical FujiNet hardware** (2026-06-27, tank_net demo),
+  and exercised by the `edge_net_realtime_meter` demo + `tools/net/edge_realtime_peer.py` peer. The
   `Network` / Fujinet *capability axis* is real; non-Atari net backends remain
   unimplemented.

--- a/engine/net_api.h
+++ b/engine/net_api.h
@@ -349,12 +349,26 @@ private:
 
 namespace ndetail {
 
-template <typename Platform, bool Enabled>
+template <typename...> using void_t = void;
+
+// Realtime packet size: GameConfig::realtime_packet_bytes if the demo defines it, else
+// the engine default. Lets a demo widen its realtime frame (e.g. to pack several
+// entities per packet) without touching the engine default or other lane users.
+template <typename C, typename = void>
+struct realtime_packet_bytes_or_default {
+    static constexpr u16 value = default_realtime_packet_bytes;
+};
+template <typename C>
+struct realtime_packet_bytes_or_default<C, void_t<decltype(C::realtime_packet_bytes)>> {
+    static constexpr u16 value = C::realtime_packet_bytes;
+};
+
+template <typename Platform, typename GameConfig, bool Enabled>
 struct realtime_facet { };
 
-template <typename Platform>
-struct realtime_facet<Platform, true> {
-    RealtimeLane<Platform> realtime{};
+template <typename Platform, typename GameConfig>
+struct realtime_facet<Platform, GameConfig, true> {
+    RealtimeLane<Platform, realtime_packet_bytes_or_default<GameConfig>::value> realtime{};
 };
 
 template <typename Platform, bool Enabled>
@@ -371,7 +385,7 @@ struct session_facet<Platform, true> {
 template <typename Platform, typename GameConfig,
           bool HasRealtime = engine::caps_of_t<Platform>::has_network_realtime,
           bool HasSession  = engine::caps_of_t<Platform>::has_network_session>
-struct NetManager : ndetail::realtime_facet<Platform, HasRealtime>,
+struct NetManager : ndetail::realtime_facet<Platform, GameConfig, HasRealtime>,
                     ndetail::session_facet<Platform, HasSession> {
     void close_all() {
         if constexpr (HasRealtime) this->realtime.close();

--- a/engine/platform/atari/fujinet_netstream_realtime.h
+++ b/engine/platform/atari/fujinet_netstream_realtime.h
@@ -8,7 +8,7 @@
 // 9Q.2 ABI). The full path is wired: LIFECYCLE (open->init->begin, close->end, active,
 // poll(status), last_error) AND the byte<->packet DATA PATH (send_nb/recv_nb — fixed 16-byte
 // all-or-nothing; see below). Validated against fujinet-pc + NetSIO + Altirra + a Docker UDP
-// peer (Mode B). NOT yet validated on physical FujiNet hardware.
+// peer (Mode B), AND on physical FujiNet hardware (2026-06-27, via the tank_net demo).
 //
 // Why a template: the netstream-ON unit tests build under mos-sim where SIOV / the OS
 // vector-page + POKEY + IRQEN writes in begin cannot execute, and add_engine_test targets
@@ -45,8 +45,8 @@ using engine::net::NetStatus;
 //
 // Values match the proven-working upstream reference
 // (fujinet-atari-netstream/examples/udp-sequence/atari_udp_sequence.c: flags 0x26, baud 31250),
-// validated against fujinet-pc + NetSIO in 9R.3 (Mode B); NOT yet validated on physical FujiNet
-// hardware. The earlier 0x20 / 19200 (internal TX clock) never transmitted: FujiNet/NetSIO drives
+// validated against fujinet-pc + NetSIO in 9R.3 (Mode B) and on physical FujiNet hardware
+// (2026-06-27, tank_net demo). The earlier 0x20 / 19200 (internal TX clock) never transmitted: FujiNet/NetSIO drives
 // an EXTERNAL transmit clock, so TX_EXT (0x04) is required or POKEY never clocks the serial output
 // and the output-ready IRQ never fires.
 //

--- a/engine/platform/atari/fujinet_netstream_realtime.h
+++ b/engine/platform/atari/fujinet_netstream_realtime.h
@@ -194,25 +194,27 @@ struct NetstreamRealtimeAdapterT {
         return NetStatus::Ok;
     }
 
-    // Fixed realtime packet size (engine::net::default_realtime_packet_bytes). The lane only
-    // ever calls send_nb/recv_nb with exactly this many bytes; any other nonzero size is a
-    // defensive InvalidArgument.
-    static constexpr u16 kPacketBytes = 16;
+    // Max realtime packet the adapter accepts in one all-or-nothing send/recv. The LANE
+    // drives the actual size (its compile-time PacketBytes, e.g. 16 or a demo's 32); this
+    // adapter just honours that size, bounded by the 128-byte NS hardware rings
+    // (NS_OUTPUT_BUFSIZE / NS_INPUT_BUFSIZE). Any size beyond the ring is a defensive
+    // InvalidArgument.
+    static constexpr u16 kMaxPacketBytes = 128;
 
-    // Stage 9R.2: ALL-OR-NOTHING TX. Send a whole 16-byte packet or nothing -- the engine
-    // RealtimeLane drops the packet only on Ok, retries on WouldBlock, so a partial write
-    // would corrupt the implicit fixed-length packet boundary. Pre-check tx_space() so the
-    // 16 byte sends cannot hit a full ring (the output IRQ only DRAINS the ring, so free
+    // Stage 9R.2: ALL-OR-NOTHING TX. Send a whole `size`-byte packet or nothing -- the
+    // engine RealtimeLane drops the packet only on Ok, retries on WouldBlock, so a partial
+    // write would corrupt the implicit fixed-length packet boundary. Pre-check tx_space()
+    // so the byte sends cannot hit a full ring (the output IRQ only DRAINS the ring, so free
     // space can only grow during the loop). send_nb/recv_nb do NOT touch state.last_error
     // (it stays owned by open/poll, keeping init/serial errors distinct from backpressure).
     static NetStatus realtime_send_nb(const void* bytes, u16 size) {
         if (!state().active) return NetStatus::Closed;
         if (bytes == nullptr && size > 0) return NetStatus::InvalidArgument;
         if (size == 0) return NetStatus::Ok;
-        if (size != kPacketBytes) return NetStatus::InvalidArgument;
-        if (Ops::tx_space() < kPacketBytes) return NetStatus::WouldBlock;  // write nothing
+        if (size > kMaxPacketBytes) return NetStatus::InvalidArgument;
+        if (Ops::tx_space() < size) return NetStatus::WouldBlock;  // write nothing
         const u8* p = static_cast<const u8*>(bytes);
-        for (u16 i = 0; i < kPacketBytes; ++i) {
+        for (u16 i = 0; i < size; ++i) {
             if (Ops::send_byte(p[i]) != 0) {
                 // Impossible under the concurrency model (free space only grows after the
                 // pre-check); a bug/race. Bytes may already have been accepted, so this is
@@ -220,20 +222,20 @@ struct NetstreamRealtimeAdapterT {
                 return NetStatus::TransportError;
             }
         }
-        return NetStatus::Ok;  // exactly 16 bytes committed, in order
+        return NetStatus::Ok;  // exactly `size` bytes committed, in order
     }
 
-    // Stage 9R.2: FULL-PACKET RX. Deliver a whole 16-byte packet or nothing. Pre-check
-    // bytes_avail() so the 16 reads cannot underrun (the input IRQ only ADDS bytes; this is
-    // the only consumer). Bytes beyond 16 stay in the RX ring for the next drain iteration.
+    // Stage 9R.2: FULL-PACKET RX. Deliver a whole `size`-byte packet or nothing. Pre-check
+    // bytes_avail() so the reads cannot underrun (the input IRQ only ADDS bytes; this is the
+    // only consumer). Bytes beyond `size` stay in the RX ring for the next drain iteration.
     static NetStatus realtime_recv_nb(void* bytes, u16 size) {
         if (!state().active) return NetStatus::Closed;
         if (bytes == nullptr && size > 0) return NetStatus::InvalidArgument;
         if (size == 0) return NetStatus::Ok;
-        if (size != kPacketBytes) return NetStatus::InvalidArgument;
-        if (Ops::bytes_avail() < kPacketBytes) return NetStatus::WouldBlock;  // consume nothing
+        if (size > kMaxPacketBytes) return NetStatus::InvalidArgument;
+        if (Ops::bytes_avail() < size) return NetStatus::WouldBlock;  // consume nothing
         u8* p = static_cast<u8*>(bytes);
-        for (u16 i = 0; i < kPacketBytes; ++i) {
+        for (u16 i = 0; i < size; ++i) {
             const u16 packed = Ops::recv_packed();   // low = data, high = status (0 ok/1 empty)
             if ((packed >> 8) != 0) {
                 // Impossible after the pre-check (only this consumer drains RX); a bug/race.
@@ -241,7 +243,7 @@ struct NetstreamRealtimeAdapterT {
             }
             p[i] = static_cast<u8>(packed & 0xff);
         }
-        return NetStatus::Ok;  // exactly 16 bytes copied
+        return NetStatus::Ok;  // exactly `size` bytes copied
     }
 
     static NetError realtime_last_error() { return state().last_error; }

--- a/engine/platform/atari/fujinet_netstream_realtime.h
+++ b/engine/platform/atari/fujinet_netstream_realtime.h
@@ -50,12 +50,19 @@ using engine::net::NetStatus;
 // an EXTERNAL transmit clock, so TX_EXT (0x04) is required or POKEY never clocks the serial output
 // and the output-ready IRQ never fires.
 //
-// kNetstreamNominalBaud: a BaudTable entry (31250 = row 0x7A12, AUDF3=21).
+// kNetstreamNominalBaud: a BaudTable entry. Default 31250 (row 0x7A12, AUDF3=21 ->
+//   ~31960 bps). Overridable at build time to a different table row, e.g.
+//   -DEDGE_NETSTREAM_NOMINAL_BAUD=49700 (row 0xC224, AUDF3=11 -> ~49716 bps, the closest
+//   entry to 50k). Must be an exact BaudTable nominal or ns_select_baud misses and init
+//   fails (see tests/backends/atari/test_netstream_init_prepare.cpp).
 // kNetstreamFlags: UDP (bit0=0) + UDP-seq (0x20, the lane is open_udp_seq) + TX external clock
 //   (0x04) + register (0x02). RX stays internal (0x08 clear). The PAL bit 0x10 is left 0 in the
 //   seed — ns_init_prepare derives it from DetectPAL; do NOT pre-set it. The handler maps
 //   flags & 0x0c == 0x04 -> SKCTL 0x10 (RX int, TX ext).
-inline constexpr u16 kNetstreamNominalBaud = 31250;
+#ifndef EDGE_NETSTREAM_NOMINAL_BAUD
+#define EDGE_NETSTREAM_NOMINAL_BAUD 31250
+#endif
+inline constexpr u16 kNetstreamNominalBaud = EDGE_NETSTREAM_NOMINAL_BAUD;
 // Default 0x26 (external TX clock) is the proven-working value. Overridable at build
 // time to experiment with clock modes, e.g. -DEDGE_NETSTREAM_FLAGS=0x22 selects an
 // INTERNAL TX clock (bit 0x04 clear): POKEY self-clocks the serial output instead of

--- a/engine/platform/atari/fujinet_netstream_realtime.h
+++ b/engine/platform/atari/fujinet_netstream_realtime.h
@@ -9,6 +9,9 @@
 // poll(status), last_error) AND the byte<->packet DATA PATH (send_nb/recv_nb — fixed 16-byte
 // all-or-nothing; see below). Validated against fujinet-pc + NetSIO + Altirra + a Docker UDP
 // peer (Mode B), AND on physical FujiNet hardware (2026-06-27, via the tank_net demo).
+// Requires fujinet-firmware >= v1.6.2: the downstream path needs the firmware's
+// whole-frame-aligned drop-oldest (older firmware byte-drops the unframed stream and
+// desyncs this marker-less deframer under load).
 //
 // Why a template: the netstream-ON unit tests build under mos-sim where SIOV / the OS
 // vector-page + POKEY + IRQEN writes in begin cannot execute, and add_engine_test targets

--- a/tests/backends/atari/test_netstream_adapter_lifecycle.cpp
+++ b/tests/backends/atari/test_netstream_adapter_lifecycle.cpp
@@ -203,13 +203,15 @@ int main() {
     CHECK(A::realtime_open_udp_seq(host, 0x1234, 0) == n::NetStatus::Ok);
     CHECK(A::realtime_active());
 
-    // ----- arg validation (active): null / zero / wrong length -----
+    // ----- arg validation (active): null / zero / oversize -----
+    // The lane drives the packet size (its compile-time PacketBytes); the adapter
+    // honours any size up to the 128-byte NS ring and rejects only oversize.
     CHECK(A::realtime_send_nb(nullptr, 16) == n::NetStatus::InvalidArgument);
     CHECK(A::realtime_send_nb(pkt, 0) == n::NetStatus::Ok);
-    CHECK(A::realtime_send_nb(pkt, 8) == n::NetStatus::InvalidArgument);   // n != 16
+    CHECK(A::realtime_send_nb(pkt, 129) == n::NetStatus::InvalidArgument);   // > kMaxPacketBytes
     CHECK(A::realtime_recv_nb(nullptr, 16) == n::NetStatus::InvalidArgument);
     CHECK(A::realtime_recv_nb(out, 0) == n::NetStatus::Ok);
-    CHECK(A::realtime_recv_nb(out, 8) == n::NetStatus::InvalidArgument);
+    CHECK(A::realtime_recv_nb(out, 129) == n::NetStatus::InvalidArgument);   // > kMaxPacketBytes
 
     // ----- TX: tx_space < 16 -> WouldBlock, NOTHING written -----
     FakeOps::tx_count = 0; FakeOps::send_fail_at = -1; FakeOps::tx_free = 15;

--- a/tests/backends/atari/test_netstream_init_prepare.cpp
+++ b/tests/backends/atari/test_netstream_init_prepare.cpp
@@ -106,6 +106,15 @@ int main() {
     CHECK(nsFinalAudf3 == 21);
     CHECK(nsFinalAudf4 == 0);
 
+    // 49700 is the closest BaudTable row to 50k (AUDF3=11 -> ~49716 bps), the
+    // EDGE_NETSTREAM_NOMINAL_BAUD=49700 build override. Guards that overriding the lane
+    // baud to this row still hits select_baud (not a miss -> init fail).
+    nsVideoStd = VIDEO_NTSC;
+    stage_nominal(49700);
+    CHECK(ns_test_select_baud_staged() == 0);
+    CHECK(nsFinalAudf3 == 11);
+    CHECK(nsFinalAudf4 == 0);
+
     // ----- baud lookup miss: failure + nsFinal* untouched -----
     nsVideoStd = VIDEO_NTSC;
     stage_nominal(0x1234);           // not present in BaudTable

--- a/tests/backends/atari/test_netstream_init_prepare.cpp
+++ b/tests/backends/atari/test_netstream_init_prepare.cpp
@@ -87,6 +87,25 @@ int main() {
     CHECK(nsFinalAudf3 == 219);
     CHECK(nsFinalAudf4 == 2);
 
+    // 31250 is the rate the REALTIME lane actually requests
+    // (kNetstreamNominalBaud, fujinet_netstream_realtime.h): verify it is a real
+    // BaudTable row and resolves to AUDF3=21,AUDF4=0 (single-byte divisor, same for
+    // NTSC/PAL) -> effective ~31960 bps via baud = 1789790/(2*(AUDF3+7)). A retune of
+    // the adapter constant to a value NOT in the table would MISS here (init fails),
+    // so this case guards the lane's configured datarate.
+    nsVideoStd = VIDEO_NTSC;
+    stage_nominal(31250);
+    nsFinalAudf3 = 0xAA; nsFinalAudf4 = 0xAA;
+    CHECK(ns_test_select_baud_staged() == 0);
+    CHECK(nsFinalAudf3 == 21);
+    CHECK(nsFinalAudf4 == 0);
+
+    nsVideoStd = VIDEO_PAL;
+    stage_nominal(31250);
+    CHECK(ns_test_select_baud_staged() == 0);
+    CHECK(nsFinalAudf3 == 21);
+    CHECK(nsFinalAudf4 == 0);
+
     // ----- baud lookup miss: failure + nsFinal* untouched -----
     nsVideoStd = VIDEO_NTSC;
     stage_nominal(0x1234);           // not present in BaudTable

--- a/tests/generic/test_adversary_net.cpp
+++ b/tests/generic/test_adversary_net.cpp
@@ -1,6 +1,9 @@
 // test_adversary_net.cpp — networked-adversary packet + dead-reckoning invariants
 // (demo/tank_net/adversary_net.h). Built for mos-sim, run under CTest (0 = pass).
 // Pure logic; no Atari hardware, no transport.
+//
+// The lane now carries ONE combined 32-byte packet per tick holding up to kMaxAdv
+// adversary records (status bit i = rec[i] live); stale/dup detection is per-PACKET.
 
 #include <stdint.h>
 #include <stdio.h>
@@ -20,111 +23,169 @@ static unsigned g_failures = 0;
         }                                                                  \
     } while (0)
 
-// Build an authoritative adversary snapshot (type 0) for the tests.
-static tanknet::TankPacket16 make_adv(u16 seq, u16 x, u16 y, u8 h, u8 sp) {
-    tanknet::TankPacket16 p{};
+// One adversary record (x,y nominal px, heading, speed).
+static tanknet::AdvRecord rec_of(u16 x, u16 y, u8 h, u8 sp) {
+    tanknet::AdvRecord r{};
+    tanknet::wr16(r.x_lo, r.x_hi, x);
+    tanknet::wr16(r.y_lo, r.y_hi, y);
+    r.heading = h;
+    r.speed   = sp;
+    return r;
+}
+
+// Build a combined authoritative adversary packet (type 0): n records, status bit i set.
+static tanknet::TankPacket32 make_adv_packet(u16 seq, const tanknet::AdvRecord* recs, u8 n) {
+    tanknet::TankPacket32 p{};
     p.magic   = tanknet::kMagic;
     p.version = tanknet::kVersion;
     p.type    = tanknet::kTypeAdversary;
     tanknet::wr16(p.seq_lo, p.seq_hi, seq);
-    tanknet::wr16(p.x_lo, p.x_hi, x);
-    tanknet::wr16(p.y_lo, p.y_hi, y);
-    p.heading = h;
-    p.speed   = sp;
+    for (u8 i = 0; i < n && i < tanknet::kMaxAdv; ++i) {
+        p.rec[i] = recs[i];
+        p.status = static_cast<u8>(p.status | (1u << i));
+    }
     p.pattern = tanknet::kPattern;
     return p;
 }
 
+// One-adversary convenience packet (only rec[0] live).
+static tanknet::TankPacket32 make_adv1(u16 seq, u16 x, u16 y, u8 h, u8 sp) {
+    const tanknet::AdvRecord r = rec_of(x, y, h, sp);
+    return make_adv_packet(seq, &r, 1);
+}
+
 // ── Packet layout + player-packet build/round-trip ─────────────────────────
 static void test_packet_roundtrip() {
-    CHECK(sizeof(tanknet::TankPacket16) == 16);
+    CHECK(sizeof(tanknet::TankPacket32) == 32);
+    CHECK(sizeof(tanknet::AdvRecord) == 6);
 
     tank::TankState s{};
     s.world_x_q4 = static_cast<i16>(300 << 4);
     s.world_y_q4 = static_cast<i16>(200 << 4);
     s.heading    = 6;
-    const tanknet::TankPacket16 p = tanknet::make_player_packet(s, 1, 42);
+    const tanknet::TankPacket32 p =
+        tanknet::make_player_packet(s, 1, 42, /*echo_adv_seq=*/1234, /*echo_flags=*/7);
 
     CHECK(p.magic == tanknet::kMagic);
     CHECK(p.version == tanknet::kVersion);
     CHECK(p.type == tanknet::kTypePlayer);
     CHECK(p.pattern == tanknet::kPattern);
     CHECK(tanknet::rd16(p.seq_lo, p.seq_hi) == 42);
-    CHECK(tanknet::rd16(p.x_lo, p.x_hi) == 300);
-    CHECK(tanknet::rd16(p.y_lo, p.y_hi) == 200);
-    CHECK(p.heading == 6);
-    CHECK(p.speed == 1);
+    // Player state lives in rec[0].
+    CHECK(tanknet::rd16(p.rec[0].x_lo, p.rec[0].x_hi) == 300);
+    CHECK(tanknet::rd16(p.rec[0].y_lo, p.rec[0].y_hi) == 200);
+    CHECK(p.rec[0].heading == 6);
+    CHECK(p.rec[0].speed == 1);
+    // Timing echo round-trips in the dedicated fields.
+    CHECK(tanknet::rd16(p.echo_seq_lo, p.echo_seq_hi) == 1234);
+    CHECK(p.echo_flags == 7);
 }
 
 // ── apply: validate, snap, reject foreign/stale ────────────────────────────
 static void test_apply_snap_and_validation() {
-    tanknet::Adversary adv{};
+    tanknet::Adversary adv[1] = {};
+    tanknet::AdvRxState rx{};
 
     // First valid snapshot: snaps position, adopts heading/speed, marks have_state.
-    CHECK(tanknet::adv_apply_packet(adv, make_adv(10, 250, 150, 4, 1)));
-    CHECK(adv.have_state == 1);
-    CHECK(tank::world_x_nominal(adv.s) == 250);
-    CHECK(tank::world_y_nominal(adv.s) == 150);
-    CHECK(adv.s.heading == 4);
-    CHECK(adv.speed == 1);
-    CHECK(adv.last_seq == 10);
+    CHECK(tanknet::adv_apply_packet(adv, 1, rx, make_adv1(10, 250, 150, 4, 1)));
+    CHECK(adv[0].have_state == 1);
+    CHECK(rx.have_state == 1);
+    CHECK(tank::world_x_nominal(adv[0].s) == 250);
+    CHECK(tank::world_y_nominal(adv[0].s) == 150);
+    CHECK(adv[0].s.heading == 4);
+    CHECK(adv[0].speed == 1);
+    CHECK(rx.last_seq == 10);
 
     // Foreign magic / wrong direction (player type) are rejected, state unchanged.
-    tanknet::TankPacket16 bad = make_adv(11, 1, 1, 0, 0);
+    tanknet::TankPacket32 bad = make_adv1(11, 1, 1, 0, 0);
     bad.magic = 0x00;
-    CHECK(!tanknet::adv_apply_packet(adv, bad));
-    tanknet::TankPacket16 wrong_dir = make_adv(11, 1, 1, 0, 0);
+    CHECK(!tanknet::adv_apply_packet(adv, 1, rx, bad));
+    tanknet::TankPacket32 wrong_dir = make_adv1(11, 1, 1, 0, 0);
     wrong_dir.type = tanknet::kTypePlayer;
-    CHECK(!tanknet::adv_apply_packet(adv, wrong_dir));
-    CHECK(tank::world_x_nominal(adv.s) == 250);   // untouched
-    CHECK(adv.last_seq == 10);
+    CHECK(!tanknet::adv_apply_packet(adv, 1, rx, wrong_dir));
+    CHECK(tank::world_x_nominal(adv[0].s) == 250);   // untouched
+    CHECK(rx.last_seq == 10);
 
     // Stale / duplicate sequence dropped; strictly-newer accepted.
-    CHECK(!tanknet::adv_apply_packet(adv, make_adv(10, 999, 999, 0, 0)));  // dup
-    CHECK(!tanknet::adv_apply_packet(adv, make_adv(3,  999, 999, 0, 0)));  // older
-    CHECK(tank::world_x_nominal(adv.s) == 250);
-    CHECK(tanknet::adv_apply_packet(adv, make_adv(11, 260, 150, 4, 1)));   // newer
-    CHECK(tank::world_x_nominal(adv.s) == 260);
+    CHECK(!tanknet::adv_apply_packet(adv, 1, rx, make_adv1(10, 999, 999, 0, 0)));  // dup
+    CHECK(!tanknet::adv_apply_packet(adv, 1, rx, make_adv1(3,  999, 999, 0, 0)));  // older
+    CHECK(tank::world_x_nominal(adv[0].s) == 250);
+    CHECK(tanknet::adv_apply_packet(adv, 1, rx, make_adv1(11, 260, 150, 4, 1)));   // newer
+    CHECK(tank::world_x_nominal(adv[0].s) == 260);
 }
 
 // ── apply: sequence wrap is handled by the signed delta ────────────────────
 static void test_apply_seq_wrap() {
-    tanknet::Adversary adv{};
-    CHECK(tanknet::adv_apply_packet(adv, make_adv(65530, 100, 100, 0, 0)));
+    tanknet::Adversary adv[1] = {};
+    tanknet::AdvRxState rx{};
+    CHECK(tanknet::adv_apply_packet(adv, 1, rx, make_adv1(65530, 100, 100, 0, 0)));
     // 2 is "newer" than 65530 across the wrap (delta = +8) -> accepted.
-    CHECK(tanknet::adv_apply_packet(adv, make_adv(2, 110, 100, 0, 0)));
-    CHECK(adv.last_seq == 2);
+    CHECK(tanknet::adv_apply_packet(adv, 1, rx, make_adv1(2, 110, 100, 0, 0)));
+    CHECK(rx.last_seq == 2);
     // 65530 is now "older" than 2 (delta = -8) -> rejected.
-    CHECK(!tanknet::adv_apply_packet(adv, make_adv(65530, 120, 100, 0, 0)));
+    CHECK(!tanknet::adv_apply_packet(adv, 1, rx, make_adv1(65530, 120, 100, 0, 0)));
 }
 
 // ── apply: out-of-range position is clamped to the world box ───────────────
 static void test_apply_clamps_world() {
-    tanknet::Adversary adv{};
-    CHECK(tanknet::adv_apply_packet(adv, make_adv(1, 1000, 1000, 0, 0)));
-    CHECK(tank::world_x_nominal(adv.s) == 632);   // kMaxCenterX
-    CHECK(tank::world_y_nominal(adv.s) == 376);   // kMaxCenterY
+    tanknet::Adversary adv[1] = {};
+    tanknet::AdvRxState rx{};
+    CHECK(tanknet::adv_apply_packet(adv, 1, rx, make_adv1(1, 1000, 1000, 0, 0)));
+    CHECK(tank::world_x_nominal(adv[0].s) == 632);   // kMaxCenterX
+    CHECK(tank::world_y_nominal(adv[0].s) == 376);   // kMaxCenterY
 }
 
 // ── dead-reckon: advances exactly like the player's move_tank ──────────────
 static void test_dead_reckon_matches_motion() {
-    tanknet::Adversary adv{};
+    tanknet::Adversary adv[1] = {};
+    tanknet::AdvRxState rx{};
     // East heading (4), speed 1. With kSpeedScale=3 the per-frame vector is +24 Q12.4
     // (1.5 px), so 6 frames advance x by 9 px and leave y unchanged.
-    CHECK(tanknet::adv_apply_packet(adv, make_adv(1, 100, 100, 4, 1)));
-    for (u8 i = 0; i < 6; ++i) tanknet::adv_dead_reckon(adv);
-    CHECK(tank::world_x_nominal(adv.s) == static_cast<i16>(100 + 6 * tank::kSpeedScale * 8 / 16));
-    CHECK(tank::world_y_nominal(adv.s) == 100);
+    CHECK(tanknet::adv_apply_packet(adv, 1, rx, make_adv1(1, 100, 100, 4, 1)));
+    for (u8 i = 0; i < 6; ++i) tanknet::adv_dead_reckon(adv[0]);
+    CHECK(tank::world_x_nominal(adv[0].s) == static_cast<i16>(100 + 6 * tank::kSpeedScale * 8 / 16));
+    CHECK(tank::world_y_nominal(adv[0].s) == 100);
 
     // speed 0 => stationary between snapshots.
-    CHECK(tanknet::adv_apply_packet(adv, make_adv(2, 100, 100, 4, 0)));
-    for (u8 i = 0; i < 6; ++i) tanknet::adv_dead_reckon(adv);
-    CHECK(tank::world_x_nominal(adv.s) == 100);
+    CHECK(tanknet::adv_apply_packet(adv, 1, rx, make_adv1(2, 100, 100, 4, 0)));
+    for (u8 i = 0; i < 6; ++i) tanknet::adv_dead_reckon(adv[0]);
+    CHECK(tank::world_x_nominal(adv[0].s) == 100);
 
     // No state yet => dead-reckon is a no-op (adversary stays hidden upstream).
     tanknet::Adversary fresh{};
     tanknet::adv_dead_reckon(fresh);
     CHECK(fresh.have_state == 0);
+}
+
+// ── combined packet: one packet snaps all live adversaries; per-PACKET seq gate ──
+static void test_combined_packet() {
+    tanknet::Adversary adv[3] = {};
+    tanknet::AdvRxState rx{};
+
+    // One packet with 3 records updates all three; status bits 0..2 set.
+    const tanknet::AdvRecord recs[3] = {
+        rec_of(100, 100, 0, 0), rec_of(200, 150, 4, 0), rec_of(300, 250, 8, 0),
+    };
+    CHECK(tanknet::adv_apply_packet(adv, 3, rx, make_adv_packet(1, recs, 3)));
+    CHECK(tank::world_x_nominal(adv[0].s) == 100);
+    CHECK(tank::world_x_nominal(adv[1].s) == 200);
+    CHECK(tank::world_y_nominal(adv[2].s) == 250);
+    CHECK(adv[0].have_state && adv[1].have_state && adv[2].have_state);
+
+    // A stale combined packet is dropped WHOLESALE (no record applied).
+    const tanknet::AdvRecord stale[3] = {
+        rec_of(999, 999, 0, 0), rec_of(999, 999, 0, 0), rec_of(999, 999, 0, 0),
+    };
+    CHECK(!tanknet::adv_apply_packet(adv, 3, rx, make_adv_packet(1, stale, 3)));  // dup seq
+    CHECK(tank::world_x_nominal(adv[1].s) == 200);                               // untouched
+
+    // status bit clear => that record is skipped even in a newer packet.
+    tanknet::TankPacket32 p = make_adv_packet(2, recs, 3);
+    p.rec[1] = rec_of(640, 384, 0, 0);   // would clamp to (632,376) if applied
+    p.status = static_cast<u8>(p.status & ~0x02);  // clear bit 1 (adv 1 not live)
+    CHECK(tanknet::adv_apply_packet(adv, 3, rx, p));
+    CHECK(tank::world_x_nominal(adv[1].s) == 200);   // adv 1 unchanged (bit clear)
+    CHECK(rx.last_seq == 2);
 }
 
 int main() {
@@ -133,6 +194,7 @@ int main() {
     test_apply_seq_wrap();
     test_apply_clamps_world();
     test_dead_reckon_matches_motion();
+    test_combined_packet();
 
     if (g_failures == 0) printf("ALL TESTS PASSED\n");
     else                 printf("%u FAILURES\n", g_failures);

--- a/tools/net/edge_tank_adversary.py
+++ b/tools/net/edge_tank_adversary.py
@@ -191,9 +191,35 @@ def choose_heading(mode, adv, player, t, patrol_period):
         return int(t / patrol_period) & 15
     dx = player[0] - adv.x_nom
     dy = player[1] - adv.y_nom
-    if mode == "avoid":
-        dx, dy = -dx, -dy
-    return heading_to(dx, dy)
+    if mode == "chase":
+        return heading_to(dx, dy)
+
+    # avoid: flee away from the player, but WALL-AWARE so it never pins in a corner.
+    # Fleeing straight away from an upper-right player drives it into the lower-left
+    # wall, where the hard world clamp would jam it. Instead: if the flee vector pushes
+    # into a wall, zero that component to slide ALONG the wall; if cornered (pushing into
+    # both), circle the perimeter clockwise so it keeps moving and looks deliberate.
+    fx, fy = -dx, -dy
+    m = 24  # px proximity that counts as "at" a wall
+    blk_x = (adv.x_nom <= WORLD_X_MIN + m and fx < 0) or \
+            (adv.x_nom >= WORLD_X_MAX - m and fx > 0)
+    blk_y = (adv.y_nom <= WORLD_Y_MIN + m and fy < 0) or \
+            (adv.y_nom >= WORLD_Y_MAX - m and fy > 0)
+    if blk_x and blk_y:
+        # Cornered: slide along a wall, clockwise around the field, by corner.
+        if adv.x_nom <= WORLD_X_MIN + m and adv.y_nom >= WORLD_Y_MAX - m:
+            fx, fy = 0, -1          # lower-left  -> north (up the left wall)
+        elif adv.x_nom <= WORLD_X_MIN + m:
+            fx, fy = 1, 0           # upper-left  -> east  (along the top wall)
+        elif adv.y_nom <= WORLD_Y_MIN + m:
+            fx, fy = 0, 1           # upper-right -> south (down the right wall)
+        else:
+            fx, fy = -1, 0          # lower-right -> west  (along the bottom wall)
+    elif blk_x:
+        fx = 0                       # slide vertically along the side wall
+    elif blk_y:
+        fy = 0                       # slide horizontally along the top/bottom wall
+    return heading_to(fx, fy)
 
 
 def main():
@@ -216,9 +242,11 @@ def main():
                     help="must match the demo's EDGE_TANK_SPEED_SCALE (default 3)")
     ap.add_argument("--start", default="160,96",
                     help="fallback start x,y nominal for adversaries not in --starts (default 160,96)")
-    ap.add_argument("--starts", default="8,376;624,376;624,16",
+    ap.add_argument("--starts", default="40,344;624,376;624,16",
                     help="per-adversary start x,y, semicolon list "
-                         "(default '8,376;624,376;624,16' — three corners); "
+                         "(default '40,344;624,376;624,16' — three corner areas; the "
+                         "lower-left is inset ~32px off the walls so a chase tank does "
+                         "not spawn pinned in the world-clamp corner); "
                          "entries beyond the list fall back to --start")
     ap.add_argument("--patrol-period", type=float, default=0.6,
                     help="seconds per heading step in patrol/no-player mode (default 0.6)")

--- a/tools/net/edge_tank_adversary.py
+++ b/tools/net/edge_tank_adversary.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
-"""Server-driven adversary for the EDGE networked two-tank demo (demo/tank_net).
+"""Server-driven adversaries for the EDGE networked multi-tank demo (demo/tank_net).
 
-Pairs with demo/tank_net/atari_tank_net_demo.cpp. Streams an authoritative
-adversary-tank STATE snapshot (world position, heading, speed) to the Atari at
+Pairs with demo/tank_net/atari_tank_net_demo.cpp. Streams authoritative
+adversary-tank STATE snapshots (world position, heading, speed) to the Atari at
 ~10 Hz over the realtime lane (ADR-015: the host sends state, not input), and —
 the link is bidirectional — consumes the Atari's own player snapshots so the
-adversary AI can react (chase / avoid).
+adversary AI can react (chase / avoid / patrol).
+
+Drives N adversaries (default 3, the demo's kAdvCount), each an independent AI with
+its own start position and mode. ALL adversaries are packed into ONE combined packet
+per tick (status bit i marks record i live) — 1 pkt/tick instead of one-per-adversary,
+the downstream-overload mitigation that keeps the Atari's receive path from falling
+behind.
 
 The TRANSPORT is generic UDP and knows nothing about Atari/SIO/POKEY/FujiNet; the
-only demo-specific knowledge is the 16-byte TankPacket16 layout below, kept in one
-place. Netstream carries an UNFRAMED byte stream, so inbound 16-byte units are
+only demo-specific knowledge is the 32-byte TankPacket32 layout below, kept in one
+place. Netstream carries an UNFRAMED byte stream, so inbound 32-byte units are
 reassembled across datagram boundaries (resync on the magic+version marker) exactly
 like tools/net/edge_realtime_peer.py.
 
@@ -34,15 +40,20 @@ import time
 # Verified frame rates (Hz), derived from ANTIC geometry (see edge_realtime_peer.py).
 TV_FPS = {"ntsc": 59.9227, "pal": 49.8607}
 
-DEFAULT_SIZE = 16
+MAX_ADV = 3                  # adversary records per combined packet (tanknet::kMaxAdv)
+DEFAULT_SIZE = 32
 
-# ── TankPacket16 layout (must match demo/tank_net/adversary_net.h) ────────────
-#   0 magic(0xAD) 1 version(0x01) 2 type(0=adversary S->C, 1=player C->S) 3 status
-#   4..5 seq LE   6..7 x_nom LE   8..9 y_nom LE   10 heading(0..15) 11 speed
-#   12..14 reserved   15 pattern(0x5A)
-_LAYOUT = "<BBBBHHHBB3sB"   # magic,ver,type,status, seq,x,y, heading,speed, resv,pattern
+# ── TankPacket32 layout (must match demo/tank_net/adversary_net.h) ────────────
+# ONE combined packet per tick carries ALL adversaries (downstream-overload fix):
+#   0 magic(0xAD) 1 version(0x02) 2 type(0=adversary S->C, 1=player C->S)
+#   3 status (S->C: bit i = rec[i] live; C->S: bit0 have_state)   4..5 seq LE
+#   6..23  rec[0..2], each = x_nom LE(2) y_nom LE(2) heading(1) speed(1)
+#          (C->S: rec[0] = player state)
+#   24..25 echo_seq LE (C->S: adv[0] last-applied seq)   26 echo_flags (C->S health)
+#   27..30 reserved   31 pattern(0x5A)
+_LAYOUT = "<BBBBH" + "HHBB" * MAX_ADV + "HB4sB"
 MAGIC = 0xAD
-VERSION = 0x01
+VERSION = 0x02
 PATTERN = 0x5A
 TYPE_ADVERSARY = 0
 TYPE_PLAYER = 1
@@ -54,23 +65,42 @@ WORLD_Y_MIN, WORLD_Y_MAX = 8, 376
 
 
 def decode(data):
-    """Decode 16 bytes into a dict, or None if not a valid TankPacket16."""
-    if len(data) != 16:
+    """Decode 32 bytes into a dict, or None if not a valid TankPacket32."""
+    if len(data) != DEFAULT_SIZE:
         return None
-    magic, ver, ptype, status, seq, x, y, heading, speed, _resv, pattern = \
-        struct.unpack(_LAYOUT, data)
+    f = struct.unpack(_LAYOUT, data)
+    magic, ver, ptype, status, seq = f[0:5]
     if magic != MAGIC:
         return None
-    return {"magic": magic, "version": ver, "type": ptype, "status": status,
-            "seq": seq, "x": x, "y": y, "heading": heading, "speed": speed,
-            "pattern": pattern}
+    recs = []
+    for i in range(MAX_ADV):
+        x, y, heading, speed = f[5 + i * 4: 9 + i * 4]
+        recs.append({"x": x, "y": y, "heading": heading, "speed": speed})
+    echo_seq, echo_flags = f[5 + MAX_ADV * 4], f[6 + MAX_ADV * 4]
+    d = {"magic": magic, "version": ver, "type": ptype, "status": status,
+         "seq": seq, "recs": recs, "echo_seq": echo_seq, "echo_flags": echo_flags,
+         "pattern": f[-1]}
+    # Player (C->S) state lives in rec[0]; flatten for convenience.
+    d.update(x=recs[0]["x"], y=recs[0]["y"],
+             heading=recs[0]["heading"], speed=recs[0]["speed"])
+    return d
 
 
-def encode(f):
-    return struct.pack(_LAYOUT, MAGIC, VERSION, f["type"], f.get("status", 0),
-                       f["seq"] & 0xFFFF, f["x"] & 0xFFFF, f["y"] & 0xFFFF,
-                       f["heading"] & 0x0F, f["speed"] & 0xFF, b"\x00\x00\x00",
-                       PATTERN)
+def encode_adversaries(seq, recs):
+    """Build a combined S->C adversary packet: one record per adversary (max MAX_ADV),
+    status bit i set for each present record."""
+    status = 0
+    fields = []
+    for i in range(MAX_ADV):
+        if i < len(recs):
+            r = recs[i]
+            status |= (1 << i)
+            fields += [r["x"] & 0xFFFF, r["y"] & 0xFFFF,
+                       r["heading"] & 0x0F, r["speed"] & 0xFF]
+        else:
+            fields += [0, 0, 0, 0]
+    return struct.pack(_LAYOUT, MAGIC, VERSION, TYPE_ADVERSARY, status,
+                       seq & 0xFFFF, *fields, 0, 0, b"\x00\x00\x00\x00", PATTERN)
 
 
 def seq_delta(a, b):
@@ -170,8 +200,13 @@ def main():
     ap = argparse.ArgumentParser(description="EDGE networked-tank adversary server.")
     ap.add_argument("--host", default="0.0.0.0", help="bind address (default 0.0.0.0)")
     ap.add_argument("--port", type=int, default=9000, help="UDP port (default 9000)")
+    ap.add_argument("--count", type=int, default=3,
+                    help="number of adversaries (default 3, the demo's kAdvCount)")
     ap.add_argument("--mode", choices=["chase", "avoid", "patrol"], default="chase",
-                    help="adversary AI (default chase)")
+                    help="fallback AI for adversaries not named in --modes (default chase)")
+    ap.add_argument("--modes", default="chase,avoid,patrol",
+                    help="per-adversary AI, comma list (default 'chase,avoid,patrol'); "
+                         "entries beyond the list fall back to --mode")
     ap.add_argument("--hz", type=float, default=10.0, help="snapshot rate (default 10)")
     ap.add_argument("--tv", choices=["ntsc", "pal"], default="ntsc",
                     help="client TV standard, for frames-per-tick (default ntsc)")
@@ -179,7 +214,12 @@ def main():
                     help="adversary dead-reckon speed in steps/frame (default 1)")
     ap.add_argument("--speed-scale", type=int, default=3,
                     help="must match the demo's EDGE_TANK_SPEED_SCALE (default 3)")
-    ap.add_argument("--start", default="160,96", help="adversary start x,y nominal (default 160,96)")
+    ap.add_argument("--start", default="160,96",
+                    help="fallback start x,y nominal for adversaries not in --starts (default 160,96)")
+    ap.add_argument("--starts", default="8,376;624,376;624,16",
+                    help="per-adversary start x,y, semicolon list "
+                         "(default '8,376;624,376;624,16' — three corners); "
+                         "entries beyond the list fall back to --start")
     ap.add_argument("--patrol-period", type=float, default=0.6,
                     help="seconds per heading step in patrol/no-player mode (default 0.6)")
     ap.add_argument("--target-host", default=None,
@@ -192,16 +232,35 @@ def main():
 
     if (args.target_host is None) != (args.target_port is None):
         ap.error("--target-host and --target-port must be given together")
+    if args.count < 1:
+        ap.error("--count must be >= 1")
+
+    def parse_xy(s):
+        x, y = (int(v) for v in s.split(","))
+        return x, y
+
     try:
-        sx, sy = (int(v) for v in args.start.split(","))
+        fallback_start = parse_xy(args.start)
+        starts = [parse_xy(s) for s in args.starts.split(";") if s.strip()]
     except ValueError:
-        ap.error("--start must be 'x,y' nominal pixels")
+        ap.error("--start/--starts must be 'x,y' nominal pixels (semicolon-separated for --starts)")
+    modes = [m for m in args.modes.split(",") if m.strip()]
+    for m in modes:
+        if m not in ("chase", "avoid", "patrol"):
+            ap.error("--modes entries must be chase|avoid|patrol")
 
     fps = TV_FPS[args.tv]
     frames_per_tick = max(1, int(round(fps / args.hz)))
     steps_per_tick = args.speed * frames_per_tick
     table = motion_table(args.speed_scale)
-    adv = TankSim(sx, sy, 0, table)
+
+    # One independent adversary per index: own sim + AI mode. ALL advs now share ONE
+    # combined packet per tick (out_seq below), so there is no per-adversary sequence.
+    advs = []
+    for i in range(args.count):
+        sx, sy = starts[i] if i < len(starts) else fallback_start
+        mode = modes[i] if i < len(modes) else args.mode
+        advs.append({"sim": TankSim(sx, sy, 0, table), "mode": mode})
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -210,9 +269,12 @@ def main():
     reasm = Reassembler(DEFAULT_SIZE)
 
     target = (args.target_host, args.target_port) if args.target_host else None
-    print("edge_tank_adversary: bound %s:%d mode=%s hz=%g fpt=%d steps/tick=%d scale=%d"
-          % (args.host, args.port, args.mode, args.hz, frames_per_tick,
+    print("edge_tank_adversary: bound %s:%d advs=%d hz=%g fpt=%d steps/tick=%d scale=%d"
+          % (args.host, args.port, len(advs), args.hz, frames_per_tick,
              steps_per_tick, args.speed_scale))
+    for i, a in enumerate(advs):
+        print("  adv %d: mode=%s start=(%d,%d)"
+              % (i, a["mode"], a["sim"].x_nom, a["sim"].y_nom))
     if target:
         print("streaming to %s:%d" % target)
     else:
@@ -220,12 +282,19 @@ def main():
 
     player = None             # last-known player (x,y) nominal
     player_last_seq = None
-    out_seq = 0
     period = 1.0 / args.hz
     next_send = time.monotonic()
     t0 = time.monotonic()
     win_start = t0
     rx = tx = bad = stale = 0
+    # Timing-echo diagnostics: how many combined packets the client is behind (lag),
+    # tracked as the latest value plus the run-wide min/max so a growing trend is
+    # obvious. pkt_sent_seq is the most recent combined-packet seq we transmitted.
+    out_seq = 0                # combined-packet sequence (one per tick, all advs)
+    pkt_sent_seq = None
+    lag_pkts = None
+    lag_min = lag_max = None
+    cli_ovf = 0          # latest client-reported RX-overflow-event count (echo_flags)
 
     try:
         while True:
@@ -247,28 +316,44 @@ def main():
                         player_last_seq = f["seq"]
                         player = (f["x"], f["y"])
                         rx += 1
+                        cli_ovf = f["echo_flags"]
+                        # End-to-end lag: how far adv[0]'s last-applied snapshot trails
+                        # the seq we most recently sent (>=0; clamp tiny negatives from
+                        # in-flight reorder to 0). Resolution ~1 packet = one send tick.
+                        if pkt_sent_seq is not None:
+                            d = seq_delta(pkt_sent_seq, f["echo_seq"])
+                            lag_pkts = d if d > 0 else 0
+                            lag_min = lag_pkts if lag_min is None else min(lag_min, lag_pkts)
+                            lag_max = lag_pkts if lag_max is None else max(lag_max, lag_pkts)
                         if target is None:
                             target = addr
                             print("learned target %s:%d" % (target[0], target[1]))
                         if args.decode:
-                            print("rx player seq=%d pos=(%d,%d) hdg=%d spd=%d"
-                                  % (f["seq"], f["x"], f["y"], f["heading"], f["speed"]))
+                            lag_s = ("lag=%d (~%dms)" % (lag_pkts, round(lag_pkts * period * 1000))
+                                     if lag_pkts is not None else "lag=?")
+                            print("rx player seq=%d pos=(%d,%d) hdg=%d spd=%d  %s ovf=%d"
+                                  % (f["seq"], f["x"], f["y"], f["heading"], f["speed"],
+                                     lag_s, cli_ovf))
             except BlockingIOError:
                 pass
 
             now = time.monotonic()
             if now >= next_send:
-                # Advance the adversary EXACTLY as the client will dead-reckon it,
-                # then snapshot — so the client's snap matches its own DR (no jump).
-                adv.heading = choose_heading(args.mode, adv, player,
-                                             now - t0, args.patrol_period)
-                adv.advance(steps_per_tick)
+                # Advance each adversary EXACTLY as the client will dead-reckon it, then
+                # snapshot ALL of them into ONE combined packet (downstream-overload fix:
+                # 1 pkt/tick instead of one-per-adversary). Client snap matches its own DR.
+                recs = []
+                for a in advs:
+                    sim = a["sim"]
+                    sim.heading = choose_heading(a["mode"], sim, player,
+                                                 now - t0, args.patrol_period)
+                    sim.advance(steps_per_tick)
+                    recs.append({"x": sim.x_nom, "y": sim.y_nom,
+                                 "heading": sim.heading, "speed": args.speed})
                 if target is not None:
-                    sock.sendto(encode({"type": TYPE_ADVERSARY, "status": 0x01,
-                                        "seq": out_seq, "x": adv.x_nom, "y": adv.y_nom,
-                                        "heading": adv.heading, "speed": args.speed}),
-                                target)
+                    sock.sendto(encode_adversaries(out_seq, recs), target)
                     tx += 1
+                    pkt_sent_seq = out_seq            # combined-packet seq just sent
                     out_seq = (out_seq + 1) & 0xFFFF
                 next_send += period
                 if next_send < now:
@@ -276,9 +361,15 @@ def main():
 
             if now - win_start >= args.stats_interval:
                 el = now - win_start
-                print("%.1fs: rx %.1f/s tx %.1f/s  adv=(%d,%d) hdg=%d  bad=%d stale=%d resync=%dB"
-                      % (el, rx / el, tx / el, adv.x_nom, adv.y_nom, adv.heading,
-                         bad, stale, reasm.resync_bytes))
+                pos = " ".join("(%d,%d)" % (a["sim"].x_nom, a["sim"].y_nom) for a in advs)
+                if lag_pkts is None:
+                    lag_s = "lag=? "
+                else:
+                    lag_s = ("lag=%d (~%dms, min%d/max%d) ovf=%d "
+                             % (lag_pkts, round(lag_pkts * period * 1000),
+                                lag_min, lag_max, cli_ovf))
+                print("%.1fs: rx %.1f/s tx %.1f/s  advs=%s  %sbad=%d stale=%d resync=%dB"
+                      % (el, rx / el, tx / el, pos, lag_s, bad, stale, reasm.resync_bytes))
                 win_start = now
                 rx = tx = 0
 


### PR DESCRIPTION
This pull request upgrades the networked tank demo from a two-tank to a multi-tank (four-tank) architecture, improves the efficiency and reliability of the realtime network protocol, and validates the system on physical FujiNet hardware. The most significant changes include packing all adversaries into a single packet per tick, supporting configurable packet sizes and baud rates, updating protocol structures, and revising documentation to reflect these features and requirements.

**Networking protocol and demo architecture:**
- The demo now supports three network-driven adversary tanks (instead of one), packing all adversaries into a single 32-byte packet per tick, reducing downstream packet rate and mitigating firmware pacing/backpressure issues. (`TankPacket32`, `AdvRecord`, and related logic in `adversary_net.h`, `atari_tank_net_demo.cpp`, and documentation updates) [[1]](diffhunk://#diff-e5f6f322a113408cb3b30709d37b0fda507db8b0864719f3ecd1aa527e2160a8L27-R65) [[2]](diffhunk://#diff-e5f6f322a113408cb3b30709d37b0fda507db8b0864719f3ecd1aa527e2160a8L75-R160) [[3]](diffhunk://#diff-e3c5b86e5537aa53a9278107bf7c43b61957a1ba5f5d8ed39857838696038533L1-R29) [[4]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL220-R266) [[5]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL272-R292) [[6]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL287-R309)
- The networked demo is now validated on physical FujiNet hardware (requires fujinet-firmware v1.6.2+ for reliable operation), not just emulators. Documentation and comments updated to reflect this. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R70) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R83) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R30) [[4]](diffhunk://#diff-e3c5b86e5537aa53a9278107bf7c43b61957a1ba5f5d8ed39857838696038533L1-R29) [[5]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL220-R266)

**Configurability and build system:**
- Added per-demo configurable realtime packet size (`GameConfig::realtime_packet_bytes`, default 16) and build-time nominal baud override (`EDGE_NETSTREAM_NOMINAL_BAUD`), with CMake support for overriding these settings. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R30) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR569-R573)

**Protocol and code structure changes:**
- Updated the wire protocol from a fixed 16-byte (`TankPacket16`) to a 32-byte (`TankPacket32`) structure, allowing multiple adversaries per packet and including timing/health echo fields. All relevant code and static assertions updated. [[1]](diffhunk://#diff-e5f6f322a113408cb3b30709d37b0fda507db8b0864719f3ecd1aa527e2160a8L27-R65) [[2]](diffhunk://#diff-e5f6f322a113408cb3b30709d37b0fda507db8b0864719f3ecd1aa527e2160a8L75-R160)
- Refactored packet application logic for combined adversary updates and improved stale/duplicate detection at the packet level.

**Documentation:**
- All references and instructions updated to describe the new multi-tank setup, protocol changes, and hardware validation status. Example server commands and observed behaviors are revised for the new architecture. [[1]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL220-R266) [[2]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL272-R292) [[3]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL287-R309) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R70) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R83) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R30)

These changes collectively improve demo realism, network efficiency, and robustness, and ensure accurate documentation for developers and users.