### PR TITLE
Fujinet lib release 4.11.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ working_documents/
 .github/
 bin/
 ATARI_MCP.md
+# Vendored third-party binaries (fujinet-lib release archives)
+third_party/
 # Python bytecode cache
 __pycache__/
 *.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+### Added
+- **`EDGE_FUJINETLIB_ROOT` accepts an unpacked fujinet-lib release archive**, not just a
+  source checkout. A release puts every header and `libfujinet.a` flat at its root; a
+  checkout keeps public headers at the root, per-machine headers under `atari/src/include`,
+  and the archive under `build/`. Both layouts are detected. Validated end to end against a
+  real FujiNet stack with `fujinet-lib-atari-4.11.2-llvm.1`: the `LiveSession` tank demo's
+  streamed playfield renders identically to the `Embedded`-asset build.
+
+### Changed
+- **The fujinet-lib session backend is now wired per target, not globally.**
+  `EDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON` previously applied its define, include path,
+  and archive to *every* target via `add_compile_definitions` / `include_directories` /
+  `link_libraries`. A new `edge_use_fujinetlib_session(<target>)` helper attaches all three
+  to just the targets that use the session lane or branch on the macro, so enabling the
+  option no longer pulls the real adapter and the archive into unrelated demos.
+- `FUJINETLIB_DIR` (the `fujinet_net_test` knob) now defaults from `EDGE_FUJINETLIB_ROOT`,
+  so a single variable configures every fujinet-lib consumer.
+
+### Fixed
+- **`fujinet_session_validate` ignored its configured host.** The `#ifndef` guard around
+  `EDGE_FUJINET_VALIDATE_HOST` was commented out, so the source unconditionally overrode
+  the CMake value with `127.0.0.1` and `-DEDGE_FUJINET_VALIDATE_HOST=` silently did
+  nothing. The demo now connects to the host it was configured with.
+
+### Known Issues
+- **`atari_tank_net_demo` links nondeterministically** (~2-4 failures in 12 with identical
+  inputs): `R_MOS_ADDR8 out of range: 256 ... '.zp.noinit'`. The llvm-mos LTO zero-page
+  allocator targets the whole 96-byte region (`$a0-$ff`) rather than actual demand and
+  intermittently overcommits by one byte. This is a toolchain bug, not an EDGE defect, and
+  no source change fixes it — zero page freed in the demo is immediately reabsorbed, and
+  shrinking the linker script's `zp` region fails every time. Retry the link; `-fno-lto`
+  avoids it at a ~20% size cost and the loss of zero-page globals.
+
 ## [0.9.0] - 2026-07-07
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,12 @@ set(EDGE_FUJINET_VALIDATE_PORT
     "Port used by demo/fujinet_session_validate runtime validation demo")
 
 if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
-    # fujinet-lib ships its public headers (fujinet-network.h) at the checkout
-    # root and its per-machine headers (fujinet-network-atari.h) under
-    # atari/src/include. Older checkouts flattened both into src/include; accept
-    # either so an in-flight checkout keeps configuring.
+    # EDGE_FUJINETLIB_ROOT accepts either shape fujinet-lib comes in:
+    #   * a source checkout — public headers (fujinet-network.h) at the root,
+    #     per-machine headers (fujinet-network-atari.h) under atari/src/include,
+    #     archive under build/. Older checkouts flattened both header sets into
+    #     src/include.
+    #   * an unpacked release archive — every header and libfujinet.a at the root.
     if(EDGE_FUJINETLIB_ROOT)
         if(NOT EDGE_FUJINETLIB_INCLUDE_DIR)
             if(EXISTS "${EDGE_FUJINETLIB_ROOT}/src/include/fujinet-network.h")
@@ -87,7 +89,11 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
             set(EDGE_FUJINETLIB_ATARI_INCLUDE_DIR "${EDGE_FUJINETLIB_ROOT}/atari/src/include")
         endif()
         if(NOT EDGE_FUJINETLIB_LIBRARY)
-            set(EDGE_FUJINETLIB_LIBRARY "${EDGE_FUJINETLIB_ROOT}/build/libfujinet.a")
+            if(EXISTS "${EDGE_FUJINETLIB_ROOT}/build/libfujinet.a")
+                set(EDGE_FUJINETLIB_LIBRARY "${EDGE_FUJINETLIB_ROOT}/build/libfujinet.a")
+            else()
+                set(EDGE_FUJINETLIB_LIBRARY "${EDGE_FUJINETLIB_ROOT}/libfujinet.a")
+            endif()
         endif()
     endif()
 
@@ -245,17 +251,24 @@ set(GENERATE_CHARSET_HEADER_SCRIPT
 
 # fujinetlib — prebuilt static library + headers, used by the fujinet_net_test
 # demo. Built with the same mos-atari8-dos toolchain (see that repo's
-# CMakeLists.txt). Override FUJINETLIB_DIR if the checkout lives elsewhere.
+# CMakeLists.txt). Defaults to EDGE_FUJINETLIB_ROOT so a single variable serves
+# both this demo and the session lane; set FUJINETLIB_DIR only to point this one
+# demo somewhere else. Both layouts are accepted — see EDGE_FUJINETLIB_ROOT above.
 set(FUJINETLIB_DIR ""
-    CACHE PATH "Path to the fujinetlib-llvm checkout")
-# Public headers sit at the checkout root upstream; older checkouts flattened
-# them into src/include.
+    CACHE PATH "Path to the fujinetlib-llvm checkout or unpacked release (defaults to EDGE_FUJINETLIB_ROOT)")
+if(NOT FUJINETLIB_DIR AND EDGE_FUJINETLIB_ROOT)
+    set(FUJINETLIB_DIR "${EDGE_FUJINETLIB_ROOT}")
+endif()
 if(EXISTS "${FUJINETLIB_DIR}/src/include/fujinet-network.h")
     set(FUJINETLIB_INC ${FUJINETLIB_DIR}/src/include)
 else()
     set(FUJINETLIB_INC ${FUJINETLIB_DIR})
 endif()
-set(FUJINETLIB_A   ${FUJINETLIB_DIR}/build/libfujinet.a)
+if(EXISTS "${FUJINETLIB_DIR}/build/libfujinet.a")
+    set(FUJINETLIB_A ${FUJINETLIB_DIR}/build/libfujinet.a)
+else()
+    set(FUJINETLIB_A ${FUJINETLIB_DIR}/libfujinet.a)
+endif()
 
 add_custom_command(
     OUTPUT ${USER_CHARSET_HEADER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,18 +144,30 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
         list(APPEND EDGE_FUJINETLIB_INCLUDE_FLAGS "-I${_fninc}")
     endforeach()
 
-    # The define is global: platform.h pulls <fujinet-network.h> into every
-    # target, and any target instantiating SessionLane calls into the archive.
-    # Header search path and link line therefore have to be global to match.
-    # libfujinet.a is a static archive, so targets that never call it pay
-    # nothing.
-    add_compile_definitions(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB=1)
-    include_directories(${EDGE_FUJINETLIB_INCLUDE_DIRS})
-    link_libraries(${EDGE_FUJINETLIB_LIBRARY})
     message(STATUS "EDGE FujiNet session backend: RealFujinetLib")
     message(STATUS "  include: ${EDGE_FUJINETLIB_INCLUDE_DIRS}")
     message(STATUS "  library: ${EDGE_FUJINETLIB_LIBRARY}")
 endif()
+
+# Opt a single target into the real fujinet-lib session backend: the define selects
+# the real adapter over the stub in fujinet.h, so it must travel together with the
+# header search path and the archive. No-op when the option is OFF.
+#
+# Per-target rather than global, so enabling the option does not compile the real
+# adapter and link a 1.4 MB archive into every unrelated demo. Apply it to any target
+# that instantiates the session lane OR merely branches on the macro — miss one and it
+# silently compiles the stub instead of failing to build.
+function(edge_use_fujinetlib_session tgt)
+    if(NOT EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
+        return()
+    endif()
+    target_compile_definitions(${tgt} PRIVATE EDGE_ATARI_FUJINET_SESSION_FUJINETLIB=1)
+    target_include_directories(${tgt} PRIVATE ${EDGE_FUJINETLIB_INCLUDE_DIRS})
+    get_target_property(_edge_tgt_type ${tgt} TYPE)
+    if(NOT _edge_tgt_type STREQUAL "OBJECT_LIBRARY")
+        target_link_libraries(${tgt} PRIVATE ${EDGE_FUJINETLIB_LIBRARY})
+    endif()
+endfunction()
 
 option(EDGE_ATARI_FUJINET_REALTIME_NETSTREAM
        "Enable the Atari FujiNet realtime Netstream adapter (EDGE-owned translated handler; no external CA65 dependency)"
@@ -402,8 +414,7 @@ if(EDGE_BUILD_DEMO)
         # the distinction impossible to miss: a build-embedded marker, a configure
         # line, and a loud warning for the stub case.
         if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
-            target_include_directories(atari_tank_demo PRIVATE ${EDGE_FUJINETLIB_INCLUDE_DIRS})
-            target_link_libraries(atari_tank_demo PRIVATE ${EDGE_FUJINETLIB_LIBRARY})
+            edge_use_fujinetlib_session(atari_tank_demo)
             target_compile_definitions(atari_tank_demo PRIVATE EDGE_TANK_LIVE_BACKEND_REAL=1)
             message(STATUS "atari_tank_demo LiveSession — Live transport backend: RealFujinetLib")
         else()
@@ -531,9 +542,8 @@ if(EDGE_BUILD_DEMO)
         target_compile_definitions(fujinet_session_validate PRIVATE
             EDGE_FUJINET_VALIDATE_HOST="${EDGE_FUJINET_VALIDATE_HOST}"
             EDGE_FUJINET_VALIDATE_PORT=${EDGE_FUJINET_VALIDATE_PORT})
-        target_include_directories(fujinet_session_validate PRIVATE
-            ${CMAKE_SOURCE_DIR} ${EDGE_FUJINETLIB_INCLUDE_DIRS})
-        target_link_libraries(fujinet_session_validate PRIVATE ${EDGE_FUJINETLIB_LIBRARY})
+        target_include_directories(fujinet_session_validate PRIVATE ${CMAKE_SOURCE_DIR})
+        edge_use_fujinetlib_session(fujinet_session_validate)
         set_target_properties(fujinet_session_validate PROPERTIES
             OUTPUT_NAME "fujinet_session_validate.xex")
         target_link_options(fujinet_session_validate PRIVATE
@@ -741,8 +751,7 @@ if(EDGE_BUILD_DEMO)
     # enabled; otherwise the session HAL is a stub that reports Ok without connecting.
     if(_TDN_SRC EQUAL 2)
         if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
-            target_include_directories(atari_tank_dual_net_demo PRIVATE ${EDGE_FUJINETLIB_INCLUDE_DIRS})
-            target_link_libraries(atari_tank_dual_net_demo PRIVATE ${EDGE_FUJINETLIB_LIBRARY})
+            edge_use_fujinetlib_session(atari_tank_dual_net_demo)
             target_compile_definitions(atari_tank_dual_net_demo PRIVATE EDGE_TANK_LIVE_BACKEND_REAL=1)
             message(STATUS "atari_tank_dual_net_demo LiveSession — session backend: RealFujinetLib")
         else()

--- a/README.md
+++ b/README.md
@@ -173,11 +173,21 @@ For a fuller walkthrough, start with [`/documents/QUICK_START.md`](./documents/Q
   (Netstream) lane needs no external library. See
   [`documents/PLATFORM_ATARI.md`](./documents/PLATFORM_ATARI.md).
 
+  Either unpack a release archive (headers and `libfujinet.a` sit at its root):
+
+  ```sh
+  unzip fujinet-lib-atari-<version>-llvm.<n>.zip -d third_party/fujinet-lib-llvm
+  ```
+
+  or build it from source (archive lands in `build/libfujinet.a`):
+
   ```sh
   git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git
   cmake -S fujinet-lib-llvm -B fujinet-lib-llvm/build   # -> build/libfujinet.a
   cmake --build fujinet-lib-llvm/build
   ```
+
+  `EDGE_FUJINETLIB_ROOT` accepts either layout.
 - **[Docker](https://www.docker.com/)** *(optional)* — runs the isolated UDP peer used
   in the Mode-B networking validation stack.
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -201,13 +201,16 @@ link `libfujinet.a` from the `llvm_changes` branch of
 and will not link under llvm-mos.
 
 ```sh
-# Build the library once:
+# Get the library once — either unpack a release archive:
+unzip fujinet-lib-atari-<version>-llvm.<n>.zip -d third_party/fujinet-lib-llvm
+
+# ...or build it from source:
 git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git
 cmake -S fujinet-lib-llvm -B fujinet-lib-llvm/build
 cmake --build fujinet-lib-llvm/build          # -> build/libfujinet.a
 
 # Atari (requires the FujiNet session lane: EDGE_ATARI_FUJINET_SESSION_FUJINETLIB=ON
-# + EDGE_FUJINETLIB_ROOT pointing at that checkout):
+# + EDGE_FUJINETLIB_ROOT pointing at the unpacked release or the checkout):
 cmake -B build-atari -DCMAKE_TOOLCHAIN_FILE=cmake/atari-toolchain.cmake \
       -DEDGE_BUILD_DEMO=ON -DEDGE_TANK_ASSET_SOURCE=LiveSession \
       -DEDGE_TANK_NET_HOST="192.168.1.10" -DEDGE_TANK_NET_PORT=9000 \

--- a/demo/fujinet_session_validate/README.md
+++ b/demo/fujinet_session_validate/README.md
@@ -36,10 +36,10 @@ Default OFF builds remain unchanged.
 
 ## Host/Port Configuration
 
-Set via compile definitions (with source defaults):
-
-- `EDGE_FUJINET_VALIDATE_HOST` (default: `"192.168.1.100"`)
-- `EDGE_FUJINET_VALIDATE_PORT` (default: `9000`)
+Set via compile definitions. CMake always supplies both, defaulting to the cache
+variables `EDGE_FUJINET_VALIDATE_HOST` (`192.168.1.205`) and
+`EDGE_FUJINET_VALIDATE_PORT` (`9000`); the source falls back to `127.0.0.1:9000`
+only when the demo is compiled outside CMake.
 
 In CMake, pass:
 
@@ -47,7 +47,8 @@ In CMake, pass:
 -DEDGE_FUJINET_VALIDATE_HOST=192.168.1.50 -DEDGE_FUJINET_VALIDATE_PORT=9000
 ```
 
-The build injects these as preprocessor definitions.
+The build injects these as preprocessor definitions. The running demo prints the
+host and port it actually compiled in, so a mismatch is visible on screen.
 
 ## Expected Server
 

--- a/demo/fujinet_session_validate/fujinet_session_validate.cpp
+++ b/demo/fujinet_session_validate/fujinet_session_validate.cpp
@@ -34,9 +34,9 @@ using engine::net::NetStatus;
 
 namespace M = atari;
 
-//#ifndef EDGE_FUJINET_VALIDATE_HOST
+#ifndef EDGE_FUJINET_VALIDATE_HOST
 #define EDGE_FUJINET_VALIDATE_HOST "127.0.0.1"
-//#endif
+#endif
 
 #ifndef EDGE_FUJINET_VALIDATE_PORT
 #define EDGE_FUJINET_VALIDATE_PORT 9000

--- a/demo/tank/ASSET_PROTOCOL.md
+++ b/demo/tank/ASSET_PROTOCOL.md
@@ -195,8 +195,11 @@ that means the llvm-mos build:
 - Atari headers: `<root>/atari/src/include` (`fujinet-network-atari.h`)
 - static library: `<root>/build/libfujinet.a`
 
-Point `EDGE_FUJINETLIB_ROOT` at `<root>`; the include dirs and archive are derived
-for you.
+An unpacked release archive instead puts every header and `libfujinet.a` directly
+at `<root>`.
+
+Point `EDGE_FUJINETLIB_ROOT` at `<root>`; either layout is detected, and the include
+dirs and archive are derived for you.
 
 The CMake variables are configurable; the path above is the validated default,
 not a hard-coded requirement. A focused CMake guard rejects the prohibited legacy

--- a/demo/tank_dual_net/README.md
+++ b/demo/tank_dual_net/README.md
@@ -97,6 +97,11 @@ Phase 1 is TCP over the `N:` device, so it must link `libfujinet.a` from the
 (upstream fujinet-lib is CC65 and will not link under llvm-mos):
 
 ```sh
+# Either unpack a release archive (headers + libfujinet.a at its root)...
+FNL="$PWD/third_party/fujinet-lib-llvm"
+unzip fujinet-lib-atari-<version>-llvm.<n>.zip -d "$FNL"
+
+# ...or build from source (EDGE_FUJINETLIB_ROOT accepts either layout):
 git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git ~/Projects/Atari/fujinet-lib-llvm
 FNL=~/Projects/Atari/fujinet-lib-llvm
 cmake -S "$FNL" -B "$FNL/build" && cmake --build "$FNL/build"   # -> build/libfujinet.a

--- a/demo/tank_net/atari_tank_net_demo.cpp
+++ b/demo/tank_net/atari_tank_net_demo.cpp
@@ -129,10 +129,18 @@ static tank::TankState g_tank = {
 static constexpr u8 kWallColpfMask     = 0x01;          // COLPF0 = walls (white)
 static constexpr u8 kDepotSurroundMask = 0x02 | 0x04;   // COLPF1|COLPF2 = depot box
 
-// Mutable game state bundled into ONE struct so it lands in main RAM (.bss), not
-// the near-full zero page — small separate statics get zp-promoted and overflow it
-// (volatile alone does not prevent promotion; see the tank demo's SimFeed/LiveState
-// bundling). The padding keeps the struct comfortably above the zp-promotion size.
+// Mutable game state bundled into ONE struct (see the tank demo's SimFeed/LiveState
+// bundling for the same idiom).
+//
+// The struct does NOT land in main RAM: LTO promotes g_st wholesale into .zp.bss,
+// bss_anchor and all. Neither the bundling nor the padding prevents that, and neither
+// does volatile. Do not "fix" this by shrinking the struct or forcing a .bss section —
+// the llvm-mos LTO zero-page allocator targets the whole 96-byte region ($a0-$ff)
+// rather than actual demand, so any bytes freed here are immediately refilled by
+// promoting something else. That saturation is why this demo's link intermittently
+// overflows zero page by one byte and fails; the bug is in the toolchain, not here.
+// Verified: freeing 62 bytes changed nothing, and shrinking the linker script's zp
+// region made it fail every time.
 struct GameState {
     tanknet::Adversary adv[kAdvCount];   // network-driven adversaries
     tanknet::AdvRxState adv_rx;      // shared packet-level seq gate (combined snapshot)
@@ -141,7 +149,7 @@ struct GameState {
     u16 tx_seq;
     u8  tx_frame;
     u8  rx_overflow_count;           // saturating RX-overflow events since last TX (echoed)
-    u8  bss_anchor[24];              // force .bss placement (main RAM is plentiful)
+    u8  bss_anchor[24];              // inert: does NOT force .bss placement (see above)
 };
 static GameState g_st = {};
 

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -460,10 +460,16 @@ using Platform = atari::FullUpgrade;   // XL, U1MB, VBXE<>, PokeyMax, NTSC, Fuji
 > **<https://github.com/brad-colbert/fujinet-lib-llvm>**:
 >
 > ```sh
+> # Either unpack a release archive (headers + libfujinet.a at its root)...
+> unzip fujinet-lib-atari-<version>-llvm.<n>.zip -d third_party/fujinet-lib-llvm
+>
+> # ...or build it from source:
 > git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git
 > cmake -S fujinet-lib-llvm -B fujinet-lib-llvm/build
 > cmake --build fujinet-lib-llvm/build          # -> build/libfujinet.a
 > ```
+>
+> `EDGE_FUJINETLIB_ROOT` accepts either layout.
 >
 > That branch retargets the Atari build to llvm-mos. Upstream
 > [FujiNetWIFI/fujinet-lib](https://github.com/FujiNetWIFI/fujinet-lib) builds the

--- a/scripts/run_tank_networked.sh
+++ b/scripts/run_tank_networked.sh
@@ -40,9 +40,12 @@ NET_PORT="${NET_PORT:-9000}"
 FUJINETLIB_ROOT="${FUJINETLIB_ROOT:-$REPO/third_party/fujinet-lib-llvm}"
 LINGER="${LINGER:-10}"
 
-[ -f "$FUJINETLIB_ROOT/build/libfujinet.a" ] || {
+[ -f "$FUJINETLIB_ROOT/build/libfujinet.a" ] || [ -f "$FUJINETLIB_ROOT/libfujinet.a" ] || {
     echo "fujinet-lib not found at: $FUJINETLIB_ROOT (set FUJINETLIB_ROOT)" >&2
-    echo "This demo uses TCP over the N: device, which needs the llvm-mos build:" >&2
+    echo "This demo uses TCP over the N: device, which needs the llvm-mos build." >&2
+    echo "Unpack a release archive there:" >&2
+    echo "  unzip fujinet-lib-atari-<ver>-llvm.<n>.zip -d third_party/fujinet-lib-llvm" >&2
+    echo "or build it from source:" >&2
     echo "  git clone -b llvm_changes https://github.com/brad-colbert/fujinet-lib-llvm.git" >&2
     echo "  cmake -S fujinet-lib-llvm -B fujinet-lib-llvm/build && cmake --build fujinet-lib-llvm/build" >&2
     exit 2; }

--- a/tests/backends/atari/CMakeLists.txt
+++ b/tests/backends/atari/CMakeLists.txt
@@ -11,6 +11,10 @@ add_engine_test(test_atari_interrupt)
 add_engine_test(test_atari_core)
 add_engine_test(test_atari_net_seam)
 add_engine_test(test_atari_fujinet_session_spec)
+# Both branch on EDGE_ATARI_FUJINET_SESSION_FUJINETLIB and must keep exercising
+# the ON path when the option is ON (no-op when it is OFF).
+edge_use_fujinetlib_session(test_atari_net_seam)
+edge_use_fujinetlib_session(test_atari_fujinet_session_spec)
 add_engine_test(test_atari_fujinet_netstream_scaffold)
 add_engine_test(test_netstream_abi_smoke)
 add_engine_test(test_netstream_state_size)
@@ -26,20 +30,16 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
 	add_library(test_atari_fujinet_session_send_nb_obj OBJECT
 		test_atari_fujinet_session_send_nb.cpp)
 	target_include_directories(test_atari_fujinet_session_send_nb_obj PRIVATE
-		${CMAKE_SOURCE_DIR}
-		${EDGE_FUJINETLIB_INCLUDE_DIRS})
-	target_compile_definitions(test_atari_fujinet_session_send_nb_obj PRIVATE
-		EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
+		${CMAKE_SOURCE_DIR})
+	edge_use_fujinetlib_session(test_atari_fujinet_session_send_nb_obj)
 
 	# Linked executable only under mos toolchain.
 	if(CMAKE_CXX_COMPILER MATCHES "mos")
 		add_executable(test_atari_fujinet_session_send_nb
 			test_atari_fujinet_session_send_nb.cpp)
 		target_include_directories(test_atari_fujinet_session_send_nb PRIVATE
-			${CMAKE_SOURCE_DIR}
-			${EDGE_FUJINETLIB_INCLUDE_DIRS})
-		target_link_libraries(test_atari_fujinet_session_send_nb PRIVATE
-			${EDGE_FUJINETLIB_LIBRARY})
+			${CMAKE_SOURCE_DIR})
+		edge_use_fujinetlib_session(test_atari_fujinet_session_send_nb)
 		# The target is 6502 code: run it under the simulator, not natively.
 		add_test(NAME test_atari_fujinet_session_send_nb
 			COMMAND mos-sim $<TARGET_FILE:test_atari_fujinet_session_send_nb>)
@@ -56,8 +56,8 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
 	add_library(edge_fujinetlib_session_smoke_obj OBJECT
 		fujinetlib_session_smoke.cpp)
 	target_include_directories(edge_fujinetlib_session_smoke_obj PRIVATE
-		${CMAKE_SOURCE_DIR}
-		${EDGE_FUJINETLIB_INCLUDE_DIRS})
+		${CMAKE_SOURCE_DIR})
+	edge_use_fujinetlib_session(edge_fujinetlib_session_smoke_obj)
 
 	# Optional link smoke executable. Build this only for mos toolchains,
 	# because host toolchains may not link an Atari-target archive.
@@ -65,10 +65,8 @@ if(EDGE_ATARI_FUJINET_SESSION_FUJINETLIB)
 		add_executable(edge_fujinetlib_session_smoke
 			fujinetlib_session_smoke.cpp)
 		target_include_directories(edge_fujinetlib_session_smoke PRIVATE
-			${CMAKE_SOURCE_DIR}
-			${EDGE_FUJINETLIB_INCLUDE_DIRS})
-		target_link_libraries(edge_fujinetlib_session_smoke PRIVATE
-			${EDGE_FUJINETLIB_LIBRARY})
+			${CMAKE_SOURCE_DIR})
+		edge_use_fujinetlib_session(edge_fujinetlib_session_smoke)
 	endif()
 endif()
 


### PR DESCRIPTION
This pull request refactors how the project integrates and configures `fujinet-lib` support, making it easier to use either a source checkout or an unpacked release archive, and ensuring that only relevant targets link against the library. It also fixes a long-standing configuration bug, updates documentation for clarity, and improves test coverage and build determinism explanations.

**CMake integration and configuration improvements:**

* `EDGE_FUJINETLIB_ROOT` now accepts both an unpacked release archive (headers and `libfujinet.a` at the root) and a source checkout (headers split, archive under `build/`); CMake detects and configures both layouts automatically. (`CMakeLists.txt`, `CHANGELOG.md`, `README.md`, `demo/README.md`, `demo/tank_dual_net/README.md`, `documents/PLATFORM_ATARI.md`, `demo/tank/ASSET_PROTOCOL.md`, `scripts/run_tank_networked.sh`) [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL73-R78) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR92-R96) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL248-R283) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R46) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R190) [[6]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL204-R213) [[7]](diffhunk://#diff-2707f27e8b2f815a24eadb28dc1330546323582a32d60fc83a6aaedffcf4c04aR100-R104) [[8]](diffhunk://#diff-38612f5904fb8c3dc3283d855aa486c7bc5ce02c15edd6b90be1e8424fcf0b99R463-R473) [[9]](diffhunk://#diff-8212ddfda957570486b51abd9162b5d294d3036d5a702fa9bb6f996c1b7e8c4fL198-R202) [[10]](diffhunk://#diff-186b0ab66f114681201b4a168b74695e20914fb8066f3670e1f3468dcb81e7eaL43-R48)
* The fujinet-lib session backend is now attached per-target (via the new `edge_use_fujinetlib_session(<target>)` function) rather than globally, so only demos and tests that need it link against the real adapter and archive. (`CMakeLists.txt`, `tests/backends/atari/CMakeLists.txt`) [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL141-R171) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL392-R417) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL521-R546) [[4]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL731-R754) [[5]](diffhunk://#diff-5bfa5f3d0d11af6d8a94167cb1864d0dced6c97fd43bbba2d00cb730aa6cf6bdR14-R17) [[6]](diffhunk://#diff-5bfa5f3d0d11af6d8a94167cb1864d0dced6c97fd43bbba2d00cb730aa6cf6bdL29-R42)

**Bug fixes:**

* Fixed `fujinet_session_validate` so it now respects the configured host: the CMake definition is no longer ignored in favor of a hardcoded value. (`demo/fujinet_session_validate/fujinet_session_validate.cpp`, `demo/fujinet_session_validate/README.md`, [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R46) [[2]](diffhunk://#diff-aca158c717f50b7376e24154e62f462a3617a7f5fc675ef511c6f2689bde93f6L39-R51) [[3]](diffhunk://#diff-206bda2d7d153f71789538f6b83bb0555b1a98afbb95ffe4dc1677d394f436c4L37-R39)

**Documentation and developer experience:**

* All relevant documentation and usage instructions are updated to reflect the new, more flexible `fujinet-lib` integration and to clarify how to build and configure the demos and tests. (`README.md`, `demo/README.md`, `demo/tank_dual_net/README.md`, `documents/PLATFORM_ATARI.md`, `demo/tank/ASSET_PROTOCOL.md`, `scripts/run_tank_networked.sh`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R190) [[2]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL204-R213) [[3]](diffhunk://#diff-2707f27e8b2f815a24eadb28dc1330546323582a32d60fc83a6aaedffcf4c04aR100-R104) [[4]](diffhunk://#diff-38612f5904fb8c3dc3283d855aa486c7bc5ce02c15edd6b90be1e8424fcf0b99R463-R473) [[5]](diffhunk://#diff-8212ddfda957570486b51abd9162b5d294d3036d5a702fa9bb6f996c1b7e8c4fL198-R202) [[6]](diffhunk://#diff-186b0ab66f114681201b4a168b74695e20914fb8066f3670e1f3468dcb81e7eaL43-R48)
* The nondeterministic zero-page linker failure in `atari_tank_net_demo` is now clearly documented as a toolchain bug, not a source issue, with guidance for workarounds. (`CHANGELOG.md`, `demo/tank_net/atari_tank_net_demo.cpp`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R46) [[2]](diffhunk://#diff-e3c5b86e5537aa53a9278107bf7c43b61957a1ba5f5d8ed39857838696038533L132-R143) [[3]](diffhunk://#diff-e3c5b86e5537aa53a9278107bf7c43b61957a1ba5f5d8ed39857838696038533L144-R152)

**Test improvements:**

* Tests that depend on the fujinet-lib session backend now explicitly opt in via `edge_use_fujinetlib_session`, ensuring coverage of both code paths. (`tests/backends/atari/CMakeLists.txt`) [[1]](diffhunk://#diff-5bfa5f3d0d11af6d8a94167cb1864d0dced6c97fd43bbba2d00cb730aa6cf6bdR14-R17) [[2]](diffhunk://#diff-5bfa5f3d0d11af6d8a94167cb1864d0dced6c97fd43bbba2d00cb730aa6cf6bdL29-R42)