### PR TITLE
Add tank_dual_net dual-lane demo + engine subsystem shutdown; release…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,28 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-27
+
 ### Added
+- **Dual-lane tank demo (`tank_dual_net`).** Uses **both** networking lanes
+  **sequentially** in one program: Phase 1 downloads the playfield map + tileset over
+  the reliable **TCP/session lane** (like the `tank` LiveSession mode), then closes it
+  and Phase 2 streams three adversaries over the **UDP/realtime lane** (like
+  `tank_net`). The lanes are never concurrent — the realtime lane reprograms POKEY
+  serial and can't coexist with fujinet-lib SIO traffic. Phase-1 source is a
+  target-private `EDGE_TANK_DUAL_ASSET_SOURCE` switch (`SimulatedNetwork` default —
+  builds with no fujinet-lib/server; `Embedded`; `LiveSession`). A combined server
+  (`tools/net/edge_tank_dual_server.py`) serves the assets over TCP then streams
+  adversaries over UDP and **loops back to Phase 1** on the client's "bye" packet.
+  Reuses the `tank` + `tank_net` headers verbatim. See [`demo/README.md`](demo/README.md).
+- **Engine subsystem teardown (`Game::shutdown()`).** `Core::shutdown` →
+  `Platform::hal::shutdown` lets a program hand control back to the OS/DOS cleanly
+  instead of running forever: closes any open net lanes, restores the OS VBI vectors
+  (`install_frame_isr` now saves them) and disables the DLI so a stale interrupt can't
+  fire into reclaimed RAM, blanks P/M graphics (P/M DMA **and** the GTIA `GRAFP`/`GRAFM`
+  registers — disabling DMA alone leaves a static vertical bar), silences POKEY, and
+  restores the charset/fine-scroll. Demos historically `run()` forever; `tank_dual_net`
+  is the first program that exits (keypress → `JMP (DOSVEC)`), which surfaced the gap.
 - **Per-demo realtime packet size** (`GameConfig::realtime_packet_bytes`, default 16)
   and a **build-overridable netstream nominal baud** (`EDGE_NETSTREAM_NOMINAL_BAUD`,
   default 31250 → AUDF3=21; e.g. 49700 selects the ~49.7k row). The Atari netstream HAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,10 +475,21 @@ if(EDGE_BUILD_DEMO)
     endif()
 
     # Dual-lane EDGE net API usage demo (stubbed seam; no real transport wiring).
-    add_executable(net_dual_lane_demo demo/net_dual_lane/net_dual_lane.cpp)
+    # When EDGE_ATARI_FUJINET_REALTIME_NETSTREAM is ON, the engine's RealtimeLane
+    # is compiled against the real _ns_* adapter (the define is global via
+    # add_compile_definitions above), so link the .S handlers to resolve those
+    # symbols — same pattern as edge_net_realtime_meter / atari_tank_net_demo.
+    set(NET_DUAL_LANE_SRC demo/net_dual_lane/net_dual_lane.cpp)
+    if(EDGE_ATARI_FUJINET_REALTIME_NETSTREAM)
+        list(APPEND NET_DUAL_LANE_SRC
+            engine/platform/atari/fujinet_netstream_realtime_abi.s
+            engine/platform/atari/fujinet_netstream_handler.S)
+    endif()
+    add_executable(net_dual_lane_demo ${NET_DUAL_LANE_SRC})
     target_compile_options(net_dual_lane_demo PRIVATE
         -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra)
-    target_include_directories(net_dual_lane_demo PRIVATE ${CMAKE_SOURCE_DIR})
+    target_include_directories(net_dual_lane_demo PRIVATE
+        ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/engine/platform/atari)
     set_target_properties(net_dual_lane_demo PROPERTIES OUTPUT_NAME "net_dual_lane_demo.xex")
     target_link_options(net_dual_lane_demo PRIVATE
         "LINKER:--Map=$<TARGET_FILE_DIR:net_dual_lane_demo>/net_dual_lane_demo.map")
@@ -572,6 +583,127 @@ if(EDGE_BUILD_DEMO)
         target_compile_definitions(atari_tank_net_demo PRIVATE EDGE_NETSTREAM_NOMINAL_BAUD=${EDGE_NETSTREAM_NOMINAL_BAUD})
     endif()
 
+    # Dual-lane tank demo (atari_tank_dual_net_demo.xex). Uses BOTH networking lanes
+    # SEQUENTIALLY: Phase 1 downloads the playfield over the TCP/session lane (like
+    # the tank LiveSession mode), then CLOSES it and streams 3 adversaries over the
+    # UDP/realtime lane (like tank_net). Reuses demo/tank + demo/tank_net headers via
+    # the include path.
+    #
+    # Phase-1 asset source, target-private (mirrors EDGE_TANK_ASSET_SOURCE), default
+    # SimulatedNetwork so the whole download->handoff->stream sequence builds and runs
+    # with NO fujinet-lib and NO server:
+    #   EDGE_TANK_DUAL_ASSET_SOURCE = Embedded | SimulatedNetwork | LiveSession
+    set(EDGE_TANK_DUAL_ASSET_SOURCE "SimulatedNetwork" CACHE STRING
+        "Dual-net demo Phase-1 asset source: Embedded | SimulatedNetwork | LiveSession")
+    set_property(CACHE EDGE_TANK_DUAL_ASSET_SOURCE PROPERTY STRINGS
+        Embedded SimulatedNetwork LiveSession)
+    if(EDGE_TANK_DUAL_ASSET_SOURCE STREQUAL "Embedded")
+        set(_TDN_SRC 0)
+    elseif(EDGE_TANK_DUAL_ASSET_SOURCE STREQUAL "SimulatedNetwork")
+        set(_TDN_SRC 1)
+    elseif(EDGE_TANK_DUAL_ASSET_SOURCE STREQUAL "LiveSession")
+        set(_TDN_SRC 2)
+    else()
+        message(FATAL_ERROR "EDGE_TANK_DUAL_ASSET_SOURCE must be Embedded, SimulatedNetwork, or LiveSession")
+    endif()
+
+    # Private embedded-asset gen headers (Embedded + SimulatedNetwork Phase 1 only;
+    # LiveSession receives them over the wire). Reuses the tank asset sources.
+    set(TANK_DUAL_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated/tank_dual_net)
+    set(TANK_DUAL_GEN_HEADERS "")
+    if(NOT _TDN_SRC EQUAL 2)
+        set(_td_tileset ${TANK_DUAL_GEN_DIR}/tank_tileset.gen.h)
+        add_custom_command(
+            OUTPUT ${_td_tileset}
+            COMMAND ${CMAKE_COMMAND}
+                    -DINPUT=${TANK_ASSET_SRC_DIR}/tank_tileset.fnt
+                    -DOUTPUT=${_td_tileset}
+                    -DSYMBOL=tileset_bytes -DNAMESPACE=demo::tank::assets
+                    -P ${GENERATE_CHARSET_HEADER_SCRIPT}
+            DEPENDS ${TANK_ASSET_SRC_DIR}/tank_tileset.fnt ${GENERATE_CHARSET_HEADER_SCRIPT}
+            COMMENT "Generating tank_dual_net tank_tileset.gen.h" VERBATIM)
+        list(APPEND TANK_DUAL_GEN_HEADERS ${_td_tileset})
+        foreach(C 0_0 1_0 0_1 1_1)
+            set(_h ${TANK_DUAL_GEN_DIR}/chunk_${C}.gen.h)
+            add_custom_command(
+                OUTPUT ${_h}
+                COMMAND ${CMAKE_COMMAND}
+                        -DINPUT=${TANK_ASSET_SRC_DIR}/chunk_${C}.scr
+                        -DOUTPUT=${_h}
+                        -DSYMBOL=chunk_${C} -DNAMESPACE=demo::tank::assets -DEXPECT_BYTES=960
+                        -P ${GENERATE_BYTES_HEADER_SCRIPT}
+                DEPENDS ${TANK_ASSET_SRC_DIR}/chunk_${C}.scr ${GENERATE_BYTES_HEADER_SCRIPT}
+                COMMENT "Generating tank_dual_net chunk_${C}.gen.h" VERBATIM)
+            list(APPEND TANK_DUAL_GEN_HEADERS ${_h})
+        endforeach()
+    endif()
+
+    # Phase 2 realtime lane: link the EDGE-owned netstream .S handlers when the real
+    # adapter is enabled (the define is global via add_compile_definitions); otherwise
+    # the realtime HAL is a stub and Phase 2 shows a red "NO NET".
+    set(TANK_DUAL_SRC
+        demo/tank_dual_net/atari_tank_dual_net_demo.cpp ${TANK_DUAL_GEN_HEADERS})
+    if(EDGE_ATARI_FUJINET_REALTIME_NETSTREAM)
+        list(APPEND TANK_DUAL_SRC
+            engine/platform/atari/fujinet_netstream_realtime_abi.s
+            engine/platform/atari/fujinet_netstream_handler.S)
+        message(STATUS "atari_tank_dual_net_demo — realtime lane: real Netstream adapter")
+    else()
+        message(STATUS "atari_tank_dual_net_demo — realtime lane: STUB HAL "
+            "(Phase 2 adversaries disabled; set -DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON)")
+    endif()
+    add_executable(atari_tank_dual_net_demo ${TANK_DUAL_SRC})
+    target_compile_options(atari_tank_dual_net_demo PRIVATE
+        -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra)
+    target_include_directories(atari_tank_dual_net_demo PRIVATE
+        ${CMAKE_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/demo/tank
+        ${CMAKE_SOURCE_DIR}/demo/tank_net
+        ${CMAKE_SOURCE_DIR}/engine/platform/atari
+        ${TANK_DUAL_GEN_DIR})
+    target_compile_definitions(atari_tank_dual_net_demo PRIVATE
+        EDGE_TANK_DUAL_ASSET_SOURCE=${_TDN_SRC})
+    set_target_properties(atari_tank_dual_net_demo PROPERTIES
+        OUTPUT_NAME "atari_tank_dual_net_demo.xex")
+    target_link_options(atari_tank_dual_net_demo PRIVATE
+        "LINKER:--Map=$<TARGET_FILE_DIR:atari_tank_dual_net_demo>/atari_tank_dual_net_demo.map")
+
+    # Phase-1 LiveSession backend: link the real fujinet-lib (session lane) when
+    # enabled; otherwise the session HAL is a stub that reports Ok without connecting.
+    if(_TDN_SRC EQUAL 2)
+        if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
+            target_include_directories(atari_tank_dual_net_demo PRIVATE ${EDGE_FUJINETLIB_INCLUDE_DIR})
+            target_link_libraries(atari_tank_dual_net_demo PRIVATE ${EDGE_FUJINETLIB_LIBRARY})
+            target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_TANK_LIVE_BACKEND_REAL=1)
+            message(STATUS "atari_tank_dual_net_demo LiveSession — session backend: RealFujinetLib")
+        else()
+            target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_TANK_LIVE_BACKEND_REAL=0)
+            message(WARNING
+                "atari_tank_dual_net_demo LiveSession selected WITHOUT the real fujinet-lib backend "
+                "(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB=OFF): Phase-1 session lane is a stub "
+                "that returns Ok without connecting. For real validation: "
+                "-DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON -DEDGE_FUJINETLIB_ROOT=<fujinetlib-llvm checkout>")
+        endif()
+        if(DEFINED EDGE_TANK_NET_HOST)
+            target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_TANK_NET_HOST="${EDGE_TANK_NET_HOST}")
+        endif()
+        if(DEFINED EDGE_TANK_NET_PORT)
+            target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_TANK_NET_PORT=${EDGE_TANK_NET_PORT})
+        endif()
+    endif()
+    if(DEFINED EDGE_TANK_HEADING)
+        target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_TANK_HEADING=${EDGE_TANK_HEADING})
+    endif()
+    if(DEFINED EDGE_NET_PEER_HOST)
+        target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_NET_PEER_HOST="${EDGE_NET_PEER_HOST}")
+    endif()
+    if(DEFINED EDGE_NET_PEER_PORT)
+        target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_NET_PEER_PORT=${EDGE_NET_PEER_PORT})
+    endif()
+    if(DEFINED EDGE_NETSTREAM_NOMINAL_BAUD)
+        target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_NETSTREAM_NOMINAL_BAUD=${EDGE_NETSTREAM_NOMINAL_BAUD})
+    endif()
+
     # Aggregate convenience target: build every always-available demo .xex with
     # one `cmake --build <dir> --target demos`. This is the stable name the
     # scripts/build_demos.sh wrapper and the README point at. The network-only
@@ -593,7 +725,8 @@ if(EDGE_BUILD_DEMO)
         arena_vbxe
         net_dual_lane_demo
         edge_net_realtime_meter
-        atari_tank_net_demo)
+        atari_tank_net_demo
+        atari_tank_dual_net_demo)
     return()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EDGE (Eight-bit Damned! Game Engine)
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
 
 EDGE is a C++20 game engine for constrained 6502-class systems, built around a small, deterministic, compile-time configured API instead of a heavy runtime.
 The project is Atari-first today, but its architecture is intended to support additional 6502-family platforms over time. Game code is written against portable engine subsystems while hardware details live behind a platform HAL and compile-time capability profiles.
@@ -74,6 +74,10 @@ Networking (`engine/net.h`):
 - the `net_dual_lane_demo` compiles and demonstrates the intended API shape; the
   `edge_net_realtime_meter` demo + host peer (`tools/net/edge_realtime_peer.py`)
   exercise and measure the realtime lane end to end
+- the **`tank_dual_net` demo uses both lanes sequentially in one program** — a TCP
+  session-lane playfield download, then a clean handoff to the realtime lane streaming
+  three adversaries — and exits cleanly to DOS on a keypress via `Game::shutdown()`
+  (see `demo/README.md`)
 
 Planned or intentionally deferred:
 
@@ -81,7 +85,6 @@ Planned or intentionally deferred:
 - realtime-lane wire framing / resync / checksum / sequence (boundaries are
   currently implicit and cannot recover from lost bytes — so firmware drops must be
   whole-frame aligned, as validated with the tank_net demo)
-- a real gameplay demo over the realtime lane
 
 ## Example program shape
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Hardware validation demo (`atari_hw_test.xex`)
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 A minimal Atari 8-bit program that drives every engine subsystem at once, so
 the engine's live ANTIC path can be confirmed on real hardware / emulators
@@ -308,6 +308,27 @@ network at `172.30.0.2:9000`).
 | Driving the player into a wall stops it; it never passes through | GTIA P0PF wall collision (white/COLPF0) + revert |
 | An adversary leaves the viewport → hidden; re-enters at the right spot | each drawn in the player's camera frame |
 | Red border when built without the netstream flag / with no peer | stub-HAL / no-transport indication |
+
+# Dual-lane tank demo (`atari_tank_dual_net_demo.xex`)
+
+Uses **both** networking lanes **sequentially** in one program
+([`tank_dual_net/`](tank_dual_net/)): Phase 1 downloads the playfield map + tileset
+over the **reliable TCP/session lane** (like the `tank` LiveSession mode), then closes
+it and Phase 2 streams the three adversaries over the **UDP/realtime lane** (like
+`tank_net`). The two lanes are never used at once — the realtime lane reprograms POKEY
+serial for continuous streaming and can't coexist with fujinet-lib SIO traffic.
+
+Phase-1 source is a target-private `EDGE_TANK_DUAL_ASSET_SOURCE` switch
+(`SimulatedNetwork` default — builds with no fujinet-lib and no server; `Embedded`;
+`LiveSession` — real TCP, needs the llvm-mos fujinet-lib). One combined server
+(`tools/net/edge_tank_dual_server.py`) serves the assets over TCP then streams
+adversaries over UDP, and **loops** back to waiting on the client's "bye".
+
+**Any keypress quits cleanly** — the new engine teardown `Game::shutdown()`
+(`Core::shutdown` → `Platform::hal::shutdown`) closes both net lanes, restores the OS
+VBI vectors, disables the DLI, fully blanks P/M graphics (DMA **and** the GRAFP/GRAFM
+registers), silences POKEY, and restores the charset/scroll, then exits to DOS via
+`DOSVEC`. Full build/server/verify details in [`tank_dual_net/README.md`](tank_dual_net/README.md).
 
 # Native bitmap primitive-drawing demo (`native_gfx.xex`)
 

--- a/demo/tank_dual_net/README.md
+++ b/demo/tank_dual_net/README.md
@@ -1,0 +1,121 @@
+# tank_dual_net — dual-lane (TCP download → UDP stream) tank demo
+
+Demonstrates **both** EDGE networking lanes in one program, used **sequentially**:
+
+| Phase | Lane | Transport | Does |
+|-------|------|-----------|------|
+| 1 | session | reliable TCP (fujinet-lib) | downloads the playfield map + tileset, with a loading screen |
+| handoff | — | — | closes TCP, installs the assets, opens the realtime lane |
+| 2 | realtime | unframed UDP netstream | streams 3 adversary tanks at ~10 Hz while you drive |
+
+This is the combination of [demo/tank](../tank) (LiveSession asset download) and
+[demo/tank_net](../tank_net) (adversary streaming) in a single binary.
+
+**Any keypress during Phase 2 quits cleanly:** the Atari sends a "bye" packet
+(`TankPacket32` type 2) to the server over a few frames, then calls `Game::shutdown()`
+and exits to DOS via `DOSVEC`. `Game::shutdown()` (new engine teardown —
+`Core::shutdown` → `Platform::hal::shutdown`) quiesces **every** subsystem init
+brought up: closes both net lanes, restores the OS VBI vectors and disables the DLI
+(so no stale interrupt fires into reclaimed RAM), turns off P/M graphics DMA (so no
+leftover sprite band paints over the OS screen), silences POKEY, and restores the
+charset/scroll. On the bye, the **server stops streaming and returns to Phase 1** —
+waiting for the next client's TCP asset request — so you can relaunch and go again.
+
+The two lanes are used one-after-the-other, never at once: the realtime lane
+reprograms POKEY serial for continuous streaming and cannot coexist with normal SIO
+command/response fujinet-lib traffic. So: *download, then switch to streaming.*
+
+Reuses `demo/tank` + `demo/tank_net` headers verbatim (added to the include path by
+CMake); only the two-phase sequencing and the TCP→close→UDP handoff are new
+([atari_tank_dual_net_demo.cpp](atari_tank_dual_net_demo.cpp)).
+
+> **Firmware:** the realtime lane requires **fujinet-firmware v1.6.2+** (whole-frame-
+> aligned drop-oldest). Older firmware byte-drops the unframed stream and desyncs the
+> adversaries. Same constraint as `demo/tank_net`.
+
+## Phase-1 asset source (`EDGE_TANK_DUAL_ASSET_SOURCE`)
+
+| Value | Phase 1 | fujinet-lib? | Server? |
+|-------|---------|--------------|---------|
+| `SimulatedNetwork` *(default)* | embedded assets fed through the real `AssetLoader` over several frames | no | no |
+| `Embedded` | skipped — compiled-in assets, straight to the handoff (test Phase 2 alone) | no | no |
+| `LiveSession` | real TCP download over `Game::net.session` | **yes** (llvm-mos `libfujinet.a`) | yes |
+
+The default `SimulatedNetwork` build proves the whole download → handoff → stream
+sequence with no library and no server (host / Altirra). Phase 2 needs
+`-DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON` for real streaming; without it the
+realtime lane is a stub, the adversaries stay hidden, and the border turns red
+("NO NET") — Phase 1 still runs.
+
+## Build
+
+Default (SimulatedNetwork; builds with the rest of the demos):
+
+```sh
+scripts/build_demos.sh                       # → build-atari/atari_tank_dual_net_demo.xex
+# or just this target:
+cmake --build build-atari --target atari_tank_dual_net_demo
+```
+
+Real dual-lane build (the decisive hardware config — both lanes + real fujinet-lib):
+
+```sh
+FNL=~/Projects/Atari/fujinetlib-llvm
+cmake -S . -B build-live \
+  -DCMAKE_TOOLCHAIN_FILE="$PWD/cmake/atari-toolchain.cmake" -DEDGE_BUILD_DEMO=ON \
+  -DEDGE_TANK_DUAL_ASSET_SOURCE=LiveSession \
+  -DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON \
+  -DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON \
+  -DEDGE_FUJINETLIB_ROOT="$FNL" \
+  -DEDGE_FUJINETLIB_INCLUDE_DIR="$FNL/src/include" \
+  -DEDGE_FUJINETLIB_LIBRARY="$FNL/build/libfujinet.a"
+cmake --build build-live --target atari_tank_dual_net_demo
+```
+
+Endpoint overrides (all optional): `-DEDGE_TANK_NET_HOST=` / `-DEDGE_TANK_NET_PORT=`
+(Phase-1 TCP), `-DEDGE_NET_PEER_HOST=` / `-DEDGE_NET_PEER_PORT=` (Phase-2 UDP),
+`-DEDGE_NETSTREAM_NOMINAL_BAUD=`.
+
+## Server
+
+One combined server serves the TCP asset transfer, then drops into the UDP adversary
+loop — mirroring the binary's own sequence:
+
+```sh
+tools/net/edge_tank_dual_server.py --port 9000
+```
+
+TCP and UDP share the port (different protocols); split with `--asset-port` /
+`--adv-port` if needed. It binds UDP before the TCP transfer so no early adversary
+packet is lost during the TCP linger. Adversary options (`--modes`, `--starts`,
+`--hz`, `--speed-scale`, …) match [edge_tank_adversary.py](../../tools/net/edge_tank_adversary.py).
+
+It **loops**: serve assets (TCP) → stream adversaries (UDP) → on the client's "bye",
+return to waiting for the next TCP request. Ctrl-C exits. The standalone
+`edge_tank_adversary.py` loops the same way (a bye → wait for the next client).
+
+Two-process alternative (same result):
+
+```sh
+tools/net/edge_tank_asset_server.py --oneshot     # then, once it completes:
+tools/net/edge_tank_adversary.py --port 9000
+```
+
+## Verify
+
+1. **Host / Altirra, no server** — build the default and screenshot it:
+   `scripts/altirra_screenshot.sh build-atari/atari_tank_dual_net_demo.xex out.png 10`.
+   The playfield (walls + map tiles) and the gold player tank confirm Phase-1
+   download + handoff + gameplay. Press any key to confirm the loop unwinds and the
+   lane closes (heads-up: Altirra shares the X display).
+2. **Altirra + NetSIO + combined server** — LiveSession build, both gates ON: the
+   loading screen completes, then 3 adversaries stream in; the server log shows the
+   TCP transfer (66 messages) followed by UDP `learned target` + adversary tx.
+3. **Real FujiNet hardware (decisive)** — same LiveSession build vs the combined
+   server on the LAN. This is the only test that proves `session.close()` →
+   `open_udp_seq()` releases/reprograms the SIO/POKEY cleanly for real. Build with
+   `-DEDGE_TANK_NET_DIAG` to self-dump the final state to `H:TANKDBG.BIN` if the
+   handoff stalls.
+
+> The realtime open blocks for ~30 frames during clock renegotiation (Netstream
+> "settle") right after the handoff — a brief screen freeze, not a hang.

--- a/demo/tank_dual_net/atari_tank_dual_net_demo.cpp
+++ b/demo/tank_dual_net/atari_tank_dual_net_demo.cpp
@@ -1,0 +1,550 @@
+// demo/tank_dual_net/atari_tank_dual_net_demo.cpp — EDGE dual-lane tank demo.
+//
+// Demonstrates BOTH EDGE networking lanes in ONE program, used SEQUENTIALLY:
+//
+//   PHASE 1 — TCP / session lane (reliable).  On boot the playfield map + tileset
+//             are downloaded over the reliable session lane with a loading screen,
+//             exactly like demo/tank's LiveSession mode (asset_loader.h +
+//             net_session_loader.h + asset_protocol.h).
+//   HANDOFF — the TCP session is CLOSED, the downloaded tileset/map are installed,
+//             then the UDP realtime lane is OPENED.
+//   PHASE 2 — UDP / realtime lane (unframed netstream).  Three server-driven
+//             adversary tanks are streamed at ~10 Hz while the local player drives,
+//             exactly like demo/tank_net (adversary_net.h).
+//
+// The two lanes are used one-after-the-other, never concurrently: the realtime lane
+// reprograms POKEY serial for continuous streaming and cannot coexist with normal
+// SIO command/response fujinet-lib traffic. "Download, then switch to streaming."
+//
+// Any keypress during Phase 2 closes the realtime lane cleanly and stops the demo.
+//
+// Reuses demo/tank + demo/tank_net headers verbatim (added to the include path by
+// CMake); only the two-phase sequencing + the TCP->close->UDP handoff are new.
+//
+// ── Phase-1 asset source (EDGE_TANK_DUAL_ASSET_SOURCE) ──────────────────────────
+//   SimulatedNetwork (default) — the Stage-5A protocol is fed from embedded assets
+//                                through the real AssetLoader over several frames
+//                                (no connection, no server). Builds with NO
+//                                fujinet-lib; proves the whole download->handoff
+//                                sequence host-side / in Altirra.
+//   Embedded                   — skip Phase 1; fill the map from compiled-in assets
+//                                and go straight to the handoff (test Phase 2 alone).
+//   LiveSession                — real TCP download over Game::net.session; requires
+//                                -DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON + the
+//                                llvm-mos libfujinet.a, plus the asset server.
+//
+// Phase 2 needs -DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON for real streaming;
+// otherwise the realtime lane is a stub (open_udp_seq -> Unsupported), the
+// adversaries stay hidden and the border turns red ("NO NET"). Phase 1 still runs.
+//
+// REQUIRES fujinet-firmware v1.6.2+ for the realtime lane (whole-frame-aligned
+// drop-oldest); older firmware desyncs the unframed deframer. See demo/tank_net.
+
+#include <stdint.h>
+
+#include <engine/platform/atari/platform.h>
+#include <engine/core.h>
+
+#include "playfield_geometry.h"
+#include "tank_camera.h"
+#include "tank_motion.h"
+#include "tank_palette.h"
+#include "tank_shapes.h"
+
+#include "adversary_net.h"           // Phase 2: demo-local packet + dead-reckoning
+
+// ── Phase-1 asset-source selection ──────────────────────────────────────────
+#define DUAL_ASSET_EMBEDDED   0
+#define DUAL_ASSET_SIMULATED  1
+#define DUAL_ASSET_LIVE       2
+#ifndef EDGE_TANK_DUAL_ASSET_SOURCE
+#define EDGE_TANK_DUAL_ASSET_SOURCE DUAL_ASSET_SIMULATED
+#endif
+// Net mode == Phase 1 loads into a game-owned tileset buffer (Simulated/Live);
+// Embedded installs the compiled-in tileset directly via Game::init(tileset).
+#define DUAL_NET_MODE (EDGE_TANK_DUAL_ASSET_SOURCE != DUAL_ASSET_EMBEDDED)
+
+#if EDGE_TANK_DUAL_ASSET_SOURCE != DUAL_ASSET_LIVE
+#include "playfield_assets.h"        // embedded tileset + chunks (NOT in live mode)
+#endif
+#if DUAL_NET_MODE
+#include "asset_loader.h"
+#include "asset_protocol.h"
+#endif
+#if EDGE_TANK_DUAL_ASSET_SOURCE == DUAL_ASSET_LIVE
+#include "net_session_loader.h"
+#endif
+
+using engine::u8;
+using engine::u16;
+using engine::i16;
+namespace M = atari;
+namespace net = engine::net;
+using G = tank::PlayfieldGeometry;
+
+// ── Phase-2 peer endpoint (UDP realtime lane), build-time overridable ──────────
+//   -DEDGE_NET_PEER_HOST='"172.30.0.2"' -DEDGE_NET_PEER_PORT=9000
+#ifndef EDGE_NET_PEER_HOST
+#define EDGE_NET_PEER_HOST "192.168.1.205"
+#endif
+#ifndef EDGE_NET_PEER_PORT
+#define EDGE_NET_PEER_PORT 9000
+#endif
+static constexpr const char* kPeerHost  = EDGE_NET_PEER_HOST;
+static constexpr u16         kPeerPort   = EDGE_NET_PEER_PORT;
+static constexpr u16         kLocalPort  = 0;
+
+// ── Platform + game configuration ────────────────────────────────────────────
+// Network::Fujinet exposes BOTH lanes (Game::net.session + Game::net.realtime),
+// regardless of the Phase-1 source (Phase 2 always needs the realtime lane).
+using Platform = atari::Platform<atari::Machine::XL, atari::RAM::Baseline,
+                                 atari::gfx::Baseline, atari::Sound::Mono,
+                                 atari::TV::NTSC, atari::Network::Fujinet>;
+
+struct PlayScreen {
+    using display = engine::DisplayLayout<
+        engine::ScrollRegion<engine::TextRegion<M::Mode::MODE_4, 24>,
+                             G::physical_width, G::physical_height>>;
+};
+// 1 local player + kAdvCount adversaries must stay <= the 4 hardware players for
+// direct-bind; 3 fills it exactly (single zone, no multiplexer).
+static constexpr u8 kAdvCount = 3;
+
+struct GameConfig {
+    using screens = engine::ScreenSet<PlayScreen>;
+    static constexpr u8 max_sprites    = 1 + kAdvCount;   // local player + adversaries
+    static constexpr u8 sound_channels = 1;
+    // No multiplexer: pin slot i -> player i for the whole frame so the tanks never
+    // swap players/colours when they cross in Y (chasing adversaries cross constantly).
+    static constexpr engine::SpriteBinding sprite_binding = engine::SpriteBinding::Direct;
+    // Widen the realtime frame so ONE packet carries all kAdvCount adversaries per tick
+    // (10 pkt/s) instead of one each (30 pkt/s) — the downstream-overload mitigation.
+    static constexpr u16 realtime_packet_bytes = sizeof(tanknet::TankPacket32);
+};
+static_assert(tanknet::kMaxAdv >= kAdvCount, "combined packet must hold every adversary");
+using Game = engine::Core<Platform, GameConfig>;
+
+static tank::PhysicalMap g_map;
+static_assert(Platform::capabilities::screen_buffer_alignment == tank::kScanWrapBoundary,
+              "kScanWrapBoundary must match the platform scan-wrap granularity");
+
+static constexpr u8 kFps        = Platform::capabilities::frames_per_second;
+static constexpr u8 kTurnPeriod = (kFps >= 60) ? 7 : 6;
+static constexpr u8 kPlayerColor = 0x1E;   // brassy (matches the original tank)
+// One vivid colour per adversary, each a hue NOT used by the playfield palette so no
+// adversary is camouflaged against a wall/tile: pink, purple, cyan.
+static constexpr u8 kAdvColors[kAdvCount] = { 0x48, 0x68, 0x98 };
+
+// Send the local player's snapshot at ~10 Hz (every ~6 frames at 60 fps / 5 at 50).
+static constexpr u8 kTxPeriod = (kFps >= 60) ? 6 : 5;
+
+// ── Local tank state ──────────────────────────────────────────────────────────
+#ifndef EDGE_TANK_HEADING
+#define EDGE_TANK_HEADING 0
+#endif
+// Spawn upper-right with a margin from the border walls (so the 16x16 sprite does
+// not start already wall-touching). Adversaries start in the other corners (server).
+static tank::TankState g_tank = {
+    static_cast<i16>(600 << 4), static_cast<i16>(32 << 4),
+    static_cast<u8>(EDGE_TANK_HEADING), 0,
+};
+
+// GTIA player->playfield collision: P0PF bit 0 = COLPF0, the white wall colour.
+static constexpr u8 kWallColpfMask = 0x01;
+
+// Mutable game state bundled into ONE struct so it lands in main RAM (.bss), not the
+// near-full zero page — small separate statics get zp-promoted and overflow it.
+struct GameState {
+    tanknet::Adversary  adv[kAdvCount];   // network-driven adversaries
+    tanknet::AdvRxState adv_rx;           // shared packet-level seq gate (combined snapshot)
+    tank::TankState     tank_safe;        // last position player 0 was NOT touching a wall
+    u8  player_speed;                     // 1 while the player is moving (for the TX packet)
+    u16 tx_seq;
+    u8  tx_frame;
+    u8  rx_overflow_count;                // saturating RX-overflow events since last TX (echoed)
+    u8  bye_frames;                       // quit: frames left to send/drain the "bye" packet
+    u8  bss_anchor[24];                   // force .bss placement (main RAM is plentiful)
+};
+static GameState g_st = {};
+
+// Playfield background. Darker than the shared palette's 0x04 (same hue, lower
+// luminance) but not black — local to this demo.
+static constexpr u8 kPlayfieldBg = 0x02;
+
+#if DUAL_NET_MODE
+// One page-aligned, game-owned 1024-byte tileset buffer (the accepted duplicate),
+// filled by the Phase-1 loader and installed at the handoff via the public charset
+// API. Declared here (before enter_streaming) so the handoff can reference it.
+alignas(256) static engine::TilesetData<1024> g_net_tileset;
+
+static void show_progress(bool failed, bool complete) {
+    Platform::hal::set_color_pf(4, failed ? 0x34 : (complete ? 0xC6 : 0x24));
+}
+#endif
+
+static void set_palette() {
+    using P = tank::Palette;
+    Platform::hal::set_color_pf(0, P::colpf0);
+    Platform::hal::set_color_pf(1, P::colpf1);
+    Platform::hal::set_color_pf(2, P::colpf2);
+    Platform::hal::set_color_pf(3, P::colpf3);
+    Platform::hal::set_color_pf(4, kPlayfieldBg);
+}
+
+// ── Phase 2: sprite submission (copied from demo/tank_net) ─────────────────────
+// Project a world point into the PLAYER's camera frame (the camera follows the
+// player, so the adversaries must be placed relative to the same submitted scroll).
+static inline i16 screen_cc_in_cam(i16 world_x_nom, u16 cam_cc) {
+    return static_cast<i16>((world_x_nom >> 1) - static_cast<i16>(cam_cc));
+}
+static inline i16 screen_sl_in_cam(i16 world_y_nom, u16 cam_sl) {
+    return static_cast<i16>(world_y_nom - static_cast<i16>(cam_sl));
+}
+
+static void submit_tank(u8 slot, const tank::TankState& s, u16 cam_cc, u16 cam_sl) {
+    const i16 wx  = tank::world_x_nominal(s);
+    const i16 wy  = tank::world_y_nominal(s);
+    const i16 scc = screen_cc_in_cam(wx, cam_cc);
+    const i16 ssl = screen_sl_in_cam(wy, cam_sl);
+    if (tank::tank_visible(scc, ssl)) {
+        const i16 px = static_cast<i16>(tank::kPmgOriginX + scc - tank::kHalfTankCC);
+        const i16 py = static_cast<i16>(tank::kPmgOriginY + ssl - tank::kHalfTankSL);
+        Game::sprite(slot, tank::shape_for(tank::silhouette_for(s.heading)),
+                     static_cast<u8>(px), static_cast<u8>(py));
+    } else {
+        Game::sprite_hide(slot);
+    }
+}
+
+// Local player (slot 0) + adversaries (slots 1..kAdvCount), all in the player camera.
+static void submit_sprites() {
+    const i16 pwx = tank::world_x_nominal(g_tank);
+    const i16 pwy = tank::world_y_nominal(g_tank);
+    const u16 cam_cc = tank::camera_scroll_x_for_world_x(pwx);
+    const u16 cam_sl = tank::camera_scroll_y_for_world_y(pwy);
+    Game::scroll.set(cam_cc, cam_sl);
+
+    submit_tank(0, g_tank, cam_cc, cam_sl);     // local player (always on-screen)
+    for (u8 i = 0; i < kAdvCount; ++i) {
+        const u8 slot = static_cast<u8>(i + 1);
+        if (g_st.adv[i].have_state) submit_tank(slot, g_st.adv[i].s, cam_cc, cam_sl);
+        else                        Game::sprite_hide(slot);
+    }
+}
+
+// ── Phase 2: per-frame step (copied from demo/tank_net) ────────────────────────
+// Order matters (ADR-016: poll the network ONCE per frame here, never in the VBI).
+static void streaming_frame_step(const engine::Input& in) {
+    if (Game::net.realtime.active()) {
+        Game::net.realtime.poll();
+        // 1. Drain authoritative snapshots. ONE combined packet carries all adversaries;
+        //    the seq gate keeps the newest (older/dup packets are dropped wholesale).
+        tanknet::TankPacket32 pkt{};
+        while (Game::net.realtime.recv(pkt)) {
+            tanknet::adv_apply_packet(g_st.adv, kAdvCount, g_st.adv_rx, pkt);
+        }
+        if (Game::net.realtime.consume_rx_overflowed() && g_st.rx_overflow_count < 255)
+            ++g_st.rx_overflow_count;
+        // 2. Dead-reckon every adversary forward between snapshots.
+        for (u8 i = 0; i < kAdvCount; ++i) tanknet::adv_dead_reckon(g_st.adv[i]);
+    }
+
+    // 2b. GTIA wall collision for player 0 (direct-bind: slot 0 IS hardware player 0).
+    if (Game::sprite_collisions().sprite_to_background(0) & kWallColpfMask) {
+        g_tank = g_st.tank_safe;
+    } else {
+        g_st.tank_safe = g_tank;
+    }
+
+    // 3. Local tank input + movement (unchanged from the original tank demo).
+    const tank::Intent intent = tank::resolve_input(in.left(), in.right(), in.up(), in.down());
+    if (intent.rotate != 0) {
+        if (g_tank.turn_counter == 0) {
+            g_tank.heading = (intent.rotate > 0) ? tank::heading_cw(g_tank.heading)
+                                                 : tank::heading_ccw(g_tank.heading);
+            g_tank.turn_counter = kTurnPeriod;
+        } else { --g_tank.turn_counter; }
+    } else { g_tank.turn_counter = 0; }
+    tank::move_tank(g_tank, intent.move);
+    g_st.player_speed = (intent.move != 0) ? 1 : 0;
+
+    // 4. Stream our own state back to the server (bidirectional; all-or-nothing TX).
+    if (Game::net.realtime.active() && ++g_st.tx_frame >= kTxPeriod) {
+        g_st.tx_frame = 0;
+        Game::net.realtime.send(
+            tanknet::make_player_packet(g_tank, g_st.player_speed, g_st.tx_seq++,
+                                        g_st.adv_rx.last_seq, g_st.rx_overflow_count));
+        g_st.rx_overflow_count = 0;
+    }
+
+    // 5. Draw all tanks.
+    submit_sprites();
+}
+
+// Per-frame streaming + quit handling (one callback to keep the demo's near-full zero
+// page in budget — a separate quit callback tips it over). A keypress starts the quit:
+// we notify the server we are leaving so it returns to Phase 1 (waiting for a new asset
+// transfer) instead of streaming to a client that is gone. The realtime lane is
+// unframed/unreliable UDP, so send the "bye" over several frames — early frames enqueue
+// it (re-sending to survive loss), later frames only poll so the serial-out IRQ clocks
+// the ring onto the wire BEFORE realtime.close() resets the TX ring. The loop then
+// exits (screen briefly frozen ~0.2 s during the drain).
+static constexpr u8 kByeFrames    = 12;
+static constexpr u8 kByeSendUntil = 4;    // send while bye_frames >= this, then drain
+static bool streaming_step(const engine::Input& in) {
+    if (g_st.bye_frames != 0) {           // quitting: drain the bye, then end the loop
+        --g_st.bye_frames;
+        if (g_st.bye_frames >= kByeSendUntil)
+            Game::net.realtime.send(tanknet::make_bye_packet(g_st.tx_seq++));
+        Game::net.realtime.poll();
+        return g_st.bye_frames == 0;
+    }
+    if (in.key_pressed()) {
+        if (!Game::net.realtime.active()) return true;   // no lane: nothing to notify
+        g_st.bye_frames = kByeFrames;     // begin the bye drain; exit once it completes
+        return false;
+    }
+    streaming_frame_step(in);
+    return false;
+}
+
+[[noreturn]] static void halt_loop() { Game::run([](const engine::Input&) {}); }
+
+// Clean program exit: hand control back to the caller via DOSVEC ($0A) — DOS if the
+// demo was launched from DOS/FujiNet, or the OS self-test/Memo Pad if booted bare.
+// The realtime lane has already restored the OS vectors + disabled serial IRQs, so
+// the machine is in a normal OS state; this is the idiomatic Atari "program done".
+[[noreturn]] static void exit_to_dos() {
+    __asm__ volatile("jmp ($000A)");
+    __builtin_unreachable();
+}
+
+// ── HANDOFF + Phase 2 ─────────────────────────────────────────────────────────
+// Close the TCP/session lane, install the downloaded assets, open the UDP/realtime
+// lane, then stream until a keypress, then close the realtime lane cleanly.
+//
+// HANDOFF DISCIPLINE: the asset transfer is complete and fully drained before we get
+// here (loader.complete()/client.ready() only fire after the COMPLETE message was
+// consumed), so the session lane is idle. Close it FIRST — that releases the SIO/N:
+// device — then do only RAM/charset writes before open_udp_seq() reprograms POKEY.
+// No session SIO op may run between session.close() and open_udp_seq() returning.
+[[noreturn]] static void enter_streaming() {
+    Game::net.session.close();               // release SIO before realtime takes POKEY
+
+#if DUAL_NET_MODE
+    // Install the received tileset (page-aligned game-owned buffer, public API) and
+    // bind the freshly-filled map. Embedded mode already did this via Game::init().
+    Game::tiles.bind_charset_page(
+        static_cast<u8>(reinterpret_cast<uintptr_t>(&g_net_tileset) >> 8));
+#endif
+    set_palette();
+    Game::scroll_map(g_map);
+    g_st.tank_safe = g_tank;                 // seed the wall-free fallback to spawn
+
+    // Open the realtime lane (Netstream settle blocks for ~30 frames inside
+    // open_udp_seq — a brief screen freeze, NOT a hang). Tolerate failure (stub HAL /
+    // no peer): run player-only with adversaries hidden and a red "NO NET" border.
+    const net::NetStatus st = Game::net.realtime.open_udp_seq(kPeerHost, kPeerPort, kLocalPort);
+    if (st != net::NetStatus::Ok || !Game::net.realtime.active()) {
+        Platform::hal::set_color_pf(4, 0x34);    // "NO NET" — red background
+    }
+
+    submit_sprites();
+    // Streams until a keypress; on keypress it sends the "bye" to the server over a few
+    // frames (so it returns to Phase 1) and then returns.
+    Game::run_until(streaming_step);
+
+    // Quiesce every subsystem (closes both net lanes — disarming the netstream serial
+    // IRQs/vectors — and tears down the VBI/DLI, P/M graphics, sound, …) so nothing
+    // keeps running or references this program's RAM once we leave it.
+    Game::shutdown();
+    exit_to_dos();                           // hand control back to DOS
+}
+
+// ── Phase 1: SimulatedNetwork ──────────────────────────────────────────────────
+#if EDGE_TANK_DUAL_ASSET_SOURCE == DUAL_ASSET_SIMULATED
+namespace P = tank::proto;
+// Bundle the loader + scratch + index in one large struct so it lands in main RAM
+// (.bss), not the near-full zero page.
+struct SimFeed {
+    tank::AssetLoader loader;
+    u8 scratch[128];
+    u8 index;
+};
+static SimFeed g_sim;
+static constexpr u8 kXfer = 0x42;
+static constexpr u8 kSimCount = 66;
+
+static u16 build_sim_message(u8 index, u8* out) {
+    if (index == 0) return P::build_manifest(out, kXfer);
+    if (index <= 16) { const u16 blk = static_cast<u16>(index - 1);
+        return P::build_tileset_block(out, kXfer, static_cast<u16>(blk * 64),
+                                      &tank::tileset.data[blk * 64], 64); }
+    if (index <= 64) { const u8 j = static_cast<u8>(index - 17);
+        const u8 chunk = static_cast<u8>(j / 12), pair = static_cast<u8>(j % 12);
+        const u8 cx = static_cast<u8>(chunk & 1), cy = static_cast<u8>(chunk >> 1);
+        const u8 start = static_cast<u8>(pair * 2);
+        return P::build_chunk_rows(out, kXfer, cx, cy, start, 2,
+                                   &tank::chunk_payload(cx, cy)[start * 40]); }
+    return P::build_complete(out, kXfer);
+}
+static bool loading_step(const engine::Input&) {
+    for (u8 i = 0; i < 6 && g_sim.index < kSimCount && !g_sim.loader.failed(); ++i) {
+        const u8 idx = g_sim.index++;
+        const u16 sz = build_sim_message(idx, g_sim.scratch);
+        g_sim.loader.consume(g_sim.scratch, sz);
+    }
+    show_progress(g_sim.loader.failed(), g_sim.loader.complete());
+    return g_sim.loader.complete() || g_sim.loader.failed();
+}
+static bool phase1_ready() { return g_sim.loader.complete(); }
+#endif  // SIMULATED
+
+// ── Phase 1: LiveSession ───────────────────────────────────────────────────────
+#if EDGE_TANK_DUAL_ASSET_SOURCE == DUAL_ASSET_LIVE
+#ifndef EDGE_TANK_NET_HOST
+#define EDGE_TANK_NET_HOST "127.0.0.1"
+#endif
+#ifndef EDGE_TANK_NET_PORT
+#define EDGE_TANK_NET_PORT 9000
+#endif
+static const char kNetHost[] = EDGE_TANK_NET_HOST;     // ROM-resident endpoint
+static constexpr u16 kNetPort = EDGE_TANK_NET_PORT;
+static constexpr u8  kXfer = 0x42;
+
+// Build-embedded live-backend marker: a stub LiveSession build must never be mistaken
+// for a real network-capable one. This string lands in the .xex (and linker map).
+#ifndef EDGE_TANK_LIVE_BACKEND_REAL
+#define EDGE_TANK_LIVE_BACKEND_REAL 0
+#endif
+#if EDGE_TANK_LIVE_BACKEND_REAL
+[[gnu::used, gnu::retain]] static const char kLiveBackendMarker[] = "EDGE-LIVE-BACKEND:RealFujinetLib";
+#else
+[[gnu::used, gnu::retain]] static const char kLiveBackendMarker[] = "EDGE-LIVE-BACKEND:Stub";
+#endif
+// Loading-lane timeouts (frames), sized for REAL FujiNet SIO throughput. They reset
+// on each accepted message / successful connect, so they bound a genuine stall.
+static constexpr u16 kFpsW = Platform::capabilities::frames_per_second;
+static constexpr u16 kConnectTimeoutFrames    = static_cast<u16>(30 * kFpsW);
+static constexpr u16 kInactivityTimeoutFrames = static_cast<u16>(60 * kFpsW);
+
+using SessionT = decltype(Game::net.session);
+static tank::NetAssetClient<SessionT> g_client;
+
+struct NetDebug {
+    u8 state; u8 net_error; u8 loader_error; u8 messages; u16 bytes;
+    u8 last_kind; u8 outstanding; u8 overflow; u8 loader_tiles; u8 loader_rows;
+};
+// Bundle the debug record + diagnostic scratch into one larger struct so it lands in
+// main RAM, not the near-full zero page.
+struct LiveState {
+    NetDebug dbg;
+    u8 diag_scratch[24];
+};
+static volatile LiveState g_live = {};
+#define g_netdbg g_live.dbg
+
+static bool loading_step(const engine::Input&) {
+    g_client.update();
+    const tank::LoadProgress pr = g_client.loader().progress();
+    g_netdbg.state        = static_cast<u8>(g_client.state());
+    g_netdbg.net_error    = static_cast<u8>(g_client.net_error());
+    g_netdbg.loader_error = static_cast<u8>(g_client.loader_error());
+    g_netdbg.messages     = g_client.messages_received();
+    g_netdbg.bytes        = g_client.bytes_received();
+    g_netdbg.last_kind    = g_client.last_kind();
+    g_netdbg.outstanding  = g_client.outstanding();
+    g_netdbg.overflow     = g_client.overflow_seen() ? 1 : 0;
+    g_netdbg.loader_tiles = pr.tileset_blocks;
+    g_netdbg.loader_rows  = pr.chunk_rows;
+    show_progress(g_client.failed(), g_client.ready());
+    return g_client.ready() || g_client.failed();
+}
+static bool phase1_ready() { return g_client.ready(); }
+
+// Optional FujiNet transfer diagnostic (-DEDGE_TANK_NET_DIAG): on completion/failure,
+// self-dump the final client + session + fujinet-lib state to H:TANKDBG.BIN via CIO,
+// so a stalled TCP->UDP handoff is observable headless. Needs Altirra /hdpathrw.
+#ifdef EDGE_TANK_NET_DIAG
+static u8 tank_diag_cio(u8 cmd, const void* buf, u16 len) {
+    volatile u8* const ICCMD = (u8*)0x0352; volatile u8* const ICBAL = (u8*)0x0354;
+    volatile u8* const ICBAH = (u8*)0x0355; volatile u8* const ICBLL = (u8*)0x0358;
+    volatile u8* const ICBLH = (u8*)0x0359; volatile u8* const ICAX1 = (u8*)0x035A;
+    volatile u8* const ICAX2 = (u8*)0x035B;
+    const uintptr_t p = (uintptr_t)buf; u8 st = 0;
+    *ICBAL = (u8)(p & 0xff); *ICBAH = (u8)((p >> 8) & 0xff);
+    *ICBLL = (u8)(len & 0xff); *ICBLH = (u8)((len >> 8) & 0xff);
+    if (cmd == 3) { *ICAX1 = 8; *ICAX2 = 0; }
+    *ICCMD = cmd;
+    __asm__ volatile("ldx #$10\n\tjsr $E456\n\tsty %0" : "=r"(st) : : "a", "x", "y");
+    return st;
+}
+static void tank_net_diag_dump() {
+    static char fn[] = "H1:TANKDBG.BIN\x9b";
+    namespace FS = atari::fujinet_session;
+    const engine::net::NetError se = Game::net.session.last_error();
+    volatile u8* d = g_live.diag_scratch;
+    d[0]  = g_netdbg.state;        d[1]  = g_netdbg.net_error;
+    d[2]  = g_netdbg.loader_error; d[3]  = g_netdbg.messages;
+    d[4]  = g_netdbg.last_kind;    d[5]  = g_netdbg.outstanding;
+    d[6]  = g_netdbg.overflow;     d[7]  = g_netdbg.loader_tiles;
+    d[8]  = g_netdbg.loader_rows;  d[9]  = static_cast<u8>(se.status);
+    d[10] = static_cast<u8>(se.detail & 0xFF); d[11] = static_cast<u8>((se.detail >> 8) & 0xFF);
+    d[12] = FS::FujinetLibSessionAdapter::session_diag_fn_error();
+    d[13] = FS::FujinetLibSessionAdapter::session_diag_device_error();
+    d[14] = FS::FujinetLibSessionAdapter::session_diag_conn();
+    d[15] = static_cast<u8>(g_netdbg.bytes & 0xFF);
+    tank_diag_cio(3, fn, 0);                          // OPEN write
+    tank_diag_cio(11, (const void*)d, 16);            // PUT BINARY (16 diag bytes)
+    tank_diag_cio(12, nullptr, 0);                    // CLOSE
+}
+#endif
+#endif  // LIVE
+
+// ── Entry point ────────────────────────────────────────────────────────────────
+int main() {
+    // Sprite sizes + colours for all four players (local + adversaries).
+    Platform::hal::set_player_size(0, M::sizep::NORMAL);
+    Game::sprite_color(0, kPlayerColor);
+    for (u8 i = 0; i < kAdvCount; ++i) {
+        const u8 slot = static_cast<u8>(i + 1);
+        Platform::hal::set_player_size(slot, M::sizep::NORMAL);
+        Game::sprite_color(slot, kAdvColors[i]);
+    }
+
+#if EDGE_TANK_DUAL_ASSET_SOURCE == DUAL_ASSET_EMBEDDED
+    // No Phase 1: install compiled-in assets and go straight to the handoff.
+    Game::init(tank::tileset);
+    set_palette();
+    tank::clear_physical_map(g_map);
+    for (u8 cy = 0; cy < G::chunk_rows; ++cy)
+        for (u8 cx = 0; cx < G::chunk_columns; ++cx)
+            tank::copy_chunk_to_map(g_map, tank::chunk_payload(cx, cy), cx, cy);
+    enter_streaming();
+
+#elif EDGE_TANK_DUAL_ASSET_SOURCE == DUAL_ASSET_SIMULATED
+    // Phase 1: feed embedded assets through the real AssetLoader (no connection).
+    Game::init();
+    set_palette();
+    tank::clear_physical_map(g_map);
+    g_sim.loader.begin(&g_map, g_net_tileset.data);
+    Game::run_until(loading_step);
+    if (!phase1_ready()) halt_loop();
+    enter_streaming();
+
+#else  // DUAL_ASSET_LIVE
+    // Phase 1: real TCP download over the reliable session lane.
+    Game::init();
+    set_palette();
+    tank::clear_physical_map(g_map);
+    g_client.begin(&Game::net.session, &g_map, g_net_tileset.data,
+                   kNetHost, kNetPort, kXfer,
+                   kConnectTimeoutFrames, kInactivityTimeoutFrames);
+    Game::run_until(loading_step);
+#ifdef EDGE_TANK_NET_DIAG
+    tank_net_diag_dump();
+#endif
+    if (!phase1_ready()) halt_loop();
+    enter_streaming();
+#endif
+}

--- a/demo/tank_net/adversary_net.h
+++ b/demo/tank_net/adversary_net.h
@@ -66,6 +66,7 @@ inline constexpr u8 kVersion = 0x02;
 inline constexpr u8 kPattern = 0x5A;
 inline constexpr u8 kTypeAdversary = 0;   // server -> client
 inline constexpr u8 kTypePlayer    = 1;   // client -> server
+inline constexpr u8 kTypeBye       = 2;   // client -> server: leaving; stop streaming
 inline constexpr u8 kStatusHaveState = 0x01;
 
 inline constexpr u16 rd16(u8 lo, u8 hi) { return static_cast<u16>(lo | (hi << 8)); }
@@ -158,6 +159,19 @@ inline TankPacket32 make_player_packet(const tank::TankState& s, u8 speed, u16 s
     p.rec[0].speed   = speed;
     wr16(p.echo_seq_lo, p.echo_seq_hi, echo_adv_seq);  // adv[0] last-applied seq
     p.echo_flags = echo_flags;                         // client health byte
+    p.pattern = kPattern;
+    return p;
+}
+
+// Build the "leaving" packet the client streams just before it closes the realtime
+// lane (type 2). The server stops streaming this client and returns to waiting for a
+// new asset-transfer request. Carries no state — just magic/version/type + seq.
+inline TankPacket32 make_bye_packet(u16 seq) {
+    TankPacket32 p{};
+    p.magic   = kMagic;
+    p.version = kVersion;
+    p.type    = kTypeBye;
+    wr16(p.seq_lo, p.seq_hi, seq);
     p.pattern = kPattern;
     return p;
 }

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -1,6 +1,6 @@
 # API Design
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 The user-facing API for the engine. This document describes what
 a game author writes. Internal engine implementation details are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 System design, component relationships, and the abstraction
 boundaries that make the engine portable across 6502 platforms

--- a/docs/CONSTRAINTS.md
+++ b/docs/CONSTRAINTS.md
@@ -1,6 +1,6 @@
 # Constraints
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Hardware budgets, platform targets, and non-negotiable rules that
 every design decision must respect.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Decisions made during design, with rationale. These explain the
 "why" behind architectural choices and document tradeoffs.

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # EDGE API Reference
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This reference is organized in two layers:
 

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -1,6 +1,6 @@
 # EDGE Atari Platform Guide
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This document describes the first concrete EDGE backend: the Atari 8-bit family.
 

--- a/documents/QUICK_START.md
+++ b/documents/QUICK_START.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This guide introduces EDGE from the engine author's point of view first, then shows the current concrete setup using the Atari backend.
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 # EDGE Engine Documentation
 
-> **Applies to EDGE v0.7.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 EDGE is a C++ engine for building games and interactive applications on constrained 6502-class systems.
 

--- a/engine/core.h
+++ b/engine/core.h
@@ -391,6 +391,20 @@ public:
     static void run_until(Cb cb) { engine::run_until<Core>(cb); }
     static bool frame_overrun() { return engine::frame_overrun<Core>(); }
 
+    // Quiesce every subsystem so a program can hand control back to its host
+    // environment instead of running forever. Closes any open network lanes, then
+    // asks the platform to tear down whatever it brought up (interrupt handlers,
+    // display/graphics output, audio) so nothing keeps running — or references the
+    // program's memory — after control leaves it. The rationale for each step lives
+    // in the platform layer (Platform::hal::shutdown). Both pieces compile away on
+    // backends that lack them (e.g. the test build has no hal::shutdown).
+    static void shutdown() {
+        // Qualify the member (Core::net) so it is not parsed as the engine::net
+        // namespace, which is also in scope here.
+        if constexpr (requires { Core::net.close_all(); }) Core::net.close_all();
+        if constexpr (requires { Platform::hal::shutdown(); }) Platform::hal::shutdown();
+    }
+
     // Called by the loop once it has consumed a frame (after clearing frame_ready_),
     // so the backend can release any per-frame interrupt guard held across the VBI
     // exit. The Atari HAL clears its VBI re-entry guard here (closing the XITVBV

--- a/engine/platform/atari/hal.h
+++ b/engine/platform/atari/hal.h
@@ -464,6 +464,15 @@ struct Hal {
         const uint16_t i =
             static_cast<uint16_t>(reinterpret_cast<uintptr_t>(&edge_imm_vbi_trampoline));
 
+        // Save the OS VBI vectors once, before the first swap, so shutdown() can
+        // restore them revision-independently (instead of hardcoding OS ROM
+        // addresses that differ across XL / AltirraOS / 400-800).
+        if (!s_vbi_installed_) {
+            s_saved_vvblki_[0] = os::VVBLKI[0]; s_saved_vvblki_[1] = os::VVBLKI[1];
+            s_saved_vvblkd_[0] = os::VVBLKD[0]; s_saved_vvblkd_[1] = os::VVBLKD[1];
+            s_vbi_installed_ = true;
+        }
+
         // NMIEN is write-only (reads return NMIST), so it can't be RMW'd: blank
         // all NMIs while the two-byte os::VVBLKI/VVBLKD vectors are swapped to avoid
         // a VBI firing on a half-written vector, then re-enable the VBI NMI. The DLI
@@ -482,6 +491,58 @@ struct Hal {
     // still running — sees the guard and skips instead of piling up and corrupting
     // the stack. See the edge_vbi_busy comment above.
     static void frame_consumed() { edge_vbi_busy = 0; }
+
+    // ── Teardown (reverse of init) ───────────────────────────────────────
+    //
+    // The engine normally runs forever; a program that instead returns to the OS/DOS
+    // must first quiesce everything init brought up, or it leaves the machine in a
+    // broken state — a stale VBI/DLI vector fires into the program's now-reclaimed
+    // RAM (crash), and live P/M DMA keeps painting leftover sprites over the OS
+    // screen (the visible band on the self-test screen). uninstall_frame_isr undoes
+    // install_frame_isr; shutdown() composes the full teardown.
+
+    // Restore the saved OS VBI vectors and re-enable the VBI NMI only, so the OS VBI
+    // keeps running (RTCLOK, shadow copies) but the engine's service no longer fires.
+    // Blank NMIEN during the two-byte vector swaps (same reason as install). No-op if
+    // the VBI was never installed (e.g. a program that exits before Core::init).
+    static void uninstall_frame_isr() {
+        if (!s_vbi_installed_) return;
+        *reg::NMIEN = 0x00;                          // blank NMIs during the swap
+        os::VVBLKI[0] = s_saved_vvblki_[0]; os::VVBLKI[1] = s_saved_vvblki_[1];
+        os::VVBLKD[0] = s_saved_vvblkd_[0]; os::VVBLKD[1] = s_saved_vvblkd_[1];
+        nmien_set(nmien::VBI);                       // OS VBI only; DLI bit cleared
+        edge_vbi_busy = 0;                           // drop the re-entry guard
+        s_vbi_installed_ = false;
+    }
+
+    // Quiesce every subsystem this HAL brought up so the caller can hand control back
+    // to the OS/DOS (e.g. JMP (DOSVEC)). Order: stop interrupts that vector into our
+    // code FIRST (DLI, then the VBI service), then the things those interrupts drove
+    // (P/M DMA, sound, charset, fine scroll). Network lanes are closed separately by
+    // the engine net facade before this. Never executed under mos-sim (no NMI/ANTIC).
+    static void shutdown() {
+        disable_raster();                            // DLI off (NMIEN = VBI only)
+        set_raster_vector(0xE4EE);                   // VDSLST -> OS no-op RTI (belt & braces)
+        uninstall_frame_isr();                       // stop engine VBI; restore OS VBI
+        sprite_dma_disable();                        // P/M DMA + GRACTL off
+        // Disabling P/M DMA stops ANTIC reloading the GTIA player/missile graphics
+        // registers, but GTIA keeps displaying their LAST latched byte on every
+        // scanline — a full-height vertical bar (GRACTL only gates the DMA reload,
+        // not the display). Zero them so no sprite remnant survives on the OS screen.
+        *reg::GRAFP0 = 0; *reg::GRAFP1 = 0; *reg::GRAFP2 = 0; *reg::GRAFP3 = 0;
+        *reg::GRAFM = 0;
+        for (uint8_t ch = 0; ch < 4; ++ch) silence_voice(ch);
+        *reg::AUDCTL = 0x00;                          // POKEY quiet
+        set_charset_base(0xE0);                      // ROM font
+        *reg::HSCROL = 0x00; *reg::VSCROL = 0x00;    // immediate VBI no longer flushes these
+        edge_fine_hscrol = 0; edge_fine_vscrol = 0;
+    }
+
+   private:
+    // Saved OS VBI vectors (VVBLKI/VVBLKD), captured by install_frame_isr.
+    inline static uint8_t s_saved_vvblki_[2] = {0, 0};
+    inline static uint8_t s_saved_vvblkd_[2] = {0, 0};
+    inline static bool    s_vbi_installed_   = false;
 };
 
 // Enable or disable playfield DMA. Call this on an opaque overlay screen to

--- a/engine/version.h
+++ b/engine/version.h
@@ -10,8 +10,8 @@
 // EDGE follows Semantic Versioning (https://semver.org/): MAJOR.MINOR.PATCH.
 
 #define EDGE_VERSION_MAJOR 0
-#define EDGE_VERSION_MINOR 7
+#define EDGE_VERSION_MINOR 8
 #define EDGE_VERSION_PATCH 0
-#define EDGE_VERSION_STRING "0.7.0"
+#define EDGE_VERSION_STRING "0.8.0"
 
 #endif // ENGINE_VERSION_H

--- a/tools/net/edge_tank_adversary.py
+++ b/tools/net/edge_tank_adversary.py
@@ -57,6 +57,7 @@ VERSION = 0x02
 PATTERN = 0x5A
 TYPE_ADVERSARY = 0
 TYPE_PLAYER = 1
+TYPE_BYE = 2
 _MARKER = bytes((MAGIC, VERSION))
 
 # World clamp (nominal px) — the centre box from tank_motion.h clamp_world.
@@ -263,6 +264,23 @@ def main():
     if args.count < 1:
         ap.error("--count must be >= 1")
 
+    # Loop so a client BYE returns us to waiting for the next client (re-binds its own
+    # socket each round); Ctrl-C (interrupt) exits. Old clients that never send BYE
+    # simply stream until Ctrl-C, as before.
+    while run_adversary_server(args) == "bye":
+        print("client left — waiting for the next one...")
+
+
+def run_adversary_server(args, sock=None):
+    """Bind (or adopt) a UDP socket and stream adversary snapshots until interrupted.
+
+    Shared by main() and the combined dual-lane server (edge_tank_dual_server.py).
+    When `sock` is given it is used as-is (already bound, non-blocking) — the dual
+    server binds UDP BEFORE the TCP asset transfer so no early adversary packet is
+    lost during the TCP linger. Otherwise a fresh socket is bound to args.host:port.
+    Validation that main() performs with ap.error is repeated here via sys.exit so
+    the function is self-contained for either caller.
+    """
     def parse_xy(s):
         x, y = (int(v) for v in s.split(","))
         return x, y
@@ -271,11 +289,11 @@ def main():
         fallback_start = parse_xy(args.start)
         starts = [parse_xy(s) for s in args.starts.split(";") if s.strip()]
     except ValueError:
-        ap.error("--start/--starts must be 'x,y' nominal pixels (semicolon-separated for --starts)")
+        sys.exit("--start/--starts must be 'x,y' nominal pixels (semicolon-separated for --starts)")
     modes = [m for m in args.modes.split(",") if m.strip()]
     for m in modes:
         if m not in ("chase", "avoid", "patrol"):
-            ap.error("--modes entries must be chase|avoid|patrol")
+            sys.exit("--modes entries must be chase|avoid|patrol")
 
     fps = TV_FPS[args.tv]
     frames_per_tick = max(1, int(round(fps / args.hz)))
@@ -290,11 +308,24 @@ def main():
         mode = modes[i] if i < len(modes) else args.mode
         advs.append({"sim": TankSim(sx, sy, 0, table), "mode": mode})
 
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind((args.host, args.port))
-    sock.setblocking(False)
+    owns_sock = sock is None
+    if owns_sock:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((args.host, args.port))
+        sock.setblocking(False)
     reasm = Reassembler(DEFAULT_SIZE)
+
+    # Discard any datagrams buffered from a PREVIOUS client before streaming. A client
+    # quits by sending BYE several times (UDP is lossy); on a reused socket the extra
+    # BYEs — and stale player packets — would otherwise be read here and instantly end
+    # (or mislead) this fresh session. The new client streams continuously, so dropping
+    # whatever is already buffered at start is harmless.
+    try:
+        while True:
+            sock.recvfrom(2048)
+    except BlockingIOError:
+        pass
 
     target = (args.target_host, args.target_port) if args.target_host else None
     print("edge_tank_adversary: bound %s:%d advs=%d hz=%g fpt=%d steps/tick=%d scale=%d"
@@ -323,9 +354,10 @@ def main():
     lag_pkts = None
     lag_min = lag_max = None
     cli_ovf = 0          # latest client-reported RX-overflow-event count (echo_flags)
+    quitting = False     # set when the client sends a BYE (type 2): stop streaming
 
     try:
-        while True:
+        while not quitting:
             # Drain inbound player snapshots (learn target + track position).
             try:
                 while True:
@@ -335,6 +367,10 @@ def main():
                         if f is None:
                             bad += 1
                             continue
+                        if f["type"] == TYPE_BYE:
+                            print("client BYE (seq=%d) — ending stream" % f["seq"])
+                            quitting = True
+                            break
                         if f["type"] != TYPE_PLAYER:
                             continue
                         if player_last_seq is not None and \
@@ -362,8 +398,12 @@ def main():
                             print("rx player seq=%d pos=(%d,%d) hdg=%d spd=%d  %s ovf=%d"
                                   % (f["seq"], f["x"], f["y"], f["heading"], f["speed"],
                                      lag_s, cli_ovf))
+                    if quitting:
+                        break
             except BlockingIOError:
                 pass
+            if quitting:
+                break
 
             now = time.monotonic()
             if now >= next_send:
@@ -407,8 +447,14 @@ def main():
         print("\nsummary: %.1fs  bad=%d stale=%d resync=%dB" % (dur, bad, stale,
                                                                reasm.resync_bytes))
         print("shutting down.")
-    finally:
+        if owns_sock:
+            sock.close()
+        return "interrupt"
+    # Reached only when the client sent BYE. Leave a caller-owned socket open so the
+    # combined server can reuse it for the next round; close one we created ourselves.
+    if owns_sock:
         sock.close()
+    return "bye"
 
 
 if __name__ == "__main__":

--- a/tools/net/edge_tank_dual_server.py
+++ b/tools/net/edge_tank_dual_server.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""edge_tank_dual_server.py — combined server for the dual-lane tank demo (stdlib only).
+
+Pairs with demo/tank_dual_net/atari_tank_dual_net_demo.cpp, which uses BOTH EDGE
+networking lanes SEQUENTIALLY:
+
+  PHASE 1 — the Atari downloads the playfield map + tileset over the reliable
+            TCP/session lane (Stage-5A asset protocol).
+  HANDOFF — the Atari closes TCP and opens the UDP/realtime lane.
+  PHASE 2 — three adversary tanks are streamed to the Atari over UDP at ~10 Hz.
+
+This one process mirrors that sequence: it serves exactly one asset transfer over
+TCP, then drops into the adversary UDP loop — one command, the same mental model as
+the binary. All protocol logic is imported from the two standalone servers
+(edge_tank_asset_server.py, edge_tank_adversary.py); only the sequencing is new.
+
+TCP and UDP can share one port number (different protocols, different sockets), so a
+single --port (default 9000) usually suffices; --asset-port / --adv-port split them.
+
+The UDP socket is bound BEFORE the TCP asset transfer so that the first adversary-
+bound packets the Atari sends right after the handoff are never lost during the TCP
+linger window.
+
+If you prefer the two-process path, run instead:
+    edge_tank_asset_server.py --oneshot           # then, once it completes:
+    edge_tank_adversary.py --port 9000
+
+Stdlib only.
+"""
+
+import argparse
+import socket
+import sys
+
+import edge_tank_adversary as adv
+import edge_tank_asset_server as assets
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Combined TCP-assets-then-UDP-adversary server for the dual-lane tank demo.")
+    # Shared / transport.
+    ap.add_argument("--host", default="0.0.0.0", help="bind address (default 0.0.0.0)")
+    ap.add_argument("--port", type=int, default=9000,
+                    help="port shared by the TCP asset lane and UDP adversary lane (default 9000)")
+    ap.add_argument("--asset-port", type=int, default=None,
+                    help="TCP asset-lane port (default: --port)")
+    ap.add_argument("--adv-port", type=int, default=None,
+                    help="UDP adversary-lane port (default: --port)")
+    ap.add_argument("--linger", type=float, default=10.0,
+                    help="seconds to keep the TCP socket open after COMPLETE so the "
+                         "FujiNet client can drain the final messages before FIN")
+    # Phase-2 adversary options (mirror edge_tank_adversary.py).
+    ap.add_argument("--count", type=int, default=3,
+                    help="number of adversaries (default 3, the demo's kAdvCount)")
+    ap.add_argument("--mode", choices=["chase", "avoid", "patrol"], default="chase",
+                    help="fallback AI for adversaries not named in --modes (default chase)")
+    ap.add_argument("--modes", default="chase,avoid,patrol",
+                    help="per-adversary AI, comma list (default 'chase,avoid,patrol')")
+    ap.add_argument("--hz", type=float, default=10.0, help="snapshot rate (default 10)")
+    ap.add_argument("--tv", choices=["ntsc", "pal"], default="ntsc",
+                    help="client TV standard, for frames-per-tick (default ntsc)")
+    ap.add_argument("--speed", type=int, default=1,
+                    help="adversary dead-reckon speed in steps/frame (default 1)")
+    ap.add_argument("--speed-scale", type=int, default=3,
+                    help="must match the demo's EDGE_TANK_SPEED_SCALE (default 3)")
+    ap.add_argument("--start", default="160,96",
+                    help="fallback start x,y nominal for adversaries not in --starts")
+    ap.add_argument("--starts", default="40,344;624,376;624,16",
+                    help="per-adversary start x,y, semicolon list (default three corner areas)")
+    ap.add_argument("--patrol-period", type=float, default=0.6,
+                    help="seconds per heading step in patrol/no-player mode (default 0.6)")
+    ap.add_argument("--target-host", default=None,
+                    help="explicit client host (else learn from first inbound packet)")
+    ap.add_argument("--target-port", type=int, default=None, help="explicit client port")
+    ap.add_argument("--stats-interval", type=float, default=1.0,
+                    help="seconds between report lines (default 1.0)")
+    ap.add_argument("--decode", action="store_true", help="log inbound player packets")
+    args = ap.parse_args()
+
+    if (args.target_host is None) != (args.target_port is None):
+        ap.error("--target-host and --target-port must be given together")
+    if args.count < 1:
+        ap.error("--count must be >= 1")
+
+    asset_port = args.asset_port if args.asset_port is not None else args.port
+    adv_port = args.adv_port if args.adv_port is not None else args.port
+
+    # Bind the UDP adversary socket ONCE, up front, and keep it across rounds so the
+    # Atari's first post-handoff packets are buffered (not dropped) during the TCP
+    # linger, and so each new session reuses the same lane.
+    udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    udp.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    udp.bind((args.host, adv_port))
+    udp.setblocking(False)
+    # run_adversary_server() reads args.host/args.port; point them at the adv lane.
+    args.port = adv_port
+
+    print("dual server ready: TCP assets %s:%d  +  UDP adversaries %s:%d"
+          % (args.host, asset_port, args.host, adv_port))
+    try:
+        while True:
+            # PHASE 1 — serve exactly one asset transfer over TCP, then close listener.
+            tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            tcp.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            tcp.bind((args.host, asset_port))
+            tcp.listen(1)
+            print("PHASE 1 (TCP assets): waiting for a request on %s:%d ..."
+                  % (args.host, asset_port))
+            conn, addr = tcp.accept()
+            try:
+                assets.serve_one(conn, addr, oneshot=True, linger=args.linger)
+            except OSError as e:
+                print("  asset transfer error: %s — back to waiting" % e)
+                tcp.close()
+                continue
+            tcp.close()
+
+            # PHASE 2 — stream adversaries until the client sends BYE (then loop back
+            # to Phase 1) or Ctrl-C (exit). Reuses the persistent UDP socket.
+            print("PHASE 2 (UDP adversaries): streaming on %s:%d ..." % (args.host, adv_port))
+            if adv.run_adversary_server(args, sock=udp) == "interrupt":
+                break
+            print("client left — returning to wait for a new TCP asset request.")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        udp.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
… 0.8.0

demo/tank_dual_net: a demo that uses BOTH networking lanes sequentially — Phase 1 downloads the playfield over the TCP/session lane, hands off, then Phase 2 streams three adversaries over the UDP/realtime lane. Any keypress quits cleanly to DOS. Reuses the tank + tank_net headers verbatim; default SimulatedNetwork build needs no fujinet-lib or server.

engine: new teardown so a program can return to the OS/DOS instead of running forever. Game::shutdown() -> Core::shutdown -> Platform::hal::shutdown closes net lanes, restores the saved OS VBI vectors, disables the DLI, blanks P/M graphics (P/M DMA AND the GTIA GRAFP/GRAFM registers — disabling DMA alone leaves a static vertical bar), silences POKEY, and restores charset/scroll. install_frame_isr now saves the OS VBI vectors for revision-independent restore.

tools/net: combined edge_tank_dual_server.py (serves assets over TCP, then streams adversaries over UDP, loops back to Phase 1 on the client's bye); edge_tank_adversary.py refactored to run_adversary_server(args, sock) and detects the bye + drains stale datagrams between sessions.

adversary_net.h: TankPacket32 type 2 (bye) + make_bye_packet.

Bump version to 0.8.0; CHANGELOG, README, and demo docs updated.