### PR TITLE
tank: player firing + adversary respawn, and LiveSession RAM-fit fix

### DIFF
--- a/demo/tank/asset_loader.h
+++ b/demo/tank/asset_loader.h
@@ -17,6 +17,7 @@
 // test. Coverage is tracked with fixed masks (no dynamic bitsets).
 
 #include <engine/types.h>
+#include <engine/attributes.h>
 
 #include "asset_protocol.h"
 #include "playfield_geometry.h"
@@ -122,7 +123,7 @@ private:
 };
 
 // ── consume(): validate the common prefix, then dispatch by kind ────────────
-inline LoadState AssetLoader::consume(const u8* p, u16 size) {
+EDGE_COLD inline LoadState AssetLoader::consume(const u8* p, u16 size) {
     if (state_ == LoadState::Failed || state_ == LoadState::Complete)
         return fail(LoadError::BadState);                 // require reset() to retry
     if (size < proto::kPrefixBytes) return fail(LoadError::BadLength);
@@ -142,7 +143,7 @@ inline LoadState AssetLoader::consume(const u8* p, u16 size) {
     }
 }
 
-inline LoadState AssetLoader::handle_manifest(const u8* p, u16 size, u8 xfer) {
+EDGE_COLD inline LoadState AssetLoader::handle_manifest(const u8* p, u16 size, u8 xfer) {
     if (state_ != LoadState::AwaitManifest) return fail(LoadError::BadState);
     if (size != proto::kManifestBytes)      return fail(LoadError::BadLength);
     if (proto::rd_u16(p + 3) != proto::kTilesetBytes ||
@@ -155,7 +156,7 @@ inline LoadState AssetLoader::handle_manifest(const u8* p, u16 size, u8 xfer) {
     return state_;
 }
 
-inline LoadState AssetLoader::handle_tileset_block(const u8* p, u16 size, u8 xfer) {
+EDGE_COLD inline LoadState AssetLoader::handle_tileset_block(const u8* p, u16 size, u8 xfer) {
     if (state_ != LoadState::Receiving) return fail(LoadError::BadState);
     if (xfer != transfer_id_)           return fail(LoadError::WrongTransfer);
     if (size < proto::kTilesetBlockHdr) return fail(LoadError::BadLength);
@@ -171,7 +172,7 @@ inline LoadState AssetLoader::handle_tileset_block(const u8* p, u16 size, u8 xfe
     return state_;
 }
 
-inline LoadState AssetLoader::handle_chunk_rows(const u8* p, u16 size, u8 xfer) {
+EDGE_COLD inline LoadState AssetLoader::handle_chunk_rows(const u8* p, u16 size, u8 xfer) {
     if (state_ != LoadState::Receiving) return fail(LoadError::BadState);
     if (xfer != transfer_id_)           return fail(LoadError::WrongTransfer);
     if (size < proto::kChunkRowsHdr)    return fail(LoadError::BadLength);
@@ -202,7 +203,7 @@ inline LoadState AssetLoader::handle_chunk_rows(const u8* p, u16 size, u8 xfer) 
     return state_;
 }
 
-inline LoadState AssetLoader::handle_complete(u16 size, u8 xfer) {
+EDGE_COLD inline LoadState AssetLoader::handle_complete(u16 size, u8 xfer) {
     if (state_ != LoadState::Receiving) return fail(LoadError::BadState);
     if (xfer != transfer_id_)           return fail(LoadError::WrongTransfer);
     if (size != proto::kCompleteBytes)  return fail(LoadError::BadLength);

--- a/demo/tank/atari_tank_demo.cpp
+++ b/demo/tank/atari_tank_demo.cpp
@@ -76,7 +76,7 @@ struct GameConfig {
 };
 using Game = engine::Core<Platform, GameConfig>;
 
-static tank::PhysicalMap g_map;
+EDGE_SCROLL_TILE_MAP(tank::PhysicalMap, g_map);
 // The scroll-map placement guard (ScrollTileMap head-pad/alignment) is sized for the
 // platform's scan-wrap boundary; keep the demo-local constant honest against caps.
 static_assert(Platform::capabilities::screen_buffer_alignment == tank::kScanWrapBoundary,

--- a/demo/tank/net_session_loader.h
+++ b/demo/tank/net_session_loader.h
@@ -21,6 +21,7 @@
 // messages, so in-flight bytes are bounded.
 
 #include <engine/net_types.h>
+#include <engine/attributes.h>
 
 #include "asset_loader.h"
 #include "asset_protocol.h"
@@ -83,7 +84,7 @@ public:
 
     // Drive one loading frame. Connect -> request -> receive chain so a frame
     // makes forward progress; the Receiving drain is still bounded per frame.
-    void update() {
+    EDGE_COLD void update() {
         if (state_ == NetState::Starting || state_ == NetState::Connecting) step_connect();
         if (state_ == NetState::Requesting) step_request();
         if (state_ == NetState::Receiving) step_receive();
@@ -104,13 +105,13 @@ public:
     bool overflow_seen()    const { return overflow_seen_; }
 
 private:
-    NetState fail(NetTransportError e) {
+    EDGE_COLD NetState fail(NetTransportError e) {
         terr_ = e;
         if (session_) session_->close();
         return state_ = NetState::Failed;
     }
 
-    void step_connect() {
+    EDGE_COLD void step_connect() {
         const NetStatus st = session_->connect_tcp(host_, port_);
         if (st == NetStatus::Ok && session_->connected()) {
             state_ = NetState::Requesting; timer_ = 0; return;
@@ -123,7 +124,7 @@ private:
         fail(NetTransportError::ConnectFailed);
     }
 
-    void step_request() {
+    EDGE_COLD void step_request() {
         u8 buf[8];
         const u16 n = build_request(buf, transfer_id_, kCreditWindow);
         if (session_->send_bytes(buf, n, sess::kRequest) != NetStatus::Ok) {
@@ -133,7 +134,7 @@ private:
         state_ = NetState::Receiving; timer_ = 0;
     }
 
-    void step_receive() {
+    EDGE_COLD void step_receive() {
         const NetStatus pst = session_->poll();
         if (pst == NetStatus::Overflow) { overflow_seen_ = true; fail(NetTransportError::RxOverflow); return; }
 

--- a/demo/tank_dual_net/README.md
+++ b/demo/tank_dual_net/README.md
@@ -34,6 +34,35 @@ Gameplay matches `tank_net`: the player has GTIA wall collision, but only *pure-
 COLPF1/COLPF2 box, so their colour bit is masked out of the wall test and the tank
 **drives over** depots while walls still block it.
 
+## Firing & adversary respawn
+
+Press the **joystick trigger** to fire a missile in the tank's current heading. Up to
+**4 missiles** can be airborne at once — each is a hardware GTIA missile (pool index ==
+missile slot), advanced in world space with the shared Q12.4 motion table. A missile
+expires when it leaves the world, after a short lifetime, or on a *pure-white* wall
+(same COLPF0 rule as the tank — missiles fly over depots too). Firing works even in the
+"NO NET" fallback (it is purely local).
+
+When a missile strikes an adversary, the **server respawns that adversary at its start
+corner**. The mechanism rides the existing 10 Hz client→server packet — no new packet
+type, no extra round-trip:
+
+- The client keeps a **monotonic per-adversary hit counter** (`TankPacket32.hit_count[i]`,
+  bytes 27..29) and bumps `hit_count[i]` each time one of its missiles hits adversary `i`
+  (collision is a software AABB in world space, so it never depends on GTIA logical↔
+  hardware player remapping). Hit detection releases the missile immediately, so one
+  missile == exactly one increment.
+- The server **edge-detects** each counter changing (a u8-ring delta, wrap-safe) and
+  respawns that adversary. Because the counter rides *every* C→S packet, a dropped
+  packet just delays the respawn one tick; because the server acts only on the change,
+  a duplicated/re-sent value respawns **once** (idempotent). The respawn logic lives in
+  [edge_tank_adversary.py](../../tools/net/edge_tank_adversary.py) (`hit_delta` +
+  `last_hit_count`), so both the standalone and combined servers get it.
+
+> Hardware missiles take the colour of their corresponding player, so the first shot
+> (missile 0) is player-coloured and rapid follow-ups borrow the adversary colours —
+> cosmetic only.
+
 > **Firmware:** the realtime lane requires **fujinet-firmware v1.6.2+** (whole-frame-
 > aligned drop-oldest). Older firmware byte-drops the unframed stream and desyncs the
 > adversaries. Same constraint as `demo/tank_net`.
@@ -79,7 +108,15 @@ cmake --build build-live --target atari_tank_dual_net_demo
 
 Endpoint overrides (all optional): `-DEDGE_TANK_NET_HOST=` / `-DEDGE_TANK_NET_PORT=`
 (Phase-1 TCP), `-DEDGE_NET_PEER_HOST=` / `-DEDGE_NET_PEER_PORT=` (Phase-2 UDP),
-`-DEDGE_NETSTREAM_NOMINAL_BAUD=`.
+`-DEDGE_NETSTREAM_NOMINAL_BAUD=`. For **real hardware**, set *both* `EDGE_TANK_NET_HOST`
+(Phase-1 TCP) and `EDGE_NET_PEER_HOST` (Phase-2 UDP) to the server's LAN IP — the
+Phase-1 default `127.0.0.1` is unreachable from the Atari.
+
+> **LiveSession is built `-Os`, the other variants `-O2`.** LiveSession links the real
+> fujinet-lib, which nearly fills the `0x2000`–`0x8000` code region; the firing code's
+> ~1.7 KB overflows it at `-O2`, so that variant compiles `-Os` (the per-frame
+> `frame_service` overrun that once required `-O2` was fixed engine-wide, so `-Os` still
+> holds 60 fps). SimulatedNetwork/Embedded don't link fujinet-lib and stay `-O2`.
 
 ## Server
 
@@ -115,7 +152,10 @@ tools/net/edge_tank_adversary.py --port 9000
    lane closes (heads-up: Altirra shares the X display).
 2. **Altirra + NetSIO + combined server** — LiveSession build, both gates ON: the
    loading screen completes, then 3 adversaries stream in; the server log shows the
-   TCP transfer (66 messages) followed by UDP `learned target` + adversary tx.
+   TCP transfer (66 messages) followed by UDP `learned target` + adversary tx. Fire at
+   an adversary and confirm the server logs `adv i HIT — respawning to (x,y)` and the
+   adversary jumps back to its start corner. (The respawn path also has a host-side
+   loopback test — see the firing section — that drives the real server over UDP.)
 3. **Real FujiNet hardware (decisive)** — same LiveSession build vs the combined
    server on the LAN. This is the only test that proves `session.close()` →
    `open_udp_seq()` releases/reprograms the SIO/POKEY cleanly for real. Build with

--- a/demo/tank_dual_net/atari_tank_dual_net_demo.cpp
+++ b/demo/tank_dual_net/atari_tank_dual_net_demo.cpp
@@ -44,6 +44,7 @@
 
 #include <engine/platform/atari/platform.h>
 #include <engine/core.h>
+#include <engine/pool.h>
 
 #include "playfield_geometry.h"
 #include "tank_camera.h"
@@ -124,7 +125,7 @@ struct GameConfig {
 static_assert(tanknet::kMaxAdv >= kAdvCount, "combined packet must hold every adversary");
 using Game = engine::Core<Platform, GameConfig>;
 
-static tank::PhysicalMap g_map;
+EDGE_SCROLL_TILE_MAP(tank::PhysicalMap, g_map);
 static_assert(Platform::capabilities::screen_buffer_alignment == tank::kScanWrapBoundary,
               "kScanWrapBoundary must match the platform scan-wrap granularity");
 
@@ -157,12 +158,37 @@ static tank::TankState g_tank = {
 static constexpr u8 kWallColpfMask     = 0x01;          // COLPF0 = walls (white)
 static constexpr u8 kDepotSurroundMask = 0x02 | 0x04;   // COLPF1|COLPF2 = depot box
 
+// ── Phase 2: player firing (hardware missiles, ADR-025) ────────────────────────
+// The local player launches missiles with the joystick trigger. Each missile is a
+// hardware GTIA missile (pool index == hardware missile slot), flies along the tank's
+// heading in world space (reusing the shared Q12.4 motion table), and expires on a
+// pure-white wall, at the world edge, or after kBulletLife frames. A missile that
+// strikes an adversary bumps a per-adversary hit counter the client streams to the
+// server, which respawns that adversary at its start corner.
+static constexpr u8  kMaxBullets  = 4;     // the four hardware missiles
+static constexpr u8  kBulletSteps = 3;     // motion-vector applications/frame (faster than the tank)
+static constexpr u8  kBulletHeight= 3;     // missile-strip rows drawn
+static constexpr u8  kBulletLife  = 70;    // ~1.2 s max flight before self-expiry
+static constexpr i16 kHitRadius   = 10;    // |dx|,|dy| (nominal px) bullet-vs-adversary centre for a hit
+static constexpr i16 kWorldMaxX   = 639;   // world bounds for off-field bullet expiry
+static constexpr i16 kWorldMaxY   = 383;
+
+struct Bullet {
+    i16 world_x_q4;
+    i16 world_y_q4;
+    u8  heading;
+    u8  life;          // frames remaining before self-expiry
+};
+
 // Mutable game state bundled into ONE struct so it lands in main RAM (.bss), not the
 // near-full zero page — small separate statics get zp-promoted and overflow it.
 struct GameState {
     tanknet::Adversary  adv[kAdvCount];   // network-driven adversaries
     tanknet::AdvRxState adv_rx;           // shared packet-level seq gate (combined snapshot)
     tank::TankState     tank_safe;        // last position player 0 was NOT touching a wall
+    engine::SlotPool<Bullet, kMaxBullets> bullets;  // pool index == hardware missile slot
+    u8  hit_count[kAdvCount];             // per-adversary missile-hit counter, streamed to the server
+    u8  fire_prev;                        // trigger level last game step (dropped-frame-safe fire edge)
     u8  player_speed;                     // 1 while the player is moving (for the TX packet)
     u16 tx_seq;
     u8  tx_frame;
@@ -171,6 +197,64 @@ struct GameState {
     u8  bss_anchor[24];                   // force .bss placement (main RAM is plentiful)
 };
 static GameState g_st = {};
+
+static inline i16 iabs16(i16 v) { return v < 0 ? static_cast<i16>(-v) : v; }
+
+// Rising edge of the joystick trigger, tracked against the level WE last observed in a
+// game step — not Input::fire_pressed(), whose prev-state shifts every VBI and so eats
+// held-fire presses on a dropped frame (see demo/arena fire_edge). Launches a missile
+// from the player's hull centre along its current heading. noinline+minsize keeps this
+// cold path's locals out of the razor-full zero page (.zp ends exactly at 0x100).
+[[gnu::noinline, clang::minsize]] static void fire_if_triggered(const engine::Input& in) {
+    const bool now  = in.fire();
+    const bool edge = now && !g_st.fire_prev;
+    g_st.fire_prev = now;
+    if (!edge) return;
+    u8 idx;
+    if (Bullet* b = g_st.bullets.acquire(idx)) {
+        b->world_x_q4 = g_tank.world_x_q4;
+        b->world_y_q4 = g_tank.world_y_q4;
+        b->heading    = g_tank.heading;
+        b->life       = kBulletLife;
+    }
+}
+
+// Advance every in-flight missile (movement + expiry + adversary hit). Drawing happens
+// later in submit_sprites() with the same camera. Releasing a bullet the instant it
+// strikes an adversary guarantees one missile == exactly one hit-counter increment. A
+// plain indexed loop (no lambda) + minsize keeps the zero-page footprint at zero.
+[[gnu::noinline, clang::minsize]] static void advance_bullets() {
+    for (u8 idx = 0; idx < kMaxBullets; ++idx) {
+        if (!g_st.bullets.active(idx)) continue;
+        Bullet& b = g_st.bullets[idx];
+        const tank::MotionVector& v = tank::motion_vector(b.heading);
+        for (u8 s = 0; s < kBulletSteps; ++s) {
+            b.world_x_q4 = static_cast<i16>(b.world_x_q4 + v.dx_q4);
+            b.world_y_q4 = static_cast<i16>(b.world_y_q4 + v.dy_q4);
+        }
+        const i16 bx = static_cast<i16>(b.world_x_q4 >> 4);
+        const i16 by = static_cast<i16>(b.world_y_q4 >> 4);
+        bool expire = bx < 0 || bx > kWorldMaxX || by < 0 || by > kWorldMaxY || --b.life == 0;
+        if (!expire) {                                   // pure-white wall stops it; flies over depots
+            const u8 wall = Game::sprite_collisions().projectile_to_background(idx);
+            if ((wall & kWallColpfMask) && !(wall & kDepotSurroundMask)) expire = true;
+        }
+        if (!expire) {                                   // adversary hit: software AABB in world space
+            for (u8 i = 0; i < kAdvCount; ++i) {
+                if (!g_st.adv[i].have_state) continue;
+                const i16 ax = tank::world_x_nominal(g_st.adv[i].s);
+                const i16 ay = tank::world_y_nominal(g_st.adv[i].s);
+                if (iabs16(static_cast<i16>(bx - ax)) < kHitRadius &&
+                    iabs16(static_cast<i16>(by - ay)) < kHitRadius) {
+                    ++g_st.hit_count[i];
+                    expire = true;
+                    break;
+                }
+            }
+        }
+        if (expire) { Game::missile_hide(idx); g_st.bullets.release(idx); }
+    }
+}
 
 // Playfield background. Darker than the shared palette's 0x04 (same hue, lower
 // luminance) but not black — local to this demo.
@@ -235,6 +319,21 @@ static void submit_sprites() {
         if (g_st.adv[i].have_state) submit_tank(slot, g_st.adv[i].s, cam_cc, cam_sl);
         else                        Game::sprite_hide(slot);
     }
+
+    // Player missiles in the same camera (point sprites — no half-tank offset).
+    for (u8 idx = 0; idx < kMaxBullets; ++idx) {
+        if (!g_st.bullets.active(idx)) { Game::missile_hide(idx); continue; }
+        const Bullet& b = g_st.bullets[idx];
+        const i16 scc = screen_cc_in_cam(static_cast<i16>(b.world_x_q4 >> 4), cam_cc);
+        const i16 ssl = screen_sl_in_cam(static_cast<i16>(b.world_y_q4 >> 4), cam_sl);
+        if (tank::tank_visible(scc, ssl)) {
+            const i16 px = static_cast<i16>(tank::kPmgOriginX + scc);
+            const i16 py = static_cast<i16>(tank::kPmgOriginY + ssl);
+            Game::missile(idx, static_cast<u8>(px), static_cast<u8>(py), kBulletHeight);
+        } else {
+            Game::missile_hide(idx);
+        }
+    }
 }
 
 // ── Phase 2: per-frame step (copied from demo/tank_net) ────────────────────────
@@ -276,16 +375,24 @@ static void streaming_frame_step(const engine::Input& in) {
     tank::move_tank(g_tank, intent.move);
     g_st.player_speed = (intent.move != 0) ? 1 : 0;
 
+    // 3b. Fire on the trigger edge + advance every in-flight missile (a hit bumps the
+    //     per-adversary counter streamed below). Firing works even with NO NET.
+    fire_if_triggered(in);
+    advance_bullets();
+
     // 4. Stream our own state back to the server (bidirectional; all-or-nothing TX).
+    //    The per-adversary hit counters ride this packet; the server respawns an
+    //    adversary when its counter changes (loss-tolerant: the value is re-sent each tick).
     if (Game::net.realtime.active() && ++g_st.tx_frame >= kTxPeriod) {
         g_st.tx_frame = 0;
         Game::net.realtime.send(
             tanknet::make_player_packet(g_tank, g_st.player_speed, g_st.tx_seq++,
-                                        g_st.adv_rx.last_seq, g_st.rx_overflow_count));
+                                        g_st.adv_rx.last_seq, g_st.rx_overflow_count,
+                                        g_st.hit_count));
         g_st.rx_overflow_count = 0;
     }
 
-    // 5. Draw all tanks.
+    // 5. Draw all tanks + missiles.
     submit_sprites();
 }
 

--- a/demo/tank_net/adversary_net.h
+++ b/demo/tank_net/adversary_net.h
@@ -56,7 +56,13 @@ struct TankPacket32 {
     AdvRecord rec[kMaxAdv];    //  6..23  adversary records (C->S: rec[0] = player)
     u8 echo_seq_lo, echo_seq_hi;  // 24..25  C->S: adv[0] last-applied seq (timing echo)
     u8 echo_flags;             // 26     C->S: client health byte (RX-overflow events)
-    u8 reserved[4];            // 27..30
+    u8 hit_count[kMaxAdv];     // 27..29  C->S: monotonic per-adversary missile-hit counter.
+                               //         The client bumps hit_count[i] each time one of its
+                               //         missiles strikes adversary i; the server edge-detects
+                               //         the change and respawns that adversary. Idempotent
+                               //         (a resent/duplicated value respawns only once) and
+                               //         loss-tolerant (the value rides every C->S packet).
+    u8 reserved;               // 30
     u8 pattern;                // 31     0x5A sanity
 };
 static_assert(sizeof(TankPacket32) == 32, "TankPacket32 must be exactly 32 bytes");
@@ -145,8 +151,14 @@ inline void adv_dead_reckon(Adversary& adv) {
 // count). The server compares echo_adv_seq against the seq it most recently SENT to
 // measure end-to-end lag in packets (≈ ms via the known send rate) and whether it
 // grows over time.
+//
+// HIT COUNTERS (optional): pass a pointer to kMaxAdv monotonic per-adversary
+// missile-hit counters and they are copied into hit_count[]; the server respawns an
+// adversary when its counter changes. nullptr leaves them zero (callers that do not
+// implement firing — e.g. demo/tank_net — keep their existing behaviour unchanged).
 inline TankPacket32 make_player_packet(const tank::TankState& s, u8 speed, u16 seq,
-                                       u16 echo_adv_seq, u8 echo_flags) {
+                                       u16 echo_adv_seq, u8 echo_flags,
+                                       const u8* hit_count = nullptr) {
     TankPacket32 p{};
     p.magic   = kMagic;
     p.version = kVersion;
@@ -159,6 +171,7 @@ inline TankPacket32 make_player_packet(const tank::TankState& s, u8 speed, u16 s
     p.rec[0].speed   = speed;
     wr16(p.echo_seq_lo, p.echo_seq_hi, echo_adv_seq);  // adv[0] last-applied seq
     p.echo_flags = echo_flags;                         // client health byte
+    if (hit_count) for (u8 i = 0; i < kMaxAdv; ++i) p.hit_count[i] = hit_count[i];
     p.pattern = kPattern;
     return p;
 }

--- a/demo/tank_net/atari_tank_net_demo.cpp
+++ b/demo/tank_net/atari_tank_net_demo.cpp
@@ -92,7 +92,7 @@ struct GameConfig {
 static_assert(tanknet::kMaxAdv >= kAdvCount, "combined packet must hold every adversary");
 using Game = engine::Core<Platform, GameConfig>;
 
-static tank::PhysicalMap g_map;
+EDGE_SCROLL_TILE_MAP(tank::PhysicalMap, g_map);
 static_assert(Platform::capabilities::screen_buffer_alignment == tank::kScanWrapBoundary,
               "kScanWrapBoundary must match the platform scan-wrap granularity");
 

--- a/engine/attributes.h
+++ b/engine/attributes.h
@@ -1,0 +1,16 @@
+#ifndef ENGINE_ATTRIBUTES_H
+#define ENGINE_ATTRIBUTES_H
+
+// attributes.h — portable function attributes shared across the engine and demos.
+//
+// EDGE_COLD marks a function as a COLD path: keep it out of the hot, -O2-inlined main
+// loop and compile it for minimum size. clang honours `minsize` per-function regardless
+// of the translation unit's -O2, so the 60 fps hot path stays fast while one-shot /
+// setup / loading code is size-optimised — no gameplay-framerate impact. `noinline` also
+// stops the cold body from being inlined (and thus duplicated/bloated) into a caller.
+//
+// Use on: screen setup, title/menu/game-over callbacks, network-download / asset-loading
+// code, and other code that runs only outside the per-frame gameplay loop.
+#define EDGE_COLD [[gnu::noinline, clang::minsize]]
+
+#endif  // ENGINE_ATTRIBUTES_H

--- a/engine/net_api.h
+++ b/engine/net_api.h
@@ -12,6 +12,7 @@
 
 #include "net_ring.h"
 #include "net_types.h"
+#include "attributes.h"
 #include "config/capabilities.h"
 
 namespace engine {
@@ -149,7 +150,7 @@ class SessionLane {
 public:
     static constexpr u16 max_message_bytes() { return MaxMessageBytes; }
 
-    NetStatus connect_tcp(const char* host, u16 port) {
+    EDGE_COLD NetStatus connect_tcp(const char* host, u16 port) {
         const NetStatus st = Platform::hal::session_connect_tcp(host, port);
         connected_ = (st == NetStatus::Ok);
         rx_.clear();
@@ -170,7 +171,7 @@ public:
     bool connected() const { return connected_; }
 
     // Nonblocking seam poll + TX flush + RX drain.
-    NetStatus poll() {
+    EDGE_COLD NetStatus poll() {
         if (!connected()) return set_status(NetStatus::Closed);
         invalidate_view();
         const NetStatus st = Platform::hal::session_poll();
@@ -187,7 +188,7 @@ public:
         return send_bytes(&message, static_cast<u16>(sizeof(Message)), 0);
     }
 
-    NetStatus send_bytes(const void* data, u16 size, u8 kind = 0) {
+    EDGE_COLD NetStatus send_bytes(const void* data, u16 size, u8 kind = 0) {
         if (!connected()) return set_status(NetStatus::Closed);
         if ((data == nullptr && size > 0) || size > MaxMessageBytes)
             return set_status(NetStatus::InvalidArgument);
@@ -207,7 +208,7 @@ public:
         return set_status(NetStatus::Ok);
     }
 
-    bool recv(SessionMessageView& view) {
+    EDGE_COLD bool recv(SessionMessageView& view) {
         invalidate_view();
         view.kind = 0;
         view.data = nullptr;
@@ -288,7 +289,7 @@ private:
     SessionMessageView current_view_{};
     NetError last_error_{};
 
-    void flush_tx_() {
+    EDGE_COLD void flush_tx_() {
         // Session framing: [kind(1)] [size_lo(1)] [size_hi(1)] [payload(size)]
         // Read the frame header first to determine total frame size, then send
         // the entire frame as one unit to session_send_nb().

--- a/engine/tiles.h
+++ b/engine/tiles.h
@@ -136,11 +136,18 @@ template <u16 N> struct HeadPad { u8 bytes[N]; };
 template <>      struct HeadPad<0> {};   // empty base -> zero storage, cells at offset 0
 }  // namespace detail
 
+// NOTE on alignment: the buffer's START must be `Boundary`-aligned for the head pad to
+// land the single interior boundary on a row edge. That alignment is applied to each
+// INSTANCE (see EDGE_SCROLL_TILE_MAP below), NOT to this type. Over-aligning the type
+// would force sizeof up to a multiple of Boundary (e.g. a 4272-byte map aligned to 4096
+// would occupy 8192), wasting a whole page; aligning the instance keeps sizeof exact
+// (head_pad + Width*Height) while still aligning the object's start.
 template <u16 Width, u16 Height, u16 Boundary>
-struct alignas(Boundary > 1 ? Boundary : 1) ScrollTileMap
+struct ScrollTileMap
     : private detail::HeadPad<(Boundary > 1) ? (Boundary % Width) : 0> {
     static constexpr u16 width    = Width;
     static constexpr u16 height   = Height;
+    static constexpr u16 boundary = Boundary;
     static constexpr u16 head_pad = (Boundary > 1) ? (Boundary % Width) : 0;
 
     static_assert(Boundary <= 1 ||
@@ -159,6 +166,15 @@ struct alignas(Boundary > 1 ? Boundary : 1) ScrollTileMap
         cells[static_cast<u16>(row * Width + col)] = tile_code;
     }
 };
+
+// Declare a ScrollTileMap instance with the required start-alignment. Every
+// ScrollTileMap object MUST be declared with this (or an equivalent `alignas`) so its
+// single interior scan-wrap boundary lands on a row edge; the type itself is not
+// over-aligned (that would round its sizeof up to a whole extra page). Greppable so new
+// instances are easy to find/audit.
+//   EDGE_SCROLL_TILE_MAP(tank::PhysicalMap, g_map);   // (declares a file-scope static)
+// `alignas` must precede `static`, so the macro emits the whole declaration.
+#define EDGE_SCROLL_TILE_MAP(MapType, name) alignas(MapType::boundary) static MapType name
 
 // ── TileDisplay ───────────────────────────────────────────────────────
 //

--- a/tests/generic/test_adversary_net.cpp
+++ b/tests/generic/test_adversary_net.cpp
@@ -79,6 +79,16 @@ static void test_packet_roundtrip() {
     // Timing echo round-trips in the dedicated fields.
     CHECK(tanknet::rd16(p.echo_seq_lo, p.echo_seq_hi) == 1234);
     CHECK(p.echo_flags == 7);
+    // No hit_count argument (default nullptr) => all counters zero.
+    for (engine::u8 i = 0; i < tanknet::kMaxAdv; ++i) CHECK(p.hit_count[i] == 0);
+
+    // With per-adversary hit counters supplied, they round-trip into hit_count[].
+    const engine::u8 hits[tanknet::kMaxAdv] = {5, 0, 200};
+    const tanknet::TankPacket32 ph =
+        tanknet::make_player_packet(s, 1, 43, 1234, 7, hits);
+    CHECK(ph.hit_count[0] == 5);
+    CHECK(ph.hit_count[1] == 0);
+    CHECK(ph.hit_count[2] == 200);
 }
 
 // ── apply: validate, snap, reject foreign/stale ────────────────────────────

--- a/tests/generic/test_asset_loader.cpp
+++ b/tests/generic/test_asset_loader.cpp
@@ -34,7 +34,7 @@ static void make_reference() {
 
 // ── Loader + its destinations ───────────────────────────────────────────────
 static tank::AssetLoader g_loader;
-static tank::PhysicalMap g_map;
+EDGE_SCROLL_TILE_MAP(tank::PhysicalMap, g_map);
 static u8 g_tileset_dest[1024];
 
 static void rebind() {

--- a/tests/generic/test_net_session_loader.cpp
+++ b/tests/generic/test_net_session_loader.cpp
@@ -105,7 +105,7 @@ struct FakeSession {
 };
 
 static FakeSession g_fs;
-static tank::PhysicalMap g_map;
+EDGE_SCROLL_TILE_MAP(tank::PhysicalMap, g_map);
 static u8 g_tsdest[1024];
 static tank::NetAssetClient<FakeSession> g_client;
 

--- a/tests/generic/test_tank_playfield.cpp
+++ b/tests/generic/test_tank_playfield.cpp
@@ -23,7 +23,7 @@ static unsigned g_failures = 0;
 using GG = tank::PlayfieldGeometry;
 
 // One real physical map + four synthetic chunk payloads (each a distinct marker).
-static tank::PhysicalMap g_map;
+EDGE_SCROLL_TILE_MAP(tank::PhysicalMap, g_map);
 static u8 g_chunk[2][2][960];   // [chunk_x][chunk_y]
 static constexpr u8 marker(u8 cx, u8 cy) { return static_cast<u8>(1 + cy * 2 + cx); } // 1..4
 

--- a/tools/net/edge_tank_adversary.py
+++ b/tools/net/edge_tank_adversary.py
@@ -50,8 +50,9 @@ DEFAULT_SIZE = 32
 #   6..23  rec[0..2], each = x_nom LE(2) y_nom LE(2) heading(1) speed(1)
 #          (C->S: rec[0] = player state)
 #   24..25 echo_seq LE (C->S: adv[0] last-applied seq)   26 echo_flags (C->S health)
-#   27..30 reserved   31 pattern(0x5A)
-_LAYOUT = "<BBBBH" + "HHBB" * MAX_ADV + "HB4sB"
+#   27..29 hit_count[0..2] (C->S: monotonic per-adversary missile-hit counter)
+#   30 reserved   31 pattern(0x5A)
+_LAYOUT = "<BBBBH" + "HHBB" * MAX_ADV + "HB" + "B" * MAX_ADV + "BB"
 MAGIC = 0xAD
 VERSION = 0x02
 PATTERN = 0x5A
@@ -78,9 +79,11 @@ def decode(data):
         x, y, heading, speed = f[5 + i * 4: 9 + i * 4]
         recs.append({"x": x, "y": y, "heading": heading, "speed": speed})
     echo_seq, echo_flags = f[5 + MAX_ADV * 4], f[6 + MAX_ADV * 4]
+    hit_base = 7 + MAX_ADV * 4
+    hit_count = list(f[hit_base: hit_base + MAX_ADV])
     d = {"magic": magic, "version": ver, "type": ptype, "status": status,
          "seq": seq, "recs": recs, "echo_seq": echo_seq, "echo_flags": echo_flags,
-         "pattern": f[-1]}
+         "hit_count": hit_count, "pattern": f[-1]}
     # Player (C->S) state lives in rec[0]; flatten for convenience.
     d.update(x=recs[0]["x"], y=recs[0]["y"],
              heading=recs[0]["heading"], speed=recs[0]["speed"])
@@ -100,13 +103,20 @@ def encode_adversaries(seq, recs):
                        r["heading"] & 0x0F, r["speed"] & 0xFF]
         else:
             fields += [0, 0, 0, 0]
+    # Tail (S->C): echo_seq=0, echo_flags=0, hit_count[0..2]=0, reserved=0, pattern.
     return struct.pack(_LAYOUT, MAGIC, VERSION, TYPE_ADVERSARY, status,
-                       seq & 0xFFFF, *fields, 0, 0, b"\x00\x00\x00\x00", PATTERN)
+                       seq & 0xFFFF, *fields, 0, 0, *([0] * MAX_ADV), 0, PATTERN)
 
 
 def seq_delta(a, b):
     """Signed shortest-path delta on a u16 sequence ring (matches the client)."""
     return ((a - b + 0x8000) & 0xFFFF) - 0x8000
+
+
+def hit_delta(a, b):
+    """Signed shortest-path delta on a u8 hit-counter ring: > 0 means a is newer than
+    b (handles the 255->0 wrap correctly; a reordered older value reads <= 0)."""
+    return ((a - b + 0x80) & 0xFF) - 0x80
 
 
 class Reassembler:
@@ -306,7 +316,8 @@ def run_adversary_server(args, sock=None):
     for i in range(args.count):
         sx, sy = starts[i] if i < len(starts) else fallback_start
         mode = modes[i] if i < len(modes) else args.mode
-        advs.append({"sim": TankSim(sx, sy, 0, table), "mode": mode})
+        # Keep the start corner so a missile-hit respawn returns the adversary there.
+        advs.append({"sim": TankSim(sx, sy, 0, table), "mode": mode, "start": (sx, sy)})
 
     owns_sock = sock is None
     if owns_sock:
@@ -341,6 +352,9 @@ def run_adversary_server(args, sock=None):
 
     player = None             # last-known player (x,y) nominal
     player_last_seq = None
+    # Per-adversary missile-hit counter last seen from the client. None until the first
+    # player packet establishes a baseline (so we never respawn on the initial value).
+    last_hit_count = [None] * len(advs)
     period = 1.0 / args.hz
     next_send = time.monotonic()
     t0 = time.monotonic()
@@ -381,6 +395,20 @@ def run_adversary_server(args, sock=None):
                         player = (f["x"], f["y"])
                         rx += 1
                         cli_ovf = f["echo_flags"]
+                        # Missile-hit respawn: the client streams a monotonic per-adversary
+                        # hit counter. Edge-detect each change (seq_delta > 0 handles u8 wrap
+                        # and reorder) and respawn that adversary at its start corner. The
+                        # first packet only records the baseline (no spurious respawn).
+                        hc = f["hit_count"]
+                        for i, a in enumerate(advs):
+                            if i >= len(hc):
+                                break
+                            if last_hit_count[i] is not None and \
+                               hit_delta(hc[i], last_hit_count[i]) > 0:
+                                sx, sy = a["start"]
+                                a["sim"] = TankSim(sx, sy, 0, table)
+                                print("adv %d HIT — respawning to (%d,%d)" % (i, sx, sy))
+                            last_hit_count[i] = hc[i]
                         # End-to-end lag: how far adv[0]'s last-applied snapshot trails
                         # the seq we most recently sent (>=0; clamp tiny negatives from
                         # in-flight reorder to 0). Resolution ~1 packet = one send tick.


### PR DESCRIPTION
Firing capability for the tank demos: the local player launches hardware missiles (pool over the 4 GTIA missiles); a missile hit on an adversary bumps a monotonic per-adversary hit counter streamed in the existing 10 Hz C->S packet (TankPacket32.hit_count[], repurposed from reserved bytes), and the Python adversary server edge-detects the change and respawns that adversary at its start corner (loss-tolerant + idempotent). Hit detection is software AABB in world space; bullets stop on pure-white walls and fly over depots.

Memory-fit fix so the LiveSession build (real fujinet-lib) runs at -O2 again (it had been forced to -Os, which slowed the per-frame hot path and caused sprite blink/jitter on hardware):

- ScrollTileMap: move the 4 KB scan-wrap alignment from the TYPE to the INSTANCE (new EDGE_SCROLL_TILE_MAP macro). Over-aligning the type rounded sizeof up to a whole extra page; g_map drops 8192 -> 4272 B with the head-pad guarantee intact.
- engine/attributes.h: shared EDGE_COLD ([[gnu::noinline, clang::minsize]]). Applied to the cold Phase-1 download path (SessionLane, NetAssetClient, AssetLoader) so it compiles min-size while the 60 fps hot path stays -O2.

Net: LiveSession links at -O2 with ~4.6 KB headroom (was overflowing). All 47 host tests pass; tank/tank_net/tank_dual_net all build; playfield renders with no 4K-straddle garble. Extended-RAM banking for the cold path is left as future work.