### PR TITLE
Double-buffered scroll commit fixes late-service shear; EDGE_HOT_OPT …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,57 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-07
+
+### Fixed
+- **Horizontal-scroll top-band shear when the frame service runs late.** Rewriting the
+  *live* display list's per-line load addresses from the deferred VBI raced the display
+  beam: input-lengthened OS vertical-blank work (most visible in `-Os` builds, e.g.
+  `tank_dual_net`) pushed the ~one-LMS-per-line coarse rewrite past vertical blank, so
+  the top rows of the frame showed the previous coarse column — a one-cell shear while
+  scrolling east/west. A scroll layout's display program is now **double-buffered**:
+  `patch_scroll()` rewrites the off-screen copy and swaps, and the screen manager
+  commits with a 2-byte write to the display-list pointer shadow (SDLSTL/SDLSTH) that
+  the OS transfers to ANTIC atomically next vertical blank — an O(1) commit that cannot
+  race the beam no matter how late the service runs. Costs ~the list size in RAM
+  (~80 B for the tank screens), scroll layouts only. A/B-verified headlessly on Altirra
+  (simulated VBI lateness: 3/11 before-shots sheared, 0/11 after). See ADR-027
+  (2026-07-07 revision).
+
 ### Changed
+- **Scroll commit timing: fine scroll is staged only by the frame service.** Because
+  the pointer-swap commit latches one frame after the service writes it, the fine
+  value must ride the same latch: `apply_scroll` stages it, the immediate VBI flushes
+  it, and the OS applies the display-list pointer in the same vertical blank — fine and
+  coarse can never split. The game-loop fine publish from the earlier top-band jitter
+  fix (`Core::publish_scroll`, called by `loop.h`) is **removed**; it would put fine one
+  frame ahead of coarse and snap the picture at every cell crossing. Net effect: scroll
+  latency grows by one frame, uniformly and imperceptibly.
 - **Tank demos let the player drive over fuel/ammo depots.** The `tank_net` and
   `tank_dual_net` player wall collision now blocks only on *pure-white* (COLPF0)
   contact. Depot icons draw white letters inside a coloured COLPF1/COLPF2 box, so their
   colour bit is masked out of the wall test (`hit & kWallColpfMask && !(hit &
   kDepotSurroundMask)`) and the tank drives over them while plain walls still stop it.
   Derived from the live `P0PF` register — no depot tile codes hardcoded.
+- **Realtime demos build at a switchable optimization level (`EDGE_HOT_OPT`).** A CMake
+  cache STRING (default `-O2`; `HOT_OPT=-Os scripts/build_demos.sh` passthrough) flips
+  every realtime demo between `-O2` and `-Os` in one knob. Measured on Altirra, all
+  realtime demos (meter, arena, tank, tank_net, tank_dual_net) hold 60 fps with zero
+  dropped frames at `-Os`, for 10-33% smaller `.xex` — the old hardcoded `-O2` pins are
+  stale.
+
+### Added
+- **Frame-overrun diagnostics.** The frame service counts serviced and dropped frames
+  (`Game::frames_dropped()` / `frames_serviced()` / `reset_frame_stats()`), so a demo
+  can prove it holds frame rate; the realtime demos grew on-screen drop tells and
+  gated perf autopilots (`EDGE_TANK_AUTOPILOT`, `EDGE_ARENA_AUTOSTART`).
+- **Gated beam-race diagnostics** for headless verification: `EDGE_SIM_VBI_LATE`
+  (backend hook delays the frame service ~30 scanlines, faking the input-driven VBI
+  lateness autopilot runs can't produce), `EDGE_SCROLL_RASTERBAR` (paints the
+  background while the coarse rewrite runs, showing where in the frame it executes),
+  and `EDGE_SCROLL_AUTOPILOT` (`atari_scroll_test` sweeps east/west over a
+  ruler-patterned map so shear is machine-detectable in screenshots). All compile-time
+  off by default.
 
 ## [0.8.0] - 2026-06-27
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,16 @@ option(EDGE_BUILD_DEMO
        "Build the Atari .xex demo via add_executable (atari8-dos toolchain only)"
        OFF)
 
+# Optimization level for the real-time (hot-path) demos. All tests and every
+# non-realtime demo build at -Os (the global default, CMakeLists line ~23); a
+# handful of per-frame demos default to -O2 because -Os was found to throttle
+# their frame path. This single knob overrides that pin so the whole build can be
+# flipped to size mode for characterization:  cmake ... -DEDGE_HOT_OPT=-Os
+# Must stay a single token (it is dropped verbatim into compiler command lines).
+set(EDGE_HOT_OPT "-O2" CACHE STRING
+    "Optimization level for the real-time (hot-path) demos: -O2 (default) | -Os | -Oz")
+set_property(CACHE EDGE_HOT_OPT PROPERTY STRINGS -O2 -Os -Oz)
+
 option(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB
        "Enable Atari FujiNet session adapter scaffolding against external fujinetlib-llvm"
        OFF)
@@ -309,7 +319,7 @@ if(EDGE_BUILD_DEMO)
 
     add_executable(atari_tank_demo demo/tank/atari_tank_demo.cpp ${TANK_GEN_HEADERS})
     target_compile_options(atari_tank_demo PRIVATE
-        -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra)
+        -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra)
     target_include_directories(atari_tank_demo PRIVATE ${CMAKE_SOURCE_DIR} ${TANK_GEN_DIR})
     target_compile_definitions(atari_tank_demo PRIVATE EDGE_TANK_ASSET_SOURCE=${_TANK_SRC})
     set_target_properties(atari_tank_demo PROPERTIES OUTPUT_NAME "atari_tank_demo.xex")
@@ -417,7 +427,7 @@ if(EDGE_BUILD_DEMO)
     # Arena demo — native ANTIC/GTIA build (constexpr in-source charset).
     add_executable(arena_native demo/arena/arena_native.cpp)
     target_compile_options(arena_native PRIVATE
-        -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra)
+        -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra)
     target_include_directories(arena_native PRIVATE ${CMAKE_SOURCE_DIR})
     set_target_properties(arena_native PROPERTIES OUTPUT_NAME "arena_native.xex")
     target_link_options(arena_native PRIVATE
@@ -427,19 +437,20 @@ if(EDGE_BUILD_DEMO)
     # over a VBXE overlay canvas. Run with a VBXE FX core, BASIC disabled.
     add_executable(arena_vbxe demo/arena/arena_vbxe.cpp)
     target_compile_options(arena_vbxe PRIVATE
-        -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra)
+        -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra)
     target_include_directories(arena_vbxe PRIVATE ${CMAKE_SOURCE_DIR})
     set_target_properties(arena_vbxe PROPERTIES OUTPUT_NAME "arena_vbxe.xex")
     target_link_options(arena_vbxe PRIVATE
         "LINKER:--Map=$<TARGET_FILE_DIR:arena_vbxe>/arena_vbxe.map")
 
     # Fujinet UDP position-streaming smoke test — links the prebuilt fujinetlib.
-    # -O2 (not -Os): -Os breaks real-time performance with the template-heavy
-    # engine headers (same as the arena demos).
+    # Uses ${EDGE_HOT_OPT} (default -O2): -Os was found to break real-time
+    # performance with the template-heavy engine headers (same as the arena
+    # demos). Build -DEDGE_HOT_OPT=-Os to characterize/flip it.
     if(EXISTS "${FUJINETLIB_INC}/fujinet-network.h" AND EXISTS "${FUJINETLIB_A}")
         add_executable(fujinet_net_test demo/fujinet_net_test/fujinet_net_test.cpp)
         target_compile_options(fujinet_net_test PRIVATE
-            -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra)
+            -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra)
         target_include_directories(fujinet_net_test PRIVATE
             ${CMAKE_SOURCE_DIR} ${FUJINETLIB_INC})
         target_link_libraries(fujinet_net_test PRIVATE ${FUJINETLIB_A})
@@ -495,7 +506,7 @@ if(EDGE_BUILD_DEMO)
         "LINKER:--Map=$<TARGET_FILE_DIR:net_dual_lane_demo>/net_dual_lane_demo.map")
 
     # Realtime networking diagnostic demo (Stage 9S.3; public Game::net.realtime).
-    # Built -O2 (per-frame net path), like the other realtime demos. When netstream
+    # Built ${EDGE_HOT_OPT} (default -O2; per-frame net path), like the other realtime demos. When netstream
     # is ON, link the real adapter's .S handlers (the define is already global via
     # add_compile_definitions above) so Mode B uses real SIO, not the stub HAL.
     set(NET_RT_METER_SRC demo/edge_net_realtime_meter.cpp)
@@ -506,7 +517,7 @@ if(EDGE_BUILD_DEMO)
     endif()
     add_executable(edge_net_realtime_meter ${NET_RT_METER_SRC})
     target_compile_options(edge_net_realtime_meter PRIVATE
-        -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra)
+        -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra)
     target_include_directories(edge_net_realtime_meter PRIVATE
         ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/engine/platform/atari)
     set_target_properties(edge_net_realtime_meter PROPERTIES
@@ -561,7 +572,7 @@ if(EDGE_BUILD_DEMO)
     endif()
     add_executable(atari_tank_net_demo ${TANK_NET_SRC})
     target_compile_options(atari_tank_net_demo PRIVATE
-        -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra)
+        -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra)
     target_include_directories(atari_tank_net_demo PRIVATE
         ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/demo/tank
         ${CMAKE_SOURCE_DIR}/engine/platform/atari ${TANK_NET_GEN_DIR})
@@ -654,7 +665,7 @@ if(EDGE_BUILD_DEMO)
     endif()
     add_executable(atari_tank_dual_net_demo ${TANK_DUAL_SRC})
     target_compile_options(atari_tank_dual_net_demo PRIVATE
-        -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra)
+        -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra)
     target_include_directories(atari_tank_dual_net_demo PRIVATE
         ${CMAKE_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/demo/tank
@@ -893,7 +904,7 @@ if(MOS_ATARI8_CXX)
     add_custom_command(
         OUTPUT ${ARENA_NATIVE_XEX}
         COMMAND ${MOS_ATARI8_CXX}
-                -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra
+                -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra
                 -I${CMAKE_SOURCE_DIR}
                 ${CMAKE_SOURCE_DIR}/demo/arena/arena_native.cpp
                 -o ${ARENA_NATIVE_XEX}
@@ -915,7 +926,7 @@ if(MOS_ATARI8_CXX)
     add_custom_command(
         OUTPUT ${ARENA_VBXE_XEX}
         COMMAND ${MOS_ATARI8_CXX}
-                -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra
+                -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra
                 -I${CMAKE_SOURCE_DIR}
                 ${CMAKE_SOURCE_DIR}/demo/arena/arena_vbxe.cpp
                 -o ${ARENA_VBXE_XEX}
@@ -931,15 +942,16 @@ if(MOS_ATARI8_CXX)
     # ── Fujinet UDP position-streaming smoke test (fujinet_net_test.xex) ──
     #   cmake --build build --target fujinet_net_test  # -> build/fujinet_net_test.xex
     # Links the prebuilt fujinetlib static lib (passed as a command-line input)
-    # and adds its include dir. -O2 (not -Os): -Os breaks real-time performance
-    # with the template-heavy engine headers (same as the arena demos).
+    # and adds its include dir. Uses ${EDGE_HOT_OPT} (default -O2): -Os was found
+    # to break real-time performance with the template-heavy engine headers (same
+    # as the arena demos). Build -DEDGE_HOT_OPT=-Os to characterize/flip it.
     if(EXISTS "${FUJINETLIB_INC}/fujinet-network.h" AND EXISTS "${FUJINETLIB_A}")
         set(FNTEST_XEX ${CMAKE_BINARY_DIR}/fujinet_net_test.xex)
         set(FNTEST_MAP ${CMAKE_BINARY_DIR}/fujinet_net_test.map)
         add_custom_command(
             OUTPUT ${FNTEST_XEX}
             COMMAND ${MOS_ATARI8_CXX}
-                    -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra
+                    -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra
                     -I${CMAKE_SOURCE_DIR} -I${FUJINETLIB_INC}
                     ${CMAKE_SOURCE_DIR}/demo/fujinet_net_test/fujinet_net_test.cpp
                     ${FUJINETLIB_A}
@@ -1223,7 +1235,7 @@ if(MOS_ATARI8_CXX)
 
     # ── Realtime networking diagnostic demo (edge_net_realtime_meter.xex) ──
     #   cmake --build build --target edge_net_realtime_meter
-    # Public Game::net.realtime only; -O2 for the per-frame net/HUD path.
+    # Public Game::net.realtime only; ${EDGE_HOT_OPT} (default -O2) for the per-frame net/HUD path.
     #
     # When EDGE_ATARI_FUJINET_REALTIME_NETSTREAM is ON, link the REAL EDGE-owned
     # Netstream adapter (define + the two .S handlers + the platform include for the
@@ -1253,7 +1265,7 @@ if(MOS_ATARI8_CXX)
     add_custom_command(
         OUTPUT ${NET_RT_METER_XEX}
         COMMAND ${MOS_ATARI8_CXX}
-                -std=c++20 -fno-exceptions -fno-rtti -O2 -Wall -Wextra
+                -std=c++20 -fno-exceptions -fno-rtti ${EDGE_HOT_OPT} -Wall -Wextra
                 ${NET_RT_METER_NS_ARGS}
                 -I${CMAKE_SOURCE_DIR}
                 ${CMAKE_SOURCE_DIR}/demo/edge_net_realtime_meter.cpp

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EDGE (Eight-bit Damned! Game Engine)
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
 
 EDGE is a C++20 game engine for constrained 6502-class systems, built around a small, deterministic, compile-time configured API instead of a heavy runtime.
 The project is Atari-first today, but its architecture is intended to support additional 6502-family platforms over time. Game code is written against portable engine subsystems while hardware details live behind a platform HAL and compile-time capability profiles.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Hardware validation demo (`atari_hw_test.xex`)
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 A minimal Atari 8-bit program that drives every engine subsystem at once, so
 the engine's live ANTIC path can be confirmed on real hardware / emulators

--- a/demo/arena/arena_native.cpp
+++ b/demo/arena/arena_native.cpp
@@ -357,6 +357,13 @@ EDGE_COLD static bool title_step(const engine::Input& in) {
     // copies this shadow to the hardware register, so all title text changes colour.
     Platform::hal::set_color_pf(0, kTitleHues[(g_title_frames / kTitleColorPeriod) % kTitleHueCount]);
     ++g_title_frames;
+#ifdef EDGE_ARENA_AUTOSTART
+    // Headless perf harness (no keyboard/joystick injection available): auto-enter
+    // PlayScreen after the title has shown briefly, so the heavy gameplay path runs
+    // unattended and the HUD DROP counter can be read from a screenshot. Inert in
+    // normal builds (define only for measurement).
+    if (g_title_frames > 30) return true;
+#endif
     return fire_edge(in);
 }
 
@@ -374,6 +381,10 @@ EDGE_COLD static void play_enter() {
     // HUD: score label, level readout, and three life hearts (raw tile code 0x05).
     hud.print(0, 0, "SCORE: 00000");
     hud.print(kHudLevelCol, 0, "LV:01");
+    // Frame-overrun diagnostic: dropped frames this round (engine counter). A
+    // nonzero DROP means the per-frame gameplay path overran 60Hz — the signal
+    // that told us -Os throttled this demo. play_step refreshes the digits live.
+    hud.print(24, 0, "DROP");
     hud.put_char(36, 0, 0x05);
     hud.put_char(37, 0, 0x05);
     hud.put_char(38, 0, 0x05);
@@ -409,10 +420,22 @@ EDGE_COLD static void play_enter() {
     g_get_ready = kGetReadyFrames;
 
     arm_fire();
+
+#ifndef EDGE_ARENA_AUTOSTART
+    // Zero the frame-overrun counter so the HUD DROP readout measures this round's
+    // gameplay, not the one-shot screen bring-up above.
+    Game::reset_frame_stats();
+#endif
+    // (Under the autostart perf harness the reset is skipped so DROP accumulates
+    //  across every round, capturing the worst-case overrun of a whole run.)
 }
 
 static bool play_step(const engine::Input& in) {
     auto& play = Game::region<PlayScreen, 1>();
+
+    // Live frame-overrun readout (engine counter): 4-digit dropped-frame count in
+    // the HUD, refreshed every frame. Stays 0 while -Os keeps up; climbs if not.
+    Game::region<PlayScreen, 0>().print_num(29, 0, Game::frames_dropped(), 4);
 
     // Death pause: lives just hit 0. Freeze every entity (skip all updates so sprites
     // hold their last-committed positions) while the room stays on screen, then signal
@@ -551,8 +574,9 @@ static bool play_step(const engine::Input& in) {
                 enemy_touch = true;
         });
         if (enemy_touch) {
-            player.lives  = static_cast<u8>(player.lives - 1);
             player.iframe = kIFrames;
+#ifndef EDGE_ARENA_AUTOSTART
+            player.lives  = static_cast<u8>(player.lives - 1);
             hud_draw_lives();
             Game::sound.play(kDamageSfx, 0);
             if (player.lives == 0) {
@@ -563,6 +587,12 @@ static bool play_step(const engine::Input& in) {
                 if (g_new_high) g_high_score = g_score;
                 g_death_timer = kDeathPause;
             }
+#else
+            // Autostart perf harness: the player is immortal, so a round runs forever
+            // with the full enemy complement chasing — a sustained worst-case 4-sprite
+            // same-band load for reading the frame-overrun (DROP) counter unattended.
+            (void)0;
+#endif
         }
     }
 

--- a/demo/atari_scroll_test.cpp
+++ b/demo/atari_scroll_test.cpp
@@ -99,9 +99,18 @@ static void fill_map() {
                 const u16 lc = static_cast<u16>(c - kMargin);   // logical column
                 if (r == 0)       t = g(static_cast<char>('0' + (lc / 10) % 10));  // col tens
                 else if (r == 1)  t = g(static_cast<char>('0' + (lc % 10)));       // col ones
+#ifdef EDGE_SCROLL_AUTOPILOT
+                // Diagnostic rig: repeat the column ruler on every row so a
+                // horizontal shear (a band of rows displaced by a coarse cell
+                // against the rest of the frame) is visible at any screen row —
+                // the '.' texture is one-cell periodic and hides it.
+                else if ((r & 1) == 0) t = g(static_cast<char>('0' + (lc / 10) % 10));
+                else                   t = g(static_cast<char>('0' + (lc % 10)));
+#else
                 else if (lc == 0) t = g(static_cast<char>('0' + (r / 10) % 10));   // row tens
                 else if (lc == 1) t = g(static_cast<char>('0' + (r % 10)));        // row ones
                 else              t = g('.');                                      // texture
+#endif
             }
             g_map.set_tile(c, r, t);
         }
@@ -116,12 +125,21 @@ static u16 g_frame = 0;
 // ── Per-frame logic (runs once per VBI via Game::run) ────────────────────
 
 static void frame_step(const engine::Input& in) {
+#ifdef EDGE_SCROLL_AUTOPILOT
+    // Diagnostic rig: sweep the viewport east/west continuously (2 fine units
+    // per frame crosses a coarse cell every other frame) so horizontal-scroll
+    // defects reproduce headlessly, without joystick input.
+    (void)in;
+    if ((g_frame / 60) & 1) Game::scroll.move(-2, 0);
+    else                    Game::scroll.move(2, 0);
+#else
     // Joystick scrolls the window. X is in fine (color-clock) units, Y in
     // scanlines; the engine clamps at the map edges and handles fine<->coarse.
     if (in.left())  Game::scroll.move(-1, 0);
     if (in.right()) Game::scroll.move(1, 0);
     if (in.up())    Game::scroll.move(0, -1);
     if (in.down())  Game::scroll.move(0, 1);
+#endif
 
     ++g_frame;
 

--- a/demo/edge_net_realtime_meter.cpp
+++ b/demo/edge_net_realtime_meter.cpp
@@ -334,6 +334,11 @@ static void draw_static_labels() {
     Game::print(20, 17, "REV");
     Game::print(0, 18, "WORST");
     Game::print(12, 18, "BEST");
+    // Engine frame-overrun diagnostic: frames the game loop failed to consume in
+    // time (dropped) out of total frames serviced. Reads Game::frames_dropped()/
+    // frames_serviced() — a nonzero DROP means the per-frame path overran 60Hz.
+    Game::print(0, 20, "FRM DROP");
+    Game::print(15, 20, "OF");
     Game::print(0, 23, "FIRE = QUIT");
     // Peer endpoint + TV/fps line (host string then ":port  ECHO  NTSC <fps>").
     Game::print(5, 1, kPeerHost);
@@ -388,6 +393,10 @@ static void draw_dynamic(bool active, u16 now) {
     print_pct(24, 17, g_loss_rev);
     print_pct(6, 18, g_loss_worst);
     print_pct(17, 18, g_loss_best);
+
+    // Frame-overrun diagnostic (engine counter): dropped / serviced.
+    Game::print_num(9, 20, Game::frames_dropped(), 5);
+    Game::print_num(18, 20, Game::frames_serviced(), 5);
 }
 
 // ── Per-frame step ────────────────────────────────────────────────────────────
@@ -486,6 +495,10 @@ int main() {
         Game::print(28, 0, "ACTIVE");
     }
 
+    // Zero the frame-overrun counters after all one-shot setup (charset load,
+    // screen bring-up, blocking netstream settle) so the on-screen DROP/SVC
+    // readout measures only the steady-state run loop, not boot-time stalls.
+    Game::reset_frame_stats();
     Game::run_until(step);
     return 0;
 }

--- a/demo/tank/atari_tank_demo.cpp
+++ b/demo/tank/atari_tank_demo.cpp
@@ -145,7 +145,15 @@ static void submit_camera_and_sprite() {
 }
 
 static void frame_step(const engine::Input& in) {
+#ifdef EDGE_TANK_AUTOPILOT
+    // Perf harness (no input-injection tooling available): auto-drive forward while
+    // turning, so the scroll hot path runs every frame and the frame-overrun counter
+    // measures sustained scrolling unattended. Inert unless EDGE_TANK_AUTOPILOT is set.
+    (void)in;
+    const tank::Intent intent = tank::resolve_input(false, true, true, false);
+#else
     const tank::Intent intent = tank::resolve_input(in.left(), in.right(), in.up(), in.down());
+#endif
     if (intent.rotate != 0) {
         if (g_tank.turn_counter == 0) {
             g_tank.heading = (intent.rotate > 0) ? tank::heading_cw(g_tank.heading)
@@ -155,6 +163,11 @@ static void frame_step(const engine::Input& in) {
     } else { g_tank.turn_counter = 0; }
     tank::move_tank(g_tank, intent.move);
     submit_camera_and_sprite();
+    // Frame-overrun tell: tint the playfield background if the loop has dropped any
+    // frame (brighter red = more), reusing the show_progress colour convention. Stays
+    // invisible while the demo holds 60Hz (frames_dropped()==0 leaves the palette be).
+    if (const u16 d = Game::frames_dropped())
+        Platform::hal::set_color_pf(4, static_cast<u8>(0x30 | (d < 14 ? d : 14)));
 }
 
 #if TANK_NET_MODE
@@ -174,6 +187,7 @@ static void show_progress(bool failed, bool complete) {
         static_cast<u8>(reinterpret_cast<uintptr_t>(&g_net_tileset) >> 8));
     Game::scroll_map(g_map);
     submit_camera_and_sprite();
+    Game::reset_frame_stats();   // measure gameplay only, not one-shot setup stalls
     Game::run(frame_step);
 }
 [[noreturn]] static void halt_loop() { Game::run([](const engine::Input&) {}); }
@@ -354,6 +368,7 @@ int main() {
             tank::copy_chunk_to_map(g_map, tank::chunk_payload(cx, cy), cx, cy);
     Game::scroll_map(g_map);
     submit_camera_and_sprite();
+    Game::reset_frame_stats();   // measure gameplay only, not one-shot setup stalls
     Game::run(frame_step);
 
 #elif EDGE_TANK_ASSET_SOURCE == TANK_ASSET_SIMULATED

--- a/demo/tank_dual_net/atari_tank_dual_net_demo.cpp
+++ b/demo/tank_dual_net/atari_tank_dual_net_demo.cpp
@@ -357,14 +357,37 @@ static void streaming_frame_step(const engine::Input& in) {
     // Pure-white contact (COLPF0, no depot-box colour) is a wall → snap back; a depot
     // letter sets a colour bit too, so the tank drives over it.
     const u8 hit = Game::sprite_collisions().sprite_to_background(0);
+#ifdef EDGE_TANK_AUTOPILOT
+    // Bounce: reverse off the wall so the patrol keeps scrolling. The GTIA
+    // collision latch lags the restore by a frame, so a plain restore+reverse
+    // re-reads the stale hit next frame, flips the heading straight back, and
+    // parks the tank at the first wall forever. Reverse once, then ignore the
+    // latch for a few frames while the tank drives clear.
+    static u8 s_bounce_cooldown = 0;
+    if (s_bounce_cooldown) {
+        --s_bounce_cooldown;
+        g_st.tank_safe = g_tank;
+    } else if ((hit & kWallColpfMask) && !(hit & kDepotSurroundMask)) {
+        g_tank = g_st.tank_safe;
+        g_tank.heading = static_cast<u8>((g_tank.heading + 8) & 15);
+        s_bounce_cooldown = 8;
+    } else {
+        g_st.tank_safe = g_tank;
+    }
+#else
     if ((hit & kWallColpfMask) && !(hit & kDepotSurroundMask)) {
         g_tank = g_st.tank_safe;
     } else {
         g_st.tank_safe = g_tank;
     }
+#endif
 
     // 3. Local tank input + movement (unchanged from the original tank demo).
+#ifdef EDGE_TANK_AUTOPILOT
+    const tank::Intent intent = tank::resolve_input(false, false, true, false);  // perf harness: auto-drive straight (reverse off walls below)
+#else
     const tank::Intent intent = tank::resolve_input(in.left(), in.right(), in.up(), in.down());
+#endif
     if (intent.rotate != 0) {
         if (g_tank.turn_counter == 0) {
             g_tank.heading = (intent.rotate > 0) ? tank::heading_cw(g_tank.heading)
@@ -394,6 +417,10 @@ static void streaming_frame_step(const engine::Input& in) {
 
     // 5. Draw all tanks + missiles.
     submit_sprites();
+    // Frame-overrun tell: tint the background BLUE if the loop dropped any frame
+    // (brighter = more). Blue is distinct from the red "NO NET" indicator.
+    if (const u16 d = Game::frames_dropped())
+        Platform::hal::set_color_pf(4, static_cast<u8>(0x80 | (d < 14 ? d : 14)));
 }
 
 // Per-frame streaming + quit handling (one callback to keep the demo's near-full zero
@@ -465,6 +492,7 @@ static bool streaming_step(const engine::Input& in) {
     }
 
     submit_sprites();
+    Game::reset_frame_stats();   // measure gameplay only, not one-shot setup stalls
     // Streams until a keypress; on keypress it sends the "bye" to the server over a few
     // frames (so it returns to Phase 1) and then returns.
     Game::run_until(streaming_step);

--- a/demo/tank_net/atari_tank_net_demo.cpp
+++ b/demo/tank_net/atari_tank_net_demo.cpp
@@ -236,12 +236,20 @@ static void frame_step(const engine::Input& in) {
     const u8 hit = Game::sprite_collisions().sprite_to_background(0);
     if ((hit & kWallColpfMask) && !(hit & kDepotSurroundMask)) {
         g_tank = g_st.tank_safe;
+#ifdef EDGE_TANK_AUTOPILOT
+        g_tank.heading = static_cast<u8>((g_tank.heading + 8) & 15);  // bounce: reverse off the wall so the patrol keeps scrolling
+#endif
     } else {
         g_st.tank_safe = g_tank;
     }
 
     // 3. Local tank input + movement (unchanged from the original tank demo).
+#ifdef EDGE_TANK_AUTOPILOT
+    (void)in;   // perf harness: auto-drive straight (reverse off walls, below) so the
+    const tank::Intent intent = tank::resolve_input(false, false, true, false);  // scroll hot path runs continuously
+#else
     const tank::Intent intent = tank::resolve_input(in.left(), in.right(), in.up(), in.down());
+#endif
     if (intent.rotate != 0) {
         if (g_tank.turn_counter == 0) {
             g_tank.heading = (intent.rotate > 0) ? tank::heading_cw(g_tank.heading)
@@ -265,6 +273,10 @@ static void frame_step(const engine::Input& in) {
 
     // 5. Draw all tanks.
     submit_sprites();
+    // Frame-overrun tell: tint the background BLUE if the loop dropped any frame
+    // (brighter = more). Blue is distinct from the red "NO NET" indicator below.
+    if (const u16 d = Game::frames_dropped())
+        Platform::hal::set_color_pf(4, static_cast<u8>(0x80 | (d < 14 ? d : 14)));
 }
 
 // ── Entry point ────────────────────────────────────────────────────────────
@@ -295,5 +307,6 @@ int main() {
     }
 
     submit_sprites();
+    Game::reset_frame_stats();   // measure gameplay only, not one-shot setup stalls
     Game::run(frame_step);
 }

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -1,6 +1,6 @@
 # API Design
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 The user-facing API for the engine. This document describes what
 a game author writes. Internal engine implementation details are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 System design, component relationships, and the abstraction
 boundaries that make the engine portable across 6502 platforms
@@ -483,14 +483,20 @@ demos, and tests (see ADR-034 in [DECISIONS.md](DECISIONS.md)):
 
 **Scroll** — manages hardware fine and coarse scrolling. The
 `ScrollManager` is portable: it owns the viewport position and
-the fine/coarse split, writes the fine-scroll registers through
+the fine/coarse split, stages the fine-scroll values through
 `Platform::hal`, and exposes `coarse_col()`/`coarse_row()`. The
 backend display program owns the load-address (coarse) patching —
-one address per visible line of a `ScrollRegion`, repointed each
-frame. Hardware conventions (per-axis fine-scroll inversion, fetch
-width) come from the display traits, so the generic layer names no
-backend specifics. The frame service applies scroll and keeps the
-Tiles viewport in sync; coarse scroll is clamped to the map edges.
+one address per visible line of a `ScrollRegion`. Scroll display
+programs are double-buffered: on a coarse change the frame service
+patches the off-screen copy and commits it with a single
+display-program-pointer write that the platform latches at the
+next frame boundary, so the per-line rewrite never races the
+display beam and fine + coarse take effect together (ADR-027,
+2026-07-07 revision). Hardware conventions (per-axis fine-scroll
+inversion, fetch width) come from the display traits, so the
+generic layer names no backend specifics. The frame service
+applies scroll and keeps the Tiles viewport in sync; coarse scroll
+is clamped to the map edges.
 
 **Sound** — manages POKEY voice allocation and sound effect /
 music playback. Sound data is `constexpr` ROM tables.

--- a/docs/CONSTRAINTS.md
+++ b/docs/CONSTRAINTS.md
@@ -1,6 +1,6 @@
 # Constraints
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Hardware budgets, platform targets, and non-negotiable rules that
 every design decision must respect.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Decisions made during design, with rationale. These explain the
 "why" behind architectural choices and document tradeoffs.
@@ -1258,6 +1258,36 @@ per visible line instead of one per region — e.g. 24 × 3 bytes),
 and the map must carry a few margin columns on the horizontal axis
 (the HSCROLL fetch overscan), with coarse scroll clamped to the
 fetch width. Both are small and standard for ANTIC scrolling.
+
+**Revision (2026-07-07): double-buffered display program; coarse
+commits by pointer swap.** Rewriting the *live* list's per-line
+load addresses from the deferred frame service raced the display
+beam: when input-lengthened OS vertical-blank work pushed the
+service late (more likely with the slower per-byte code of `-Os`
+builds), the rewrite ran past vertical blank and the top rows of
+the frame displayed the previous coarse offset while the rest
+showed the new one — a one-cell horizontal shear during scrolling.
+Moving the rewrite to the immediate VBI made it worse (a heavy
+operation cannot fit the blank window). A scroll layout's display
+program now keeps TWO byte-identical copies of the list (the
+second costs roughly the list size, and only for scroll layouts):
+`patch_scroll()` rewrites the OFF-screen copy and swaps, and the
+screen manager commits by writing the new front's address to the
+display-list pointer shadow — an O(1) write the OS transfers to
+the hardware atomically in the next vertical blank, so the heavy
+rewrite may run at any point in the frame. Each copy's JVB loops
+to its own base; one LMS-position table indexes both. Because the
+commit now latches one frame later than the old in-place patch,
+the fine-scroll value is staged ONLY by the frame service — the
+game-loop fine publish (added for the earlier top-band jitter fix)
+is removed, since it would put fine one frame ahead of coarse and
+snap the picture at every cell crossing. The fine flush (immediate
+VBI) and the pointer transfer (OS shadow copy) land in the same
+vertical blank, keeping fine and coarse atomic; scroll latency
+grows by one frame, uniformly. Verified A/B on the emulator with a
+gated service-delay diagnostic (`EDGE_SIM_VBI_LATE`) and a
+row-alignment analyzer over screenshots; covered by
+`tests/backends/atari/test_atari_scroll.cpp`.
 
 ---
 

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # EDGE API Reference
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This reference is organized in two layers:
 

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -1,6 +1,6 @@
 # EDGE Atari Platform Guide
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This document describes the first concrete EDGE backend: the Atari 8-bit family.
 

--- a/documents/QUICK_START.md
+++ b/documents/QUICK_START.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This guide introduces EDGE from the engine author's point of view first, then shows the current concrete setup using the Atari backend.
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 # EDGE Engine Documentation
 
-> **Applies to EDGE v0.8.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 EDGE is a C++ engine for building games and interactive applications on constrained 6502-class systems.
 

--- a/engine/core.h
+++ b/engine/core.h
@@ -193,6 +193,15 @@ public:
     // Frame-ready flag set by frame_service(), polled by the loop (loop.h).
     static inline volatile bool frame_ready_ = false;
 
+    // Frame-overrun diagnostic. frame_service() sets frame_ready_ once per frame;
+    // if the flag is STILL set the next time the service runs, the game loop never
+    // consumed the previous frame — the frame overran its budget and was dropped.
+    // frames_serviced_ counts every service; frames_dropped_ counts the overruns.
+    // Free-running u16 (wrap ~18 min at 60/s); read/reset via the forwarders below.
+    // Cost is a couple of increments per frame — negligible on the hot path.
+    static inline volatile u16 frames_serviced_ = 0;
+    static inline volatile u16 frames_dropped_  = 0;
+
     // ── Initialisation ──
     //
     // With a tileset: enable sprites, bring up the initial screen, load the
@@ -391,6 +400,14 @@ public:
     static void run_until(Cb cb) { engine::run_until<Core>(cb); }
     static bool frame_overrun() { return engine::frame_overrun<Core>(); }
 
+    // Frame-overrun diagnostic accessors (see frames_dropped_/frames_serviced_).
+    // frames_dropped() is the number of frames the game loop failed to consume in
+    // time; frames_serviced() is the total frames the service ran. reset_frame_stats()
+    // zeroes both so a demo can measure a clean window (e.g. after warm-up/setup).
+    static u16 frames_dropped()  { return frames_dropped_; }
+    static u16 frames_serviced() { return frames_serviced_; }
+    static void reset_frame_stats() { frames_dropped_ = 0; frames_serviced_ = 0; }
+
     // Quiesce every subsystem so a program can hand control back to its host
     // environment instead of running forever. Closes any open network lanes, then
     // asks the platform to tear down whatever it brought up (interrupt handlers,
@@ -414,13 +431,6 @@ public:
             Platform::hal::frame_consumed();
     }
 
-    // Called by the loop right after the game callback has committed this frame's
-    // scroll position, before it waits for the next frame boundary. Publishes the
-    // fine-scroll position so the backend latches THIS frame's value (keeping fine
-    // and coarse scroll coherent — see Screen::publish_fine_scroll). No-op unless a
-    // scroll map is bound.
-    static void publish_scroll() { screen.publish_fine_scroll(scroll); }
-
     // ── Per-frame service ──
     //
     // The backend's frame interrupt runs this once per frame in the
@@ -428,6 +438,15 @@ public:
     // a plain void(*)() for install_frame_isr().
     static void frame_service() {
         using caps = engine::caps_of_t<Platform>;
+
+#ifdef EDGE_SIM_VBI_LATE
+        // Diagnostic build gate: delay the whole service the way long pre-service
+        // host work (e.g. live input processing) does, so sub-frame beam-race
+        // defects reproduce headlessly — automated input keeps the host's
+        // pre-service work short, hiding them. No-op without a backend hook.
+        if constexpr (requires { Platform::hal::sim_vbi_late(); })
+            Platform::hal::sim_vbi_late();
+#endif
 
         // 0. Suppress idle-dim (the backend would otherwise dim/cycle colours
         //    after a few minutes of no console/keyboard input).
@@ -538,7 +557,12 @@ public:
         // 7. User frame hooks.
         interrupts.run_frame_hooks();
 
-        // 8. Release the loop's frame.
+        // 8. Release the loop's frame. If the previous frame was never consumed
+        //    (frame_ready_ still set), the game loop overran its budget — record the
+        //    dropped frame for the frame-overrun diagnostic before re-arming.
+        // (plain assignment, not ++: compound ops on a volatile are deprecated in C++20)
+        frames_serviced_ = static_cast<u16>(frames_serviced_ + 1);
+        if (frame_ready_) frames_dropped_ = static_cast<u16>(frames_dropped_ + 1);
         frame_ready_ = true;
     }
 

--- a/engine/loop.h
+++ b/engine/loop.h
@@ -47,7 +47,6 @@ template <typename Core, typename Cb>
         Core::frame_consumed();   // release the VBI guard now the frame is consumed
         sync_after_vbi();
         cb(Core::input);
-        Core::publish_scroll();   // latch THIS frame's fine scroll before the next frame service
         if (Core::hooks.post_render) Core::hooks.post_render();
     }
 }
@@ -61,7 +60,6 @@ void run_until(Cb cb) {
         Core::frame_consumed();   // release the VBI guard now the frame is consumed
         sync_after_vbi();
         const bool done = cb(Core::input);
-        Core::publish_scroll();   // latch THIS frame's fine scroll before the next frame service
         if (Core::hooks.post_render) Core::hooks.post_render();
         if (done) return;
     }

--- a/engine/platform/atari/display_list.h
+++ b/engine/platform/atari/display_list.h
@@ -20,6 +20,8 @@
 // absolute (runtime) buffer address, so the list is built at set_screen time and
 // the builder inserts an extra LMS at every mode line that enters a new 4K page.
 
+#include <stddef.h>
+
 #include "../../display.h"
 #include "../../types.h"
 #include "antic.h"
@@ -113,12 +115,27 @@ constexpr u16 max_scroll_lms_count() {
 // mode-line-misaligned base) still corrupts its tail — unavoidable via the
 // display list alone; place the shared buffer so 4K boundaries align to
 // mode-line edges.
+//
+// Scroll layouts keep TWO copies of the list (double_buffered below): ANTIC
+// executes the front copy while patch_scroll() rewrites the ~one-LMS-per-line
+// coarse offset into the back copy and swaps. The commit is then a 2-byte
+// display-list-pointer write (the SDLSTL shadow, via the HAL) that the OS copies
+// to ANTIC atomically in the next vertical blank — so the heavy LMS rewrite can
+// run at any point in the frame without racing the beam. (Rewriting the live
+// list from the deferred VBI sheared the top band whenever input-lengthened OS
+// VBI work pushed the rewrite past vblank.) Both copies are built identically —
+// same 4K-crossing LMS layout, byte-for-byte — except the JVB, which loops each
+// copy back to its own start; only the scroll LMS address bytes ever differ.
 template <typename Layout>
 struct DisplayProgram {
     static constexpr u8  region_count = Layout::region_count;
     static constexpr u16 capacity     = detail::display_list_capacity<Layout>();
     static constexpr u16 max_lms      = detail::max_lms_count<Layout>();
     static constexpr u16 max_scroll_lms = detail::max_scroll_lms_count<Layout>();
+    // Only scroll layouts pay for the second list: they are the only ones whose
+    // list is rewritten per frame (the coarse LMS patch). Everything else keeps a
+    // 1-byte stub so non-scroll screens are unaffected.
+    static constexpr bool double_buffered = Layout::has_scroll;
 
     u8  bytes[capacity]              = {};
     u16 size                         = 0;   // bytes actually used by build()
@@ -129,8 +146,18 @@ struct DisplayProgram {
     // Low-byte index of every scroll-region LMS, in visible-line (top-to-bottom)
     // order, so patch_scroll() can repoint each line independently. The generic
     // ScrollManager never sees these — it only supplies coarse col/row.
+    // One table serves both list copies: they share the exact byte layout.
     u16 scroll_lms_pos[max_scroll_lms] = {};
     u16 scroll_lms_count               = 0;
+    // Back copy of the list for scroll layouts (see the struct comment); a 1-byte
+    // stub otherwise. Which copy is front alternates with every patch_scroll().
+    u8  bytes_b[double_buffered ? capacity : 1] = {};
+    u8  front_b                        = 0;   // 1 = bytes_b is the front copy
+
+    // The list copy the display hardware should be executing (the front). For a
+    // non-double-buffered layout this is always `bytes`.
+    u8*       front()       { return (double_buffered && front_b) ? bytes_b : bytes; }
+    const u8* front() const { return (double_buffered && front_b) ? bytes_b : bytes; }
 
     // Build the display list for screen memory based at `screen_base`, with the
     // list itself residing at `dl_base` (used by the JVB to loop the list).
@@ -138,6 +165,7 @@ struct DisplayProgram {
         u16 p   = 0;
         lms_count = 0;
         scroll_lms_count = 0;
+        front_b = 0;
 
         // Pure-overlay layout: ANTIC DMA is disabled entirely by the screen
         // manager, so the list need only satisfy the DLISTL pointer requirement.
@@ -218,14 +246,41 @@ struct DisplayProgram {
         bytes[p++] = lo(dl_base);
         bytes[p++] = hi(dl_base);
         size = p;
+
+        // Mirror the list into the back copy for scroll layouts: byte-identical
+        // (so the shared lms_pos/scroll_lms_pos tables index both) except the
+        // JVB, which must loop this copy back to its own start. The copy's base
+        // is derived from `dl_base` by the members' fixed offset so it stays
+        // consistent even when a test builds against a synthetic base address.
+        if constexpr (double_buffered) {
+            for (u16 i = 0; i < size; ++i) bytes_b[i] = bytes[i];
+            const u16 alt_base = static_cast<u16>(
+                dl_base + (offsetof(DisplayProgram, bytes_b) -
+                           offsetof(DisplayProgram, bytes)));
+            bytes_b[jvb_pos]     = lo(alt_base);
+            bytes_b[jvb_pos + 1] = hi(alt_base);
+        }
     }
 
     // Repoint every scroll-region LMS at the bound map for a coarse (col, row)
     // offset: visible line i loads `map_base + (coarse_row + i)*map_width +
     // coarse_col`. This is the ONLY place the ANTIC LMS bytes are rewritten at run
     // time; the generic ScrollManager supplies only the coarse offsets (it never
-    // touches the display list). A no-op for layouts with no scroll region.
-    void patch_scroll(u16 map_base, u16 map_width, u16 coarse_col, u16 coarse_row) {
+    // touches the display list).
+    //
+    // The rewrite lands in the BACK copy and swaps it to front (see the struct
+    // comment): the caller commits by handing the returned front pointer to the
+    // display-program shadow — an O(1) write the OS applies in the next vertical
+    // blank — so this per-line loop never races the beam no matter when it runs.
+    // Returns the new front (the copy just patched).
+    u8* patch_scroll(u16 map_base, u16 map_width, u16 coarse_col, u16 coarse_row) {
+#ifdef EDGE_SCROLL_RASTERBAR
+        // Diagnostic: paint the background for the duration of the rewrite so a
+        // screenshot shows where in the frame it runs (a visible band = past
+        // vblank — harmless now that the rewrite targets the off-screen copy).
+        *reinterpret_cast<volatile u8*>(0xD01A) = 0x36;   // COLBK, bright orange
+#endif
+        u8* const dst = double_buffered && !front_b ? bytes_b : bytes;
         // Successive visible lines differ by exactly one map row, so walk the load
         // address incrementally (one multiply for the first line, then += map_width)
         // instead of a 16-bit multiply per line. The per-line multiply made this the
@@ -235,10 +290,17 @@ struct DisplayProgram {
         // coarse_col` for every i.
         u16 a = static_cast<u16>(map_base + coarse_row * map_width + coarse_col);
         for (u16 i = 0; i < scroll_lms_count; ++i) {
-            bytes[scroll_lms_pos[i]]     = lo(a);
-            bytes[scroll_lms_pos[i] + 1] = hi(a);
+            dst[scroll_lms_pos[i]]     = lo(a);
+            dst[scroll_lms_pos[i] + 1] = hi(a);
             a = static_cast<u16>(a + map_width);
         }
+        if constexpr (double_buffered) front_b = static_cast<u8>(!front_b);
+#ifdef EDGE_SCROLL_RASTERBAR
+        // Restore the game's background colour from the OS shadow (COLOR4).
+        *reinterpret_cast<volatile u8*>(0xD01A) =
+            *reinterpret_cast<volatile u8*>(0x02C8);
+#endif
+        return dst;
     }
 
 private:

--- a/engine/platform/atari/hal.h
+++ b/engine/platform/atari/hal.h
@@ -492,6 +492,16 @@ struct Hal {
     // the stack. See the edge_vbi_busy comment above.
     static void frame_consumed() { edge_vbi_busy = 0; }
 
+    // Diagnostic hook (EDGE_SIM_VBI_LATE in engine/core.h): burn ~30 scanlines of
+    // WSYNC waits at the top of the deferred service to fake the start drift that
+    // live joystick/keyboard input causes (the OS VBI's input processing runs
+    // first) — the drift that pushed the coarse scroll rewrite past vblank at -Os.
+    // Autopilot/headless runs generate no real input, so without this the race
+    // window never opens. Generates no code unless the gated call is compiled in.
+    static void sim_vbi_late() {
+        for (uint8_t i = 0; i < 30; ++i) *reg::WSYNC = 0;
+    }
+
     // ── Teardown (reverse of init) ───────────────────────────────────────
     //
     // The engine normally runs forever; a program that instead returns to the OS/DOS

--- a/engine/screen.h
+++ b/engine/screen.h
@@ -202,7 +202,7 @@ public:
 
         // Program the display. Blank DMA and install the program in all cases.
         Platform::hal::display_dma_disable();
-        Platform::hal::set_display_program(dl.bytes);
+        Platform::hal::set_display_program(dl.front());
         if constexpr (!S::display::is_pure_overlay) {
             // Playfield content present (playfield-only or mixed overlay+playfield):
             // re-enable playfield DMA. Mixed layouts cost only the display-program
@@ -216,7 +216,7 @@ public:
         // blitter — the bus-contention fix (formerly a manual playfield-DMA disable),
         // now automatic.
 
-        active_dl_      = dl.bytes;
+        active_dl_      = dl.front();
         active_dl_size_ = dl.size;
 
         // A fresh screen is not scroll-bound until bind_scroll_map(); apply_scroll
@@ -253,9 +253,13 @@ public:
         scroll_bound_     = true;
 
         // Point the scroll region's view at the map so region-view writes land in
-        // the map buffer, and set the initial (unscrolled) load addresses.
+        // the map buffer, and set the initial (unscrolled) load addresses. The
+        // patch lands in the program's back copy and swaps it to front, so commit
+        // the new front to the display hardware (same sequence as apply_scroll).
         views_.template for_screen<S>().template get<idx>().ptr = map_base;
-        dl.patch_scroll(scroll_map_base_, scroll_map_width_, 0, 0);
+        u8* const front = dl.patch_scroll(scroll_map_base_, scroll_map_width_, 0, 0);
+        Platform::hal::set_display_program(front);
+        active_dl_ = front;
         // Invalidate the apply_scroll coarse cache so the next frame re-patches
         // regardless of the prior (possibly different-program) coarse offset.
         last_coarse_col_ = 0xFFFF;
@@ -271,10 +275,17 @@ public:
                         tr::fine_scroll_inverts_x(mode), tr::fine_scroll_inverts_y(mode));
     }
 
-    // Per-frame scroll update (called from the frame service). Writes the fine
-    // registers and repoints the scroll-region load addresses for the current coarse
-    // offset. No-op unless a map is bound and the ScrollManager is active and not
-    // suspended.
+    // Per-frame scroll update (called from the frame service). Stages the fine
+    // registers and, when the coarse offset crossed a cell, patches the program's
+    // back copy and commits it with a display-program-pointer write. Both the
+    // staged fine value and the committed program pointer are latched by the
+    // backend at the NEXT frame boundary — the same one — so fine and coarse
+    // always go live together for the same scroll position, and neither can race
+    // the beam no matter how late in the frame this service runs. (Staging fine
+    // anywhere else — e.g. from the game loop, as an earlier design did — puts it
+    // one frame ahead of the coarse commit and snaps the picture at every cell
+    // crossing.) No-op unless a map is bound and the ScrollManager is active and
+    // not suspended.
     template <typename ScrollT>
     void apply_scroll(ScrollT& scroll) {
         if (!scroll_bound_ || !scroll.active() || scroll.suspended()) return;
@@ -288,24 +299,13 @@ public:
         const u16 cc = scroll.coarse_col();
         const u16 cr = scroll.coarse_row();
         if (cc != last_coarse_col_ || cr != last_coarse_row_) {
-            scroll_patch_(scroll_prog_, scroll_map_base_, scroll_map_width_, cc, cr);
+            u8* const front = scroll_patch_(scroll_prog_, scroll_map_base_,
+                                            scroll_map_width_, cc, cr);
+            Platform::hal::set_display_program(front);
+            active_dl_ = front;
             last_coarse_col_ = cc;
             last_coarse_row_ = cr;
         }
-    }
-
-    // Publish only the fine-scroll position to the backend. Called from the game
-    // loop right after the game commits its frame (engine/loop.h), so the value the
-    // backend latches at the next frame boundary reflects THIS frame's position.
-    // The backend may latch the fine registers at a different point in the frame
-    // than the coarse load addresses (apply_scroll, run from the frame service); if
-    // the fine value were published only there it could lag the coarse offset by a
-    // frame and shear the picture during motion. write_fine() carries no display-
-    // program side effects, so it is safe to call outside the frame service.
-    template <typename ScrollT>
-    void publish_fine_scroll(ScrollT& scroll) {
-        if (!scroll_bound_ || !scroll.active() || scroll.suspended()) return;
-        scroll.write_fine();
     }
 
     // Typed region view for region N of screen S (compile-time type safety:
@@ -354,11 +354,12 @@ private:
 
     // Type-erasing trampoline so apply_scroll can call the backend display
     // program's patch_scroll without the ScreenManager naming the per-screen
-    // program type at the call site.
+    // program type at the call site. Returns the program's new front copy for
+    // the caller to commit to the display hardware.
     template <typename S>
-    static void patch_thunk(void* p, u16 base, u16 width, u16 col, u16 row) {
+    static u8* patch_thunk(void* p, u16 base, u16 width, u16 col, u16 row) {
         using DP = typename Platform::template display_program<typename S::display>;
-        static_cast<DP*>(p)->patch_scroll(base, width, col, row);
+        return static_cast<DP*>(p)->patch_scroll(base, width, col, row);
     }
 
     alignas(buffer_align) u8 screen_buffer_[buffer_size + pad_slack] = {};
@@ -370,7 +371,7 @@ private:
     // Scroll binding (type-erased: the active program type is captured in
     // scroll_patch_ at bind time so apply_scroll names no per-screen type).
     void*  scroll_prog_      = nullptr;
-    void (*scroll_patch_)(void*, u16, u16, u16, u16) = nullptr;
+    u8* (*scroll_patch_)(void*, u16, u16, u16, u16) = nullptr;
     u16    scroll_map_base_  = 0;
     u16    scroll_map_width_ = 0;
     bool   scroll_bound_     = false;

--- a/engine/version.h
+++ b/engine/version.h
@@ -10,8 +10,8 @@
 // EDGE follows Semantic Versioning (https://semver.org/): MAJOR.MINOR.PATCH.
 
 #define EDGE_VERSION_MAJOR 0
-#define EDGE_VERSION_MINOR 8
+#define EDGE_VERSION_MINOR 9
 #define EDGE_VERSION_PATCH 0
-#define EDGE_VERSION_STRING "0.8.0"
+#define EDGE_VERSION_STRING "0.9.0"
 
 #endif // ENGINE_VERSION_H

--- a/scripts/build_demos.sh
+++ b/scripts/build_demos.sh
@@ -9,6 +9,8 @@
 # Usage:  scripts/build_demos.sh
 #   BUILD_DIR=<dir>   build directory (default: build-atari)
 #   RECONF=1          force a fresh CMake configure even if the cache exists
+#   HOT_OPT=<flag>    optimization for the realtime demos: -O2 (default) | -Os | -Oz
+#                     (only applied at configure time; use RECONF=1 to change it)
 #
 # Run scripts/setup.sh first if you are unsure the toolchain is installed.
 
@@ -21,7 +23,8 @@ if [ ! -f "$BUILD_DIR/CMakeCache.txt" ] || [ "${RECONF:-0}" = "1" ]; then
     echo "== configuring Atari demo build in $BUILD_DIR =="
     cmake -S "$REPO" -B "$BUILD_DIR" \
         -DCMAKE_TOOLCHAIN_FILE="$REPO/cmake/atari-toolchain.cmake" \
-        -DEDGE_BUILD_DEMO=ON
+        -DEDGE_BUILD_DEMO=ON \
+        ${HOT_OPT:+-DEDGE_HOT_OPT="$HOT_OPT"}
 fi
 
 echo "== building all demos (target: demos) =="

--- a/tests/backends/atari/test_atari_scroll.cpp
+++ b/tests/backends/atari/test_atari_scroll.cpp
@@ -133,15 +133,43 @@ static void test_scroll_build() {
     CHECK(g_dl.bytes[g_dl.region_lms_pos[0] - 1] == (0x02 | M::DL_LMS));
 }
 
-// ── patch_scroll repoints each line by the map-width stride ────────────
+// ── patch_scroll repoints each line, into the back copy, and swaps ─────
 
 static void test_patch_scroll() {
     g_dl.build(0x4000, 0x4000);
-    g_dl.patch_scroll(0x8000, MAP_W, /*col*/ 3, /*row*/ 2);
 
+    // Scroll layouts are double-buffered: build mirrors the list into a second
+    // copy, byte-identical (so one scroll_lms_pos table indexes both) except the
+    // JVB, which loops each copy back to its own start.
+    static_assert(decltype(g_dl)::double_buffered, "scroll layout double-buffers");
+    const u16 alt_base = static_cast<u16>(
+        0x4000 + (addr_of(g_dl.bytes_b) - addr_of(g_dl.bytes)));
+    for (u16 i = 0; i < g_dl.size; ++i) {
+        if (i == g_dl.jvb_pos || i == g_dl.jvb_pos + 1) continue;
+        CHECK(g_dl.bytes_b[i] == g_dl.bytes[i]);
+    }
+    CHECK(read16(g_dl.bytes,   g_dl.jvb_pos) == 0x4000);
+    CHECK(read16(g_dl.bytes_b, g_dl.jvb_pos) == alt_base);
+    CHECK(g_dl.front() == g_dl.bytes);
+
+    // The coarse rewrite lands in the OFF-screen copy, which becomes the front;
+    // the returned pointer is what the caller commits to the display hardware.
+    u8* front = g_dl.patch_scroll(0x8000, MAP_W, /*col*/ 3, /*row*/ 2);
+    CHECK(front == g_dl.bytes_b);
+    CHECK(front == g_dl.front());
     for (u16 i = 0; i < g_dl.scroll_lms_count; ++i) {
         const u16 expect = static_cast<u16>(0x8000 + (2 + i) * MAP_W + 3);
-        CHECK(read16(g_dl.bytes, g_dl.scroll_lms_pos[i]) == expect);
+        CHECK(read16(front, g_dl.scroll_lms_pos[i]) == expect);
+    }
+
+    // A second patch swaps back to the primary copy, fully repatched (each patch
+    // rewrites every scroll LMS, so a stale back copy can never leak through).
+    front = g_dl.patch_scroll(0x8000, MAP_W, /*col*/ 4, /*row*/ 2);
+    CHECK(front == g_dl.bytes);
+    CHECK(front == g_dl.front());
+    for (u16 i = 0; i < g_dl.scroll_lms_count; ++i) {
+        const u16 expect = static_cast<u16>(0x8000 + (2 + i) * MAP_W + 4);
+        CHECK(read16(front, g_dl.scroll_lms_pos[i]) == expect);
     }
 }
 
@@ -169,6 +197,8 @@ static void test_apply_scroll() {
     const u16 map = addr_of(g_map);
     CHECK(scroll.active());
     CHECK(first_scroll_addr() == map);             // bound at coarse (0,0)
+    // bind committed the freshly patched front copy to the display hardware.
+    CHECK(MockHal::last_program == g_sm.active_dl());
 
     // Scroll to (20,17). Horizontal fine is inverted and absorbs into its cell;
     // vertical fine is raw. hscrol 0 (20%4==0), vscrol 1 (17%8), coarse col 5,
@@ -180,6 +210,8 @@ static void test_apply_scroll() {
     CHECK(MockHal::vscrol == 1);
     CHECK(MockHal::fine_writes == 2);
     CHECK(first_scroll_addr() == static_cast<u16>(map + 2 * MAP_W + 5));
+    // The coarse change patched the back copy, swapped, and committed it.
+    CHECK(MockHal::last_program == g_sm.active_dl());
 
     // Suspended: apply_scroll writes nothing and leaves the list unchanged.
     scroll.suspend();


### PR DESCRIPTION
…+ frame diagnostics; release 0.9.0

Scroll (ADR-027, 2026-07-07 revision): a scroll layout's display program now keeps two byte-identical list copies. patch_scroll() rewrites the off-screen copy and swaps; the screen manager commits with a 2-byte SDLSTL/SDLSTH write the OS latches atomically next vertical blank, so the per-line LMS rewrite can never race the beam — fixes the -Os top-band shear under input-lengthened OS VBI work. Fine scroll is staged only by the frame service now (main-loop publish_scroll removed) so fine and coarse always latch in the same vblank. A/B-verified on Altirra with simulated VBI lateness: 3/11 before-shots show the one-cell top-band split, 0/11 after. ctest 47/47.

Also: EDGE_HOT_OPT CMake knob (all realtime demos hold 60fps/0 drops at -Os), frame-overrun counters (Game::frames_dropped/frames_serviced), gated perf autopilots and beam-race diagnostics (EDGE_SIM_VBI_LATE, EDGE_SCROLL_RASTERBAR, EDGE_SCROLL_AUTOPILOT).