### PR TITLE
fujinet-lib: support upstream header layout; fix global-scope wiring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ set(EDGE_FUJINETLIB_INCLUDE_DIR
     ""
     CACHE PATH
     "Path to fujinetlib include directory (contains fujinet-network.h)")
+set(EDGE_FUJINETLIB_ATARI_INCLUDE_DIR
+    ""
+    CACHE PATH
+    "Path to fujinetlib Atari include directory (contains fujinet-network-atari.h); defaults to EDGE_FUJINETLIB_INCLUDE_DIR when both headers share a directory")
 set(EDGE_FUJINETLIB_LIBRARY
     ""
     CACHE FILEPATH
@@ -66,13 +70,29 @@ set(EDGE_FUJINET_VALIDATE_PORT
     "Port used by demo/fujinet_session_validate runtime validation demo")
 
 if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
+    # fujinet-lib ships its public headers (fujinet-network.h) at the checkout
+    # root and its per-machine headers (fujinet-network-atari.h) under
+    # atari/src/include. Older checkouts flattened both into src/include; accept
+    # either so an in-flight checkout keeps configuring.
     if(EDGE_FUJINETLIB_ROOT)
         if(NOT EDGE_FUJINETLIB_INCLUDE_DIR)
-            set(EDGE_FUJINETLIB_INCLUDE_DIR "${EDGE_FUJINETLIB_ROOT}/src/include")
+            if(EXISTS "${EDGE_FUJINETLIB_ROOT}/src/include/fujinet-network.h")
+                set(EDGE_FUJINETLIB_INCLUDE_DIR "${EDGE_FUJINETLIB_ROOT}/src/include")
+            else()
+                set(EDGE_FUJINETLIB_INCLUDE_DIR "${EDGE_FUJINETLIB_ROOT}")
+            endif()
+        endif()
+        if(NOT EDGE_FUJINETLIB_ATARI_INCLUDE_DIR
+           AND EXISTS "${EDGE_FUJINETLIB_ROOT}/atari/src/include/fujinet-network-atari.h")
+            set(EDGE_FUJINETLIB_ATARI_INCLUDE_DIR "${EDGE_FUJINETLIB_ROOT}/atari/src/include")
         endif()
         if(NOT EDGE_FUJINETLIB_LIBRARY)
             set(EDGE_FUJINETLIB_LIBRARY "${EDGE_FUJINETLIB_ROOT}/build/libfujinet.a")
         endif()
+    endif()
+
+    if(NOT EDGE_FUJINETLIB_ATARI_INCLUDE_DIR)
+        set(EDGE_FUJINETLIB_ATARI_INCLUDE_DIR "${EDGE_FUJINETLIB_INCLUDE_DIR}")
     endif()
 
     if(NOT EDGE_FUJINETLIB_INCLUDE_DIR OR NOT EDGE_FUJINETLIB_LIBRARY)
@@ -84,9 +104,9 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
         message(FATAL_ERROR
             "Missing fujinet-network.h under EDGE_FUJINETLIB_INCLUDE_DIR='${EDGE_FUJINETLIB_INCLUDE_DIR}'")
     endif()
-    if(NOT EXISTS "${EDGE_FUJINETLIB_INCLUDE_DIR}/fujinet-network-atari.h")
+    if(NOT EXISTS "${EDGE_FUJINETLIB_ATARI_INCLUDE_DIR}/fujinet-network-atari.h")
         message(FATAL_ERROR
-            "Missing fujinet-network-atari.h under EDGE_FUJINETLIB_INCLUDE_DIR='${EDGE_FUJINETLIB_INCLUDE_DIR}'")
+            "Missing fujinet-network-atari.h under EDGE_FUJINETLIB_ATARI_INCLUDE_DIR='${EDGE_FUJINETLIB_ATARI_INCLUDE_DIR}'")
     endif()
     if(NOT EXISTS "${EDGE_FUJINETLIB_LIBRARY}")
         message(FATAL_ERROR
@@ -99,6 +119,7 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
     foreach(_fnpath
             "${EDGE_FUJINETLIB_ROOT}"
             "${EDGE_FUJINETLIB_INCLUDE_DIR}"
+            "${EDGE_FUJINETLIB_ATARI_INCLUDE_DIR}"
             "${EDGE_FUJINETLIB_LIBRARY}")
         if(_fnpath MATCHES "/mnt/old_ubuntu_22")
             message(FATAL_ERROR
@@ -106,9 +127,27 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
         endif()
     endforeach()
 
+    # The machine-specific dir precedes the public one, matching fujinet-lib's
+    # own target_include_directories order.
+    set(EDGE_FUJINETLIB_INCLUDE_DIRS
+        "${EDGE_FUJINETLIB_ATARI_INCLUDE_DIR}"
+        "${EDGE_FUJINETLIB_INCLUDE_DIR}")
+    list(REMOVE_DUPLICATES EDGE_FUJINETLIB_INCLUDE_DIRS)
+    set(EDGE_FUJINETLIB_INCLUDE_FLAGS)
+    foreach(_fninc IN LISTS EDGE_FUJINETLIB_INCLUDE_DIRS)
+        list(APPEND EDGE_FUJINETLIB_INCLUDE_FLAGS "-I${_fninc}")
+    endforeach()
+
+    # The define is global: platform.h pulls <fujinet-network.h> into every
+    # target, and any target instantiating SessionLane calls into the archive.
+    # Header search path and link line therefore have to be global to match.
+    # libfujinet.a is a static archive, so targets that never call it pay
+    # nothing.
     add_compile_definitions(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB=1)
+    include_directories(${EDGE_FUJINETLIB_INCLUDE_DIRS})
+    link_libraries(${EDGE_FUJINETLIB_LIBRARY})
     message(STATUS "EDGE FujiNet session backend: RealFujinetLib")
-    message(STATUS "  include: ${EDGE_FUJINETLIB_INCLUDE_DIR}")
+    message(STATUS "  include: ${EDGE_FUJINETLIB_INCLUDE_DIRS}")
     message(STATUS "  library: ${EDGE_FUJINETLIB_LIBRARY}")
 endif()
 
@@ -209,7 +248,13 @@ set(GENERATE_CHARSET_HEADER_SCRIPT
 # CMakeLists.txt). Override FUJINETLIB_DIR if the checkout lives elsewhere.
 set(FUJINETLIB_DIR ""
     CACHE PATH "Path to the fujinetlib-llvm checkout")
-set(FUJINETLIB_INC ${FUJINETLIB_DIR}/src/include)
+# Public headers sit at the checkout root upstream; older checkouts flattened
+# them into src/include.
+if(EXISTS "${FUJINETLIB_DIR}/src/include/fujinet-network.h")
+    set(FUJINETLIB_INC ${FUJINETLIB_DIR}/src/include)
+else()
+    set(FUJINETLIB_INC ${FUJINETLIB_DIR})
+endif()
 set(FUJINETLIB_A   ${FUJINETLIB_DIR}/build/libfujinet.a)
 
 add_custom_command(
@@ -344,7 +389,7 @@ if(EDGE_BUILD_DEMO)
         # the distinction impossible to miss: a build-embedded marker, a configure
         # line, and a loud warning for the stub case.
         if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
-            target_include_directories(atari_tank_demo PRIVATE ${EDGE_FUJINETLIB_INCLUDE_DIR})
+            target_include_directories(atari_tank_demo PRIVATE ${EDGE_FUJINETLIB_INCLUDE_DIRS})
             target_link_libraries(atari_tank_demo PRIVATE ${EDGE_FUJINETLIB_LIBRARY})
             target_compile_definitions(atari_tank_demo PRIVATE EDGE_TANK_LIVE_BACKEND_REAL=1)
             message(STATUS "atari_tank_demo LiveSession — Live transport backend: RealFujinetLib")
@@ -474,7 +519,7 @@ if(EDGE_BUILD_DEMO)
             EDGE_FUJINET_VALIDATE_HOST="${EDGE_FUJINET_VALIDATE_HOST}"
             EDGE_FUJINET_VALIDATE_PORT=${EDGE_FUJINET_VALIDATE_PORT})
         target_include_directories(fujinet_session_validate PRIVATE
-            ${CMAKE_SOURCE_DIR} ${EDGE_FUJINETLIB_INCLUDE_DIR})
+            ${CMAKE_SOURCE_DIR} ${EDGE_FUJINETLIB_INCLUDE_DIRS})
         target_link_libraries(fujinet_session_validate PRIVATE ${EDGE_FUJINETLIB_LIBRARY})
         set_target_properties(fujinet_session_validate PROPERTIES
             OUTPUT_NAME "fujinet_session_validate.xex")
@@ -683,7 +728,7 @@ if(EDGE_BUILD_DEMO)
     # enabled; otherwise the session HAL is a stub that reports Ok without connecting.
     if(_TDN_SRC EQUAL 2)
         if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
-            target_include_directories(atari_tank_dual_net_demo PRIVATE ${EDGE_FUJINETLIB_INCLUDE_DIR})
+            target_include_directories(atari_tank_dual_net_demo PRIVATE ${EDGE_FUJINETLIB_INCLUDE_DIRS})
             target_link_libraries(atari_tank_dual_net_demo PRIVATE ${EDGE_FUJINETLIB_LIBRARY})
             target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_TANK_LIVE_BACKEND_REAL=1)
             message(STATUS "atari_tank_dual_net_demo LiveSession — session backend: RealFujinetLib")
@@ -985,7 +1030,7 @@ if(MOS_ATARI8_CXX)
                     -DEDGE_FUJINET_VALIDATE_HOST=\"${EDGE_FUJINET_VALIDATE_HOST}\"
                     -DEDGE_FUJINET_VALIDATE_PORT=${EDGE_FUJINET_VALIDATE_PORT}
                     -DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=1
-                    -I${CMAKE_SOURCE_DIR} -I${EDGE_FUJINETLIB_INCLUDE_DIR}
+                    -I${CMAKE_SOURCE_DIR} ${EDGE_FUJINETLIB_INCLUDE_FLAGS}
                     ${CMAKE_SOURCE_DIR}/demo/fujinet_session_validate/fujinet_session_validate.cpp
                     ${EDGE_FUJINETLIB_LIBRARY}
                     -o ${FN_SESSION_VALIDATE_XEX}

--- a/README.md
+++ b/README.md
@@ -163,13 +163,21 @@ For a fuller walkthrough, start with [`/documents/QUICK_START.md`](./documents/Q
   — bridges an emulator (Altirra) to FujiNet over the NetSIO UDP protocol (`netsiohub`
   + the Altirra `netsio.atdevice`). EDGE's realtime (Netstream) lane is validated
   against this stack.
-- **fujinet-lib (llvm-mos build)** — a pre-built C library (`libfujinet.a` + headers)
-  for the session lane's real TCP transport, only required when configuring with
-  `-DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON` (OFF by default; see
-  [`documents/PLATFORM_ATARI.md`](./documents/PLATFORM_ATARI.md)). Note that the
-  upstream [fujinet-lib](https://github.com/FujiNetWIFI/fujinet-lib) is built for CC65
-  and is **not** compatible with EDGE's llvm-mos toolchain; an llvm-mos-compatible
-  build is required and is **not yet published**.
+- **[fujinet-lib (llvm-mos build)](https://github.com/brad-colbert/fujinet-lib-llvm/tree/llvm_changes)**
+  — a C library (`libfujinet.a` + headers) providing the `N:` device and TCP
+  transport. **On Atari, any use of TCP or the `N:` device must link this
+  library, built from the `llvm_changes` branch.** Upstream
+  [fujinet-lib](https://github.com/FujiNetWIFI/fujinet-lib) targets CC65 and will
+  not link against EDGE's llvm-mos toolchain. Only required when configuring with
+  `-DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON` (OFF by default); the realtime
+  (Netstream) lane needs no external library. See
+  [`documents/PLATFORM_ATARI.md`](./documents/PLATFORM_ATARI.md).
+
+  ```sh
+  git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git
+  cmake -S fujinet-lib-llvm -B fujinet-lib-llvm/build   # -> build/libfujinet.a
+  cmake --build fujinet-lib-llvm/build
+  ```
 - **[Docker](https://www.docker.com/)** *(optional)* — runs the isolated UDP peer used
   in the Mode-B networking validation stack.
 
@@ -194,7 +202,7 @@ Useful environment knobs (all optional; sensible defaults):
 | Variable | Used by | Meaning |
 | --- | --- | --- |
 | `ALTIRRA_DIR` | `run_tank_*.sh`, `setup.sh` | Path to your Altirra install (else common locations are searched) |
-| `FUJINETLIB_ROOT` | `run_tank_networked.sh` | fujinet-lib (llvm-mos) checkout for the live networking demo |
+| `FUJINETLIB_ROOT` | `run_tank_networked.sh` | fujinet-lib (llvm-mos, `llvm_changes` branch) checkout for the live networking demo |
 | `BUILD_DIR` | `build_demos.sh` | Build directory (default `build-atari`) |
 | `RECONF=1` | `build_demos.sh` | Force a fresh CMake configure |
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -195,13 +195,23 @@ public charset API (`bind_charset_page`).
 
 ### LiveSession build + server
 
+`LiveSession` opens a TCP connection over the `N:` device, so on Atari it must
+link `libfujinet.a` from the `llvm_changes` branch of
+<https://github.com/brad-colbert/fujinet-lib-llvm>. Upstream fujinet-lib is CC65
+and will not link under llvm-mos.
+
 ```sh
-# Atari (requires the FujiNet session lane: build fujinet-lib, then configure with
-# EDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON + EDGE_FUJINETLIB_ROOT=...):
+# Build the library once:
+git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git
+cmake -S fujinet-lib-llvm -B fujinet-lib-llvm/build
+cmake --build fujinet-lib-llvm/build          # -> build/libfujinet.a
+
+# Atari (requires the FujiNet session lane: EDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON
+# + EDGE_FUJINETLIB_ROOT pointing at that checkout):
 cmake -B build-atari -DCMAKE_TOOLCHAIN_FILE=cmake/atari-toolchain.cmake \
       -DEDGE_BUILD_DEMO=ON -DEDGE_TANK_ASSET_SOURCE=LiveSession \
       -DEDGE_TANK_NET_HOST="192.168.1.10" -DEDGE_TANK_NET_PORT=9000 \
-      -DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON -DEDGE_FUJINETLIB_ROOT=/path/to/fujinet-lib
+      -DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON -DEDGE_FUJINETLIB_ROOT=/path/to/fujinet-lib-llvm
 cmake --build build-atari --target atari_tank_demo
 
 # Host server (Python stdlib only):

--- a/demo/fujinet_session_validate/README.md
+++ b/demo/fujinet_session_validate/README.md
@@ -20,10 +20,16 @@ Realtime lane is intentionally not used.
 
 ## Build Gating
 
-This demo is built only when all of the following are true:
+This demo opens a TCP connection over the `N:` device, so it must link
+`libfujinet.a` built from the `llvm_changes` branch of
+<https://github.com/brad-colbert/fujinet-lib-llvm>. Upstream fujinet-lib is CC65
+and will not link under llvm-mos.
+
+It is built only when all of the following are true:
 
 - `EDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON`
 - valid `EDGE_FUJINETLIB_INCLUDE_DIR` and `EDGE_FUJINETLIB_LIBRARY` are set
+  (both are derived for you from `EDGE_FUJINETLIB_ROOT`)
 - Atari/llvm-mos build path is active (same gating style as existing FujiNet demo rules)
 
 Default OFF builds remain unchanged.

--- a/demo/tank/ASSET_PROTOCOL.md
+++ b/demo/tank/ASSET_PROTOCOL.md
@@ -182,13 +182,21 @@ transfer over real FujiNet SIO.
 
 ### Dependency
 
-- fujinet-lib root (validated local checkout):
-  `/home/brad/Dropbox/Projects/Atari/fujinetlib-llvm`
-  - source commit `7803c86` (tag `wave3b-done`)
-  - public headers: `<root>/src/include` (`fujinet-network.h`, `fujinet-network-atari.h`)
-  - static library: `<root>/build/libfujinet.a`
-  - built with the `/usr/local/bin` llvm-mos toolchain
-    (`mos-atari8-dos-clang`, `llvm-ar`) — verified, no rebuild required.
+`LiveSession` is TCP over the `N:` device, so it must link fujinet-lib. On Atari
+that means the llvm-mos build:
+
+- source: the **`llvm_changes`** branch of
+  <https://github.com/brad-colbert/fujinet-lib-llvm>. Upstream
+  [FujiNetWIFI/fujinet-lib](https://github.com/FujiNetWIFI/fujinet-lib) builds the
+  Atari target with CC65 and **will not link** under llvm-mos.
+- build: `cmake -S <root> -B <root>/build && cmake --build <root>/build`, using the
+  `/usr/local/bin` llvm-mos toolchain (`mos-atari8-dos-clang`, `llvm-ar`).
+- public headers: `<root>` (`fujinet-network.h`)
+- Atari headers: `<root>/atari/src/include` (`fujinet-network-atari.h`)
+- static library: `<root>/build/libfujinet.a`
+
+Point `EDGE_FUJINETLIB_ROOT` at `<root>`; the include dirs and archive are derived
+for you.
 
 The CMake variables are configurable; the path above is the validated default,
 not a hard-coded requirement. A focused CMake guard rejects the prohibited legacy
@@ -216,7 +224,7 @@ cmake -B build-atari-live \
   -DEDGE_BUILD_DEMO=ON \
   -DEDGE_TANK_ASSET_SOURCE=LiveSession \
   -DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON \
-  -DEDGE_FUJINETLIB_ROOT=/home/brad/Dropbox/Projects/Atari/fujinetlib-llvm \
+  -DEDGE_FUJINETLIB_ROOT=/path/to/fujinet-lib-llvm \
   -DEDGE_TANK_NET_HOST=192.168.1.205 \
   -DEDGE_TANK_NET_PORT=9000
 cmake --build build-atari-live --target atari_tank_demo

--- a/demo/tank_dual_net/README.md
+++ b/demo/tank_dual_net/README.md
@@ -91,18 +91,22 @@ scripts/build_demos.sh                       # → build-atari/atari_tank_dual_n
 cmake --build build-atari --target atari_tank_dual_net_demo
 ```
 
-Real dual-lane build (the decisive hardware config — both lanes + real fujinet-lib):
+Real dual-lane build (the decisive hardware config — both lanes + real fujinet-lib).
+Phase 1 is TCP over the `N:` device, so it must link `libfujinet.a` from the
+`llvm_changes` branch of <https://github.com/brad-colbert/fujinet-lib-llvm>
+(upstream fujinet-lib is CC65 and will not link under llvm-mos):
 
 ```sh
-FNL=~/Projects/Atari/fujinetlib-llvm
+git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git ~/Projects/Atari/fujinet-lib-llvm
+FNL=~/Projects/Atari/fujinet-lib-llvm
+cmake -S "$FNL" -B "$FNL/build" && cmake --build "$FNL/build"   # -> build/libfujinet.a
+
 cmake -S . -B build-live \
   -DCMAKE_TOOLCHAIN_FILE="$PWD/cmake/atari-toolchain.cmake" -DEDGE_BUILD_DEMO=ON \
   -DEDGE_TANK_DUAL_ASSET_SOURCE=LiveSession \
   -DEDGE_ATARI_FUJINET_REALTIME_NETSTREAM=ON \
   -DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON \
-  -DEDGE_FUJINETLIB_ROOT="$FNL" \
-  -DEDGE_FUJINETLIB_INCLUDE_DIR="$FNL/src/include" \
-  -DEDGE_FUJINETLIB_LIBRARY="$FNL/build/libfujinet.a"
+  -DEDGE_FUJINETLIB_ROOT="$FNL"
 cmake --build build-live --target atari_tank_dual_net_demo
 ```
 

--- a/docs/CONSTRAINTS.md
+++ b/docs/CONSTRAINTS.md
@@ -107,7 +107,10 @@ parameter, not a linear tier progression.
 - Primary target for multiplayer networking
 - Implementation status (two lanes; see ADR-032, ADR-033):
   - Session lane (TCP, framed/reliable): optionally wired to fujinet-lib
-    (`-DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON`; OFF by default)
+    (`-DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON`; OFF by default). TCP and the
+    `N:` device require `libfujinet.a` from the `llvm_changes` branch of
+    https://github.com/brad-colbert/fujinet-lib-llvm (upstream fujinet-lib is
+    CC65 and will not link under llvm-mos)
   - Realtime lane (fixed 16-byte packets, no wire framing; unframed stream, so
     the consumer reassembles units): wired to an EDGE-owned FujiNet Netstream
     path; validated against the fujinet-pc emulator stack (NetSIO + Altirra +

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -699,8 +699,11 @@ are available.
 > **Implementation status:**
 > - **Session lane** — optionally wired to real fujinet-lib TCP transport.
 >   Enable with `-DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON` at configure time
->   (requires an external fujinet-lib checkout; OFF by default).
->   When OFF, session methods return `Unsupported`/`WouldBlock` stubs.
+>   (OFF by default). When OFF, session methods return `Unsupported`/`WouldBlock`
+>   stubs. On Atari, TCP and the `N:` device require linking `libfujinet.a` built
+>   from the `llvm_changes` branch of
+>   <https://github.com/brad-colbert/fujinet-lib-llvm> — upstream fujinet-lib is
+>   CC65 and will not link under llvm-mos.
 > - **Realtime lane** — wired to an EDGE-owned FujiNet Netstream path (fixed
 >   16-byte packets, all-or-nothing TX/RX, **no wire framing**; no fujinet-lib).
 >   The data path is validated against the fujinet-pc emulator stack

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -452,21 +452,44 @@ using Platform = atari::FullUpgrade;   // XL, U1MB, VBXE<>, PokeyMax, NTSC, Fuji
 
 #### Session lane — optional fujinet-lib wiring
 
-The session lane can be wired to the real [fujinet-lib](https://github.com/FujiNetWIFI/fujinet-lib)
-C library using the `EDGE_ATARI_FUJINET_SESSION_FUJINETLIB` CMake option.
-This is **OFF by default**; default builds require no external library.
+> **TCP and the `N:` device require fujinet-lib.** On the Atari target, anything
+> that opens a TCP connection or talks to the `N:` device — the session lane, the
+> `fujinet_net_test` / `fujinet_session_validate` demos, the tank demos'
+> `LiveSession` asset source — must link `libfujinet.a` built from the
+> **`llvm_changes`** branch of
+> **<https://github.com/brad-colbert/fujinet-lib-llvm>**:
+>
+> ```sh
+> git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git
+> cmake -S fujinet-lib-llvm -B fujinet-lib-llvm/build
+> cmake --build fujinet-lib-llvm/build          # -> build/libfujinet.a
+> ```
+>
+> That branch retargets the Atari build to llvm-mos. Upstream
+> [FujiNetWIFI/fujinet-lib](https://github.com/FujiNetWIFI/fujinet-lib) builds the
+> Atari target with CC65 and **will not link** against EDGE's llvm-mos toolchain —
+> it is not a drop-in substitute. The realtime (Netstream) lane is EDGE-owned
+> assembly and needs no external library; only TCP / `N:` does.
+
+The session lane is wired to fujinet-lib with the
+`EDGE_ATARI_FUJINET_SESSION_FUJINETLIB` CMake option. This is **OFF by default**;
+default builds require no external library.
 
 ```sh
 # Enable at configure time and point to your fujinet-lib checkout:
 cmake -S . -B build \
     -DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON \
-    -DEDGE_FUJINETLIB_ROOT=/path/to/fujinetlib-llvm
+    -DEDGE_FUJINETLIB_ROOT=/path/to/fujinet-lib-llvm
 
-# Or supply include dir and archive explicitly:
+# Or supply the include dirs and archive explicitly. fujinet-lib keeps its public
+# headers at the checkout root and the per-machine ones under atari/src/include.
+# EDGE_FUJINETLIB_ATARI_INCLUDE_DIR defaults to the public dir, which is what
+# older checkouts that flattened both into src/include need.
 cmake -S . -B build \
     -DEDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON \
-    -DEDGE_FUJINETLIB_INCLUDE_DIR=/path/to/fujinetlib-llvm/src/include \
-    -DEDGE_FUJINETLIB_LIBRARY=/path/to/fujinetlib-llvm/lib/libfujinet.a
+    -DEDGE_FUJINETLIB_INCLUDE_DIR=/path/to/fujinet-lib-llvm \
+    -DEDGE_FUJINETLIB_ATARI_INCLUDE_DIR=/path/to/fujinet-lib-llvm/atari/src/include \
+    -DEDGE_FUJINETLIB_LIBRARY=/path/to/fujinet-lib-llvm/build/libfujinet.a
 ```
 
 **When ON**, the session adapter calls:

--- a/engine/platform/atari/fujinet_session_fujinetlib.h
+++ b/engine/platform/atari/fujinet_session_fujinetlib.h
@@ -11,6 +11,17 @@
 #include "../../types.h"
 #include "../../net_types.h"
 
+// fujinet-lib is a C library: its declarations must land at global scope. Any
+// other translation unit that includes these headers directly sees the same
+// names, and the include guards make whichever inclusion comes first the one
+// that decides the scope.
+#if defined(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
+extern "C" {
+#include <fujinet-network.h>
+#include <fujinet-network-atari.h>
+}
+#endif
+
 namespace atari {
 namespace fujinet_session {
 
@@ -22,13 +33,6 @@ using engine::net::NetError;
 using engine::net::NetStatus;
 
 static constexpr u16 kTcpDeviceSpecCapacity = 96;
-
-#if defined(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
-extern "C" {
-#include <fujinet-network.h>
-#include <fujinet-network-atari.h>
-}
-#endif
 
 // Build "N:TCP://<host>:<port>/" into a fixed destination buffer.
 inline NetStatus build_tcp_devicespec(const char* host,

--- a/scripts/run_tank_networked.sh
+++ b/scripts/run_tank_networked.sh
@@ -11,7 +11,11 @@
 #   REBUILD=1            force a rebuild even if the .xex already exists
 #   NET_HOST=<ip>        server address the FujiNet connects to (default LAN IP)
 #   NET_PORT=<n>         server TCP port (default 9000)
-#   FUJINETLIB_ROOT=...  fujinet-lib checkout (default validated local path)
+#   FUJINETLIB_ROOT=...  fujinet-lib checkout (default validated local path).
+#                        TCP / the N: device need the llvm-mos build: the
+#                        llvm_changes branch of
+#                        https://github.com/brad-colbert/fujinet-lib-llvm
+#                        (upstream fujinet-lib is CC65 and will not link).
 #   LINGER=<sec>         server post-COMPLETE linger (default 10)
 #   ALTIRRA_DIR / ALTIRRA_TV / ALTIRRA_EXTRA   as in run_tank_embedded.sh
 #
@@ -33,11 +37,15 @@ XEX="$BUILD_DIR/atari_tank_demo.xex"
 
 NET_HOST="${NET_HOST:-$(hostname -I | awk '{print $1}')}"
 NET_PORT="${NET_PORT:-9000}"
-FUJINETLIB_ROOT="${FUJINETLIB_ROOT:-$REPO/third_party/fujinetlib-llvm}"
+FUJINETLIB_ROOT="${FUJINETLIB_ROOT:-$REPO/third_party/fujinet-lib-llvm}"
 LINGER="${LINGER:-10}"
 
 [ -f "$FUJINETLIB_ROOT/build/libfujinet.a" ] || {
-    echo "fujinet-lib not found at: $FUJINETLIB_ROOT (set FUJINETLIB_ROOT)" >&2; exit 2; }
+    echo "fujinet-lib not found at: $FUJINETLIB_ROOT (set FUJINETLIB_ROOT)" >&2
+    echo "This demo uses TCP over the N: device, which needs the llvm-mos build:" >&2
+    echo "  git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git" >&2
+    echo "  cmake -S fujinet-lib-llvm -B fujinet-lib-llvm/build && cmake --build fujinet-lib-llvm/build" >&2
+    exit 2; }
 
 # ── Build if needed (real fujinet-lib backend; /usr/local/bin llvm-mos) ───────
 if [ ! -f "$XEX" ] || [ "${REBUILD:-0}" = "1" ]; then

--- a/tests/backends/atari/CMakeLists.txt
+++ b/tests/backends/atari/CMakeLists.txt
@@ -27,7 +27,7 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
 		test_atari_fujinet_session_send_nb.cpp)
 	target_include_directories(test_atari_fujinet_session_send_nb_obj PRIVATE
 		${CMAKE_SOURCE_DIR}
-		${EDGE_FUJINETLIB_INCLUDE_DIR})
+		${EDGE_FUJINETLIB_INCLUDE_DIRS})
 	target_compile_definitions(test_atari_fujinet_session_send_nb_obj PRIVATE
 		EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
 
@@ -37,11 +37,12 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
 			test_atari_fujinet_session_send_nb.cpp)
 		target_include_directories(test_atari_fujinet_session_send_nb PRIVATE
 			${CMAKE_SOURCE_DIR}
-			${EDGE_FUJINETLIB_INCLUDE_DIR})
+			${EDGE_FUJINETLIB_INCLUDE_DIRS})
 		target_link_libraries(test_atari_fujinet_session_send_nb PRIVATE
 			${EDGE_FUJINETLIB_LIBRARY})
+		# The target is 6502 code: run it under the simulator, not natively.
 		add_test(NAME test_atari_fujinet_session_send_nb
-			COMMAND test_atari_fujinet_session_send_nb)
+			COMMAND mos-sim $<TARGET_FILE:test_atari_fujinet_session_send_nb>)
 	endif()
 else()
 	# OFF-mode: standard test, no special includes.
@@ -56,7 +57,7 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
 		fujinetlib_session_smoke.cpp)
 	target_include_directories(edge_fujinetlib_session_smoke_obj PRIVATE
 		${CMAKE_SOURCE_DIR}
-		${EDGE_FUJINETLIB_INCLUDE_DIR})
+		${EDGE_FUJINETLIB_INCLUDE_DIRS})
 
 	# Optional link smoke executable. Build this only for mos toolchains,
 	# because host toolchains may not link an Atari-target archive.
@@ -65,7 +66,7 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
 			fujinetlib_session_smoke.cpp)
 		target_include_directories(edge_fujinetlib_session_smoke PRIVATE
 			${CMAKE_SOURCE_DIR}
-			${EDGE_FUJINETLIB_INCLUDE_DIR})
+			${EDGE_FUJINETLIB_INCLUDE_DIRS})
 		target_link_libraries(edge_fujinetlib_session_smoke PRIVATE
 			${EDGE_FUJINETLIB_LIBRARY})
 	endif()

--- a/tests/backends/atari/test_atari_fujinet_session_send_nb.cpp
+++ b/tests/backends/atari/test_atari_fujinet_session_send_nb.cpp
@@ -58,11 +58,9 @@ static void test_send_nb_valid_not_connected_closed() {
 // references network_write and the compiler must resolve the symbol.
 // Runtime behavior with hardware is tested via the mos-toolchain link smoke.
 static void test_send_nb_when_connected_network_write_compile_path() {
-    // network_write is declared inside the atari::fujinet_session namespace
-    // (included via the adapter header's extern "C" block inside that namespace).
-    // Verify the symbol resolves through the expected qualified path.
-    using atari::fujinet_session::network_write;
-    uint8_t (*p_write)(const char*, const uint8_t*, uint16_t) = &network_write;
+    // network_write is a C declaration at global scope, brought in by the
+    // adapter header. Verify the symbol resolves there and nowhere else.
+    uint8_t (*p_write)(const char*, const uint8_t*, uint16_t) = &::network_write;
     (void)p_write;  // compile-only check; not reachable without hardware
 }
 

--- a/tests/backends/atari/test_atari_fujinet_session_spec.cpp
+++ b/tests/backends/atari/test_atari_fujinet_session_spec.cpp
@@ -9,8 +9,13 @@ using engine::net::NetStatus;
 
 namespace fs = atari::fujinet_session;
 
+#if defined(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
+static_assert(fs::FujinetLibSessionAdapter::state_size_bytes() > 0,
+              "ON mode must carry fujinet session adapter state");
+#else
 static_assert(fs::FujinetLibSessionAdapter::state_size_bytes() == 0,
               "OFF mode must add zero fujinet session adapter state");
+#endif
 
 static unsigned g_failures = 0;
 

--- a/tests/backends/atari/test_atari_net_seam.cpp
+++ b/tests/backends/atari/test_atari_net_seam.cpp
@@ -63,7 +63,12 @@ static void test_fujinet_seam_surface() {
     CHECK(FujiPlatform::hal::realtime_last_error().status == n::NetStatus::WouldBlock);
 #endif
 
-    // Session seam is independent of the netstream realtime wiring (both modes).
+#if !defined(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
+    // OFF-mode session seam stubs. Independent of the netstream realtime wiring
+    // (both realtime modes). In ON mode the seam delegates to the real
+    // fujinet-lib (network_init/network_open -> SIO), which cannot run here; the
+    // ON-mode session lane is covered by test_atari_fujinet_session_send_nb's
+    // pre-connection guards and validated on hardware by fujinet_session_validate.
     CHECK(FujiPlatform::hal::session_connect_tcp("host", 5000) ==
           n::NetStatus::Ok);
         CHECK(!FujiPlatform::hal::session_connected());
@@ -76,6 +81,15 @@ static void test_fujinet_seam_surface() {
     CHECK(FujiPlatform::hal::session_recv_nb(&io, 1) == n::NetStatus::WouldBlock);
 
         CHECK(FujiPlatform::hal::session_last_error().status == n::NetStatus::WouldBlock);
+#else
+    // ON mode: nullptr host is rejected before any hardware access, so this one
+    // guard is still safe to exercise under the simulator.
+    CHECK(FujiPlatform::hal::session_connect_tcp(nullptr, 5000) ==
+          n::NetStatus::InvalidArgument);
+    CHECK(FujiPlatform::hal::session_recv_nb(nullptr, 1) ==
+          n::NetStatus::InvalidArgument);
+    (void)io;
+#endif
 }
 
 int main() {


### PR DESCRIPTION
The formalized fujinet-lib-llvm checkout restores the upstream directory structure, which splits the headers: fujinet-network.h at the checkout root, fujinet-network-atari.h under atari/src/include. EDGE assumed both lived in one flat src/include and hard-errored at configure time. Detect either layout and add EDGE_FUJINETLIB_ATARI_INCLUDE_DIR for the split case.

Fixing the configure error exposed three latent defects that it had been hiding:

- fujinet_session_fujinetlib.h included the C headers inside namespace atari::fujinet_session. extern "C" sets linkage, not name lookup, so the declarations really were namespaced; whichever TU included first won via the include guards. fujinet_net_test.cpp's own global-scope include therefore became a no-op and network_init was undeclared. Include at global scope.

- EDGE_ATARI_FUJINET_SESSION_FUJINETLIB is a global define, so platform.h pulls the fujinet headers into every target and any target instantiating SessionLane calls into the archive -- but the include path and link line were per-target, so `cmake --build` over the whole tree could never work. Match the scope: global define, global include, global link. The archive is static, so targets that never call it pay nothing.

- The sim suite could not be configured with the backend ON: test_atari_fujinet_session_spec asserted the OFF-mode state size unconditionally, and the ON-branch add_test ran the 6502 ELF natively instead of under mos-sim. test_atari_net_seam asserted stub return values, so with a real backend it called network_init() -> real SIO under a simulator; its session block is now OFF-mode only, mirroring how the file already guards its realtime seam.

Verified: 18 Atari .xex build (5 link libfujinet.a), 47/47 sim tests pass with the backend both ON and OFF. The new library is ABI-identical to the old one (106 exported symbols, none added or removed).

Docs: name the llvm_changes branch of github.com/brad-colbert/fujinet-lib-llvm as the requirement for Atari TCP / the N: device, and drop the stale claim that an llvm-mos build is unpublished. Upstream fujinet-lib is CC65 and will not link under llvm-mos. Also refresh ASSET_PROTOCOL.md, which pinned a hardcoded home directory, an old commit, and the old header layout.