### PR TITLE
tank demos: drive over fuel/ammo depots, block only on pure-white walls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+### Changed
+- **Tank demos let the player drive over fuel/ammo depots.** The `tank_net` and
+  `tank_dual_net` player wall collision now blocks only on *pure-white* (COLPF0)
+  contact. Depot icons draw white letters inside a coloured COLPF1/COLPF2 box, so their
+  colour bit is masked out of the wall test (`hit & kWallColpfMask && !(hit &
+  kDepotSurroundMask)`) and the tank drives over them while plain walls still stop it.
+  Derived from the live `P0PF` register — no depot tile codes hardcoded.
+
 ## [0.8.0] - 2026-06-27
 
 ### Added

--- a/demo/README.md
+++ b/demo/README.md
@@ -251,11 +251,15 @@ not the multiplexer.
 
 The local player starts in the **upper-right** of the world; the adversaries start in
 the other corners (the server's `--starts`). The player has **wall collision**: GTIA
-player→playfield collision (P0PF) is read each frame, and a hit on the white wall
-colour (COLPF0) snaps the player back to its last wall-free position. This is
-reliable specifically because of direct binding — logical slot 0 is always hardware
-player 0, so the P0PF mask is never reassigned by a multiplexer. (The adversaries are
-not wall-collided; their motion is the server's authority.)
+player→playfield collision (P0PF) is read each frame, and a *pure-white* hit (COLPF0
+with no colour bit) snaps the player back to its last wall-free position. Depot icons
+(fuel/ammo) draw white letters inside a coloured COLPF1/COLPF2 box, so they set a
+colour bit too — those are masked out of the wall test and the tank **drives over**
+them; only plain white walls stop it. The whole test is derived from the live P0PF
+register, with no depot tile codes hardcoded. This is reliable specifically because of
+direct binding — logical slot 0 is always hardware player 0, so the P0PF mask is never
+reassigned by a multiplexer. (The adversaries are not wall-collided; their motion is
+the server's authority.)
 
 > The realtime lane is validated on the emulator stack (Altirra + NetSIO + Docker peer)
 > **and on physical FujiNet hardware** (2026-06-27, this demo).
@@ -305,7 +309,8 @@ network at `172.30.0.2:9000`).
 | Their silhouettes match their headings as they turn | heading→silhouette on each received state |
 | Driving the player makes the adversaries chase/avoid/patrol | bidirectional link + per-adversary AI (server consumes the Atari's TX) |
 | Adversaries cross the player (and each other) in Y with **no colour flip** | direct binding, not the Y-sort multiplexer |
-| Driving the player into a wall stops it; it never passes through | GTIA P0PF wall collision (white/COLPF0) + revert |
+| Driving the player into a wall stops it; it never passes through | GTIA P0PF wall collision (pure white/COLPF0) + revert |
+| Driving over a fuel/ammo depot does **not** stop the tank | depot letters set a COLPF1/COLPF2 colour bit, masked out of the wall test |
 | An adversary leaves the viewport → hidden; re-enters at the right spot | each drawn in the player's camera frame |
 | Red border when built without the netstream flag / with no peer | stub-HAL / no-transport indication |
 

--- a/demo/tank_dual_net/README.md
+++ b/demo/tank_dual_net/README.md
@@ -29,6 +29,11 @@ Reuses `demo/tank` + `demo/tank_net` headers verbatim (added to the include path
 CMake); only the two-phase sequencing and the TCP→close→UDP handoff are new
 ([atari_tank_dual_net_demo.cpp](atari_tank_dual_net_demo.cpp)).
 
+Gameplay matches `tank_net`: the player has GTIA wall collision, but only *pure-white*
+(COLPF0) contact stops it. Fuel/ammo depots draw white letters inside a coloured
+COLPF1/COLPF2 box, so their colour bit is masked out of the wall test and the tank
+**drives over** depots while walls still block it.
+
 > **Firmware:** the realtime lane requires **fujinet-firmware v1.6.2+** (whole-frame-
 > aligned drop-oldest). Older firmware byte-drops the unframed stream and desyncs the
 > adversaries. Same constraint as `demo/tank_net`.

--- a/demo/tank_dual_net/atari_tank_dual_net_demo.cpp
+++ b/demo/tank_dual_net/atari_tank_dual_net_demo.cpp
@@ -150,7 +150,12 @@ static tank::TankState g_tank = {
 };
 
 // GTIA player->playfield collision: P0PF bit 0 = COLPF0, the white wall colour.
-static constexpr u8 kWallColpfMask = 0x01;
+// Depot icons (fuel/ammo) draw their white letters inside a coloured box
+// (COLPF1/COLPF2), so overlapping a depot also sets a colour bit; a plain wall is
+// pure white. Block only on pure-white contact so the tank drives over depots while
+// walls still stop it — derived from the live register, no depot tile codes hardcoded.
+static constexpr u8 kWallColpfMask     = 0x01;          // COLPF0 = walls (white)
+static constexpr u8 kDepotSurroundMask = 0x02 | 0x04;   // COLPF1|COLPF2 = depot box
 
 // Mutable game state bundled into ONE struct so it lands in main RAM (.bss), not the
 // near-full zero page — small separate statics get zp-promoted and overflow it.
@@ -250,7 +255,10 @@ static void streaming_frame_step(const engine::Input& in) {
     }
 
     // 2b. GTIA wall collision for player 0 (direct-bind: slot 0 IS hardware player 0).
-    if (Game::sprite_collisions().sprite_to_background(0) & kWallColpfMask) {
+    // Pure-white contact (COLPF0, no depot-box colour) is a wall → snap back; a depot
+    // letter sets a colour bit too, so the tank drives over it.
+    const u8 hit = Game::sprite_collisions().sprite_to_background(0);
+    if ((hit & kWallColpfMask) && !(hit & kDepotSurroundMask)) {
         g_tank = g_st.tank_safe;
     } else {
         g_st.tank_safe = g_tank;

--- a/demo/tank_net/atari_tank_net_demo.cpp
+++ b/demo/tank_net/atari_tank_net_demo.cpp
@@ -121,8 +121,13 @@ static tank::TankState g_tank = {
 };
 
 // GTIA player→playfield collision: P0PF bit 0 = COLPF0, the white wall colour
-// (tank_palette colpf0). A set bit means player 0's hull overlapped a wall.
-static constexpr u8 kWallColpfMask = 0x01;
+// (tank_palette colpf0). A set bit means player 0's hull overlapped white.
+// Depot icons (fuel/ammo) draw their white letters inside a coloured box
+// (COLPF1/COLPF2), so overlapping a depot also sets a colour bit; a plain wall is
+// pure white. Block only on pure-white contact so the tank drives over depots while
+// walls still stop it — derived from the live register, no depot tile codes hardcoded.
+static constexpr u8 kWallColpfMask     = 0x01;          // COLPF0 = walls (white)
+static constexpr u8 kDepotSurroundMask = 0x02 | 0x04;   // COLPF1|COLPF2 = depot box
 
 // Mutable game state bundled into ONE struct so it lands in main RAM (.bss), not
 // the near-full zero page — small separate statics get zp-promoted and overflow it
@@ -224,10 +229,12 @@ static void frame_step(const engine::Input& in) {
 
     // 2b. GTIA wall collision for player 0. The engine latched P0PF from last
     // frame's render; direct-bind means logical slot 0 IS hardware player 0, so the
-    // mask is reliable (no multiplexer reassignment). If the hull drove into a white
-    // wall (COLPF0), snap back to the last wall-free position; otherwise remember
-    // this position as wall-free.
-    if (Game::sprite_collisions().sprite_to_background(0) & kWallColpfMask) {
+    // mask is reliable (no multiplexer reassignment). Pure-white contact (COLPF0 with
+    // no depot-box colour) is a wall: snap back to the last wall-free position.
+    // White-plus-colour is a depot letter, so let the tank drive over it and remember
+    // the position as wall-free.
+    const u8 hit = Game::sprite_collisions().sprite_to_background(0);
+    if ((hit & kWallColpfMask) && !(hit & kDepotSurroundMask)) {
         g_tank = g_st.tank_safe;
     } else {
         g_st.tank_safe = g_tank;


### PR DESCRIPTION
The tank_net and tank_dual_net player wall collision distinguished only "white or not": any COLPF0 contact snapped the tank back. Depot icons (fuel/ammo) draw white letters inside a coloured COLPF1/COLPF2 box, so they tripped the wall test and blocked the tank.

Mask the depot-box colour bits out of the wall test (hit & kWallColpfMask && !(hit & kDepotSurroundMask)): pure white is a wall and still snaps back; white-plus-colour is a depot letter, so the tank drives over it. Derived from the live P0PF register, no depot tile codes hardcoded.

Docs: update the demo/README.md tank_net wall-collision paragraph and "What to look for" table, add a gameplay note to tank_dual_net/README.md, and record the behavior change in CHANGELOG.md [Unreleased].