### PR TITLE
Vscroll region buffer line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,24 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
   so a single variable configures every fujinet-lib consumer.
 
 ### Fixed
-- **`fujinet_session_validate` ignored its configured host.** The `#ifndef` guard around
+- **A vertical fine-scroll region truncated the first mode line of the region below
+  it.** The display-list builder set the VSCROLL bit on *every* line of a scroll
+  region, so ANTIC's variable-height exit line — the first line after the flagged
+  zone, displayed at `VSCROL + 1` scanlines (Altirra-measured) — landed on whatever
+  mode line followed the region. In-tree demos never showed it (their scroll region
+  was last, so the truncation fell into vertical blank), but any layout with a region
+  *below* a scroll region had that region's first row shrink, grow, and bob with the
+  scroll phase. A scroll region now terminates itself with a **buffer line**
+  (VSCROLL clear, HSCROLL kept, LMS one map-row stride past the last visible line),
+  so the exit line displays the map row scrolling in at the window's bottom —
+  mirroring the top edge — and every following region renders at full height at
+  every phase. At the bottom map stop the buffer LMS clamps to the last map row
+  (no out-of-map fetch; maps need no padding row). Budget note: a scroll region now
+  occupies a constant `8*height + 1` scanlines instead of a phase-dependent
+  `8*height - VSCROL` — see "Scrolling on Atari" in `documents/PLATFORM_ATARI.md`
+  and ADR-036. Verified by extended mos-sim construction tests and headless Altirra
+  phase sweeps (new regression demo `atari_vscroll_split_test`); the tank demo
+  (region-last layout) is pixel-identical before/after. The `#ifndef` guard around
   `EDGE_FUJINET_VALIDATE_HOST` was commented out, so the source unconditionally overrode
   the CMake value with `127.0.0.1` and `-DEDGE_FUJINET_VALIDATE_HOST=` silently did
   nothing. The demo now connects to the host it was configured with.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The canonical version number lives in [`engine/version.h`](engine/version.h);
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-14
+
 ### Added
 - **`EDGE_FUJINETLIB_ROOT` accepts an unpacked fujinet-lib release archive**, not just a
   source checkout. A release puts every header and `libfujinet.a` flat at its root; a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -907,6 +907,29 @@ if(MOS_ATARI8_CXX)
         VERBATIM)
     add_custom_target(atari_scroll_test DEPENDS ${SCROLL_TEST_XEX})
 
+    # ── Vertical-scroll split-layout demo (atari_vscroll_split_test.xex) ──
+    # Regression guard for the scroll-region exit-line defect (ADR-036): a
+    # scrolled viewport with fixed text rows BELOW it, sweeping every VSCROL
+    # phase. Build with EXTRA -DEDGE_VSWEEP_BOTTOM for the bottom-stop variant.
+    #
+    #   cmake --build build --target atari_vscroll_split_test
+    set(VSCROLL_SPLIT_XEX ${CMAKE_BINARY_DIR}/atari_vscroll_split_test.xex)
+    set(VSCROLL_SPLIT_MAP ${CMAKE_BINARY_DIR}/atari_vscroll_split_test.map)
+    add_custom_command(
+        OUTPUT ${VSCROLL_SPLIT_XEX}
+        COMMAND ${MOS_ATARI8_CXX}
+                -std=c++20 -fno-exceptions -fno-rtti -Os -Wall -Wextra
+                -I${CMAKE_SOURCE_DIR}
+                ${CMAKE_SOURCE_DIR}/demo/atari_vscroll_split_test.cpp
+                -o ${VSCROLL_SPLIT_XEX}
+                -Wl,--Map=${VSCROLL_SPLIT_MAP}
+        DEPENDS ${CMAKE_SOURCE_DIR}/demo/atari_vscroll_split_test.cpp
+                ${EDGE_ENGINE_HEADERS}
+        BYPRODUCTS ${VSCROLL_SPLIT_MAP}
+        COMMENT "Building Atari XEX demo (atari_vscroll_split_test.xex)"
+        VERBATIM)
+    add_custom_target(atari_vscroll_split_test DEPENDS ${VSCROLL_SPLIT_XEX})
+
     # ── VBXE Phase 4a bring-up smoke test (atari_vbxe_bringup.xex) ───────
     #   cmake -B build -DEDGE_VBXE_BRINGUP_MODE=2 ...   # 0=bars, 1=solid, 2=probe
     #   cmake --build build --target atari_vbxe_bringup  # -> build/atari_vbxe_bringup.xex

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EDGE (Eight-bit Damned! Game Engine)
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](./CHANGELOG.md) for version history.
 
 EDGE is a C++20 game engine for constrained 6502-class systems, built around a small, deterministic, compile-time configured API instead of a heavy runtime.
 The project is Atari-first today, but its architecture is intended to support additional 6502-family platforms over time. Game code is written against portable engine subsystems while hardware details live behind a platform HAL and compile-time capability profiles.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Hardware validation demo (`atari_hw_test.xex`)
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 A minimal Atari 8-bit program that drives every engine subsystem at once, so
 the engine's live ANTIC path can be confirmed on real hardware / emulators

--- a/demo/atari_vscroll_split_test.cpp
+++ b/demo/atari_vscroll_split_test.cpp
@@ -1,0 +1,123 @@
+// demo/atari_vscroll_split_test.cpp — vertical fine-scroll SPLIT-layout
+// validation demo: a scrolled viewport with fixed text rows BELOW it.
+//
+// This is the layout shape that exposed the scroll-region exit-line defect: the
+// region after a vertically fine-scrolled zone is ANTIC's variable-height exit
+// line, so without the region's own terminating buffer line the first text row
+// under the viewport shrinks and grows with the VSCROL phase. The in-tree
+// scroll demo (atari_scroll_test.cpp) has its HUD ABOVE the region, so it never
+// showed the defect; this demo is the regression guard for regions below.
+//
+// The demo runs an unattended sweep holding each vertical fine-scroll phase
+// (VSCROL 0..7) for kHold frames, cycling forever, and renders everything a
+// headless screenshot needs to *measure* the behavior:
+//
+//   map row 1  (top visible row)  : full-width inverse band — its visible height
+//                                   is the zone's top truncation (8 - VSCROL).
+//   map row 12 (mid window)       : full-width inverse band — a full-height
+//                                   8-scanline reference for pixel scaling.
+//   map row 23 (row scrolling in) : inverse at map cols 8..17 ("left window") —
+//                                   visible only on the region's buffer line,
+//                                   growing with VSCROL (the bottom-edge mirror
+//                                   of the top truncation).
+//   HUD row 0                     : inverse at cols 24..39 ("right window") —
+//                                   the first fixed row below the region. Must
+//                                   be a full 8 scanlines at every phase.
+//   HUD row 1                     : the current phase, drawn as (VSCROL+1)
+//                                   inverse blocks at cols 0,2,..,14 so a
+//                                   screenshot self-labels which phase it caught.
+//
+// Build with -DEDGE_VSWEEP_BOTTOM to hold the camera at the bottom stop instead
+// of sweeping: the last map row (31) carries an inverse band at map cols 20..29
+// ("centre window") to show the buffer line's clamped repeat of the last row
+// (centre band reads 8+1 scanlines; without the clamp the buffer line would
+// fetch out-of-map RAM).
+
+#include <stdint.h>
+
+#include <engine/platform/atari/platform.h>
+#include <engine/core.h>
+
+using engine::u8;
+using engine::u16;
+namespace M = atari;
+
+using Platform = atari::Platform<
+    atari::Machine::XL,
+    atari::RAM::Baseline,
+    atari::gfx::Baseline,
+    atari::Sound::Mono,
+    atari::TV::NTSC>;
+
+static constexpr u16 kMapW = 64;
+static constexpr u16 kMapH = 32;
+static constexpr u8  kVis  = 22;
+
+struct SplitScreen {
+    // Region 0: the 22-row scrolled viewport. Region 1: a fixed 2-row Mode-2 HUD
+    // BELOW it — the region the zone's exit line would truncate.
+    using display = engine::DisplayLayout<
+        engine::ScrollRegion<engine::TextRegion<M::Mode::MODE_2, kVis>, kMapW, kMapH>,
+        engine::TextRegion<M::Mode::MODE_2, 2>>;
+};
+
+struct GameConfig {
+    using screens = engine::ScreenSet<SplitScreen>;
+    static constexpr u8 max_sprites    = 1;
+    static constexpr u8 sound_channels = 1;
+};
+
+using Game = engine::Core<Platform, GameConfig>;
+
+static engine::TileMap<kMapW, kMapH> g_map;
+
+static constexpr u8 kInv = 0x80;   // inverse space: a solid full-height block
+
+static void fill_map() {
+    for (u16 r = 0; r < kMapH; ++r) {
+        for (u16 c = 0; c < kMapW; ++c) {
+            u8 t = M::ascii_to_internal('.');
+            if (r == 1 || r == 12)                   t = kInv;   // full-width bands
+            if (r == 23 && c >= 8  && c <= 17)       t = kInv;   // buffer-line band (left)
+            if (r == kMapH - 1 && c >= 20 && c <= 29) t = kInv;  // bottom-stop band (centre)
+            g_map.set_tile(c, r, t);
+        }
+    }
+}
+
+static void frame_step(const engine::Input&) {
+#ifdef EDGE_VSWEEP_BOTTOM
+    // Hold the camera at the bottom stop: coarse row = kMapH - kVis, phase 0.
+    Game::scroll.set(0, (kMapH - kVis) * 8);
+    const u8 phase = 0;
+#else
+    // Hold each vertical phase for kHold frames, cycling 0..7. The coarse row
+    // stays 1 throughout (y = 8..15), so only the fine phase changes.
+    static u16 g_frame = 0;
+    constexpr u16 kHold = 120;   // frames per phase (~2 s NTSC)
+    const u8 phase = static_cast<u8>((g_frame / kHold) % 8);
+    Game::scroll.set(0, static_cast<u16>(8 + phase));
+    ++g_frame;
+#endif
+
+    // HUD row 0: the truncation-measurement band (right half). Static content,
+    // rewritten each frame for robustness.
+    auto& hud = Game::region<1>();
+    for (u8 c = 24; c < 40; ++c) hud.put_char(c, 0, kInv);
+    // HUD row 1: phase label — (phase+1) blocks at even columns.
+    for (u8 i = 0; i < 8; ++i)
+        hud.put_char(static_cast<u8>(2 * i), 1, i <= phase ? kInv : 0);
+}
+
+int main() {
+    Game::init();
+
+    Platform::hal::set_color_pf(4, 0x90);   // COLBK  : dark blue background
+    Platform::hal::set_color_pf(2, 0x90);   // COLPF2 : text background
+    Platform::hal::set_color_pf(1, 0x0E);   // COLPF1 : text luminance (white)
+
+    fill_map();
+    Game::scroll_map(g_map);
+
+    Game::run(frame_step);
+}

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -1,6 +1,6 @@
 # API Design
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 The user-facing API for the engine. This document describes what
 a game author writes. Internal engine implementation details are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 System design, component relationships, and the abstraction
 boundaries that make the engine portable across 6502 platforms

--- a/docs/CONSTRAINTS.md
+++ b/docs/CONSTRAINTS.md
@@ -1,6 +1,6 @@
 # Constraints
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Hardware budgets, platform targets, and non-negotiable rules that
 every design decision must respect.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1865,3 +1865,59 @@ The mode is covered by host regression tests
 a Y crossing, and it is validated live in the tank_net demo on Altirra Mode B. The
 multiplexer's own latent single-zone swap (the same Y-sort reassignment for ≤ 4
 multiplexed sprites) is unchanged and remains a known issue for multiplexed games.
+
+## ADR-036: Vertical Scroll Zones Self-Terminate with a Buffer Line
+
+**Status:** Accepted
+
+**Context:**
+ANTIC delimits vertical fine scroll with the display list itself: the
+consecutive mode lines carrying the VSCROLL bit form the scrolled zone, and
+VSCROL truncates the zone's two *boundary* lines. Altirra-measured (phase sweep
+0..7, split layout): the first flagged line displays only its bottom
+`8 - VSCROL` scanlines, and the **first line after the zone — the first
+instruction without the bit — is the zone's exit line**, displayed
+bottom-anchored at `VSCROL + 1` scanlines (glyph rows 0..VSCROL). The builder
+used to set VSCROLL on every line of a `ScrollRegion` through the last, so the
+exit line landed on whatever mode line *followed* the region. Every in-tree
+demo placed its scroll region last in the layout — the exit line fell into the
+JVB and vertical blank, invisible — but the first consumer layout with a text
+region *below* a scroll region had its first HUD row shrink and grow with the
+scroll phase (a blinking, vertically bobbing row).
+
+**Decision:**
+A scroll region terminates itself: `DisplayProgram::build()` emits the region's
+`height` lines with VSCROLL set **plus one buffer line with VSCROLL clear**,
+whose LMS points one map-row stride past the last visible line. The buffer line
+participates in `scroll_lms_pos[]`, so `patch_scroll()` strides it with the
+zone; at the bottom stop (`coarse_row == map_height - height`, the
+ScrollManager's clamp) its LMS is clamped to the map's **last** row. The buffer
+line keeps DL_HSCROLL.
+
+**Rationale:**
+The variable-height exit line is unavoidable hardware behaviour; the only
+question is what it displays. Landing it inside the region on the *incoming*
+map row makes the bottom edge mirror the top edge (the row scrolls in as
+`VSCROL + 1` scanlines while the top row scrolls out to `8 - VSCROL`) — the
+seamless behaviour a scrolled window wants — and guarantees every following
+region's lines display at full height at every phase. DL_HSCROLL stays set
+because the line displays map content: it must match the zone's widened fetch
+and horizontal phase or its pixels would shift against the rows above. The
+bottom-stop clamp (repeat the last row rather than fetch past the map) keeps
+the engine's existing no-legal-camera-position-fetches-out-of-map invariant
+(`tests/generic/test_mode4_geometry.cpp::test_no_oob_lms`) without demanding
+consumers pad their maps; at the stop (fine phase 0 there) it shows exactly one
+repeated scanline.
+
+**Consequences:**
+A scroll region now occupies a **constant `8*height + 1` scanlines** (8-scanline
+modes) instead of the old phase-dependent `8*height - VSCROL`; layouts must
+budget the extra line (all in-tree layouts re-checked: worst case 217 of the
+240-scanline ANTIC limit). The display list grows by one 3-byte LMS per scroll
+region and `scroll_lms_pos[]` by one entry. Verified by mos-sim construction
+tests (buffer-line opcode/stride, bottom-stop clamp, following-region bytes
+untouched) and on Altirra with `demo/atari_vscroll_split_test.cpp`: the first
+row below the region measures a full 8 scanlines with a fixed top edge at every
+VSCROL phase (pre-fix: `VSCROL + 1` scanlines, bottom-anchored), and the tank
+demo (region-last layout) is pixel-identical before/after. See the "Scrolling
+on Atari" section of `documents/PLATFORM_ATARI.md`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 Decisions made during design, with rationale. These explain the
 "why" behind architectural choices and document tradeoffs.

--- a/documents/API_REFERENCE.md
+++ b/documents/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # EDGE API Reference
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This reference is organized in two layers:
 

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -1,6 +1,6 @@
 # EDGE Atari Platform Guide
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This document describes the first concrete EDGE backend: the Atari 8-bit family.
 

--- a/documents/PLATFORM_ATARI.md
+++ b/documents/PLATFORM_ATARI.md
@@ -277,6 +277,30 @@ not visible. Reserve a margin column in your map. This is intentional hardware
 behaviour, captured in ADR-027 of [`docs/DECISIONS.md`](../docs/DECISIONS.md) and
 demonstrated by `atari_scroll_test`.
 
+### Vertical scroll and the region's scanline budget
+
+ANTIC's vertical fine scroll truncates the two *boundary* lines of the scrolled
+zone: the first line shows only its bottom `8 - VSCROL` scanlines, and the first
+line *after* the zone is a variable-height "exit" line of `VSCROL + 1`
+scanlines. So that this exit line never lands on the region that follows (which
+would make that region's first row shrink and grow as the camera fine-scrolls),
+the engine terminates every scroll region with its own **buffer line**: an extra
+mode line, fine-scroll-flagged for horizontal only, that displays the top of the
+map row scrolling in at the window's bottom edge.
+
+Budget consequence: a scroll region occupies a **constant `8 x height + 1`
+scanlines** (for 8-scanline modes) — one scanline more than `height` text rows —
+at every scroll phase. Example: a 22-row scrolled viewport plus a 2-row text HUD
+is `22*8 + 1 + 16 = 193` scanlines after the standard top blanks, comfortably
+inside ANTIC's 240-scanline display ceiling.
+
+At the bottom edge of the map (camera at its lowest stop) the buffer line
+repeats one scanline of the map's last row instead of fetching past the map —
+no out-of-map memory is ever displayed, and maps need no spare padding row.
+Rationale and measurements: ADR-036 of
+[`docs/DECISIONS.md`](../docs/DECISIONS.md); demonstrated by
+`atari_vscroll_split_test` (a viewport with a text HUD *below* it).
+
 ## Sound on Atari
 
 EDGE sound effects describe a note's timbre with the generic `engine::audio::Waveform` enum:

--- a/documents/QUICK_START.md
+++ b/documents/QUICK_START.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 This guide introduces EDGE from the engine author's point of view first, then shows the current concrete setup using the Atari backend.
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 # EDGE Engine Documentation
 
-> **Applies to EDGE v0.9.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
+> **Applies to EDGE v0.10.0** — see [CHANGELOG](../CHANGELOG.md) for version history.
 
 EDGE is a C++ engine for building games and interactive applications on constrained 6502-class systems.
 

--- a/engine/platform/atari/display_list.h
+++ b/engine/platform/atari/display_list.h
@@ -36,7 +36,8 @@ namespace detail {
 // Base display-list length for `Layout` assuming one LMS per region (no 4K
 // crossings): 3 blank-line instructions + per region (1 mode/LMS byte + 2 LMS
 // address bytes + height-1 mode bytes) + a 3-byte JVB. A scroll region instead
-// emits one LMS (3 bytes) per visible line, so it contributes 3*height.
+// emits one LMS (3 bytes) per visible line PLUS one for its exit buffer line
+// (see build()), so it contributes 3*(height+1).
 template <typename Layout>
 constexpr u16 display_list_base_size() {
     u16 s = 3 + 3;
@@ -45,7 +46,7 @@ constexpr u16 display_list_base_size() {
             // Overlay region: ceil(H/8) blank instructions, no mode lines / LMS.
             s += static_cast<u16>((Layout::region_height[i] + 7) / 8);
         } else if (Layout::region_is_scroll[i]) {
-            s += static_cast<u16>(3 * Layout::region_height[i]);
+            s += static_cast<u16>(3 * (Layout::region_height[i] + 1));
         } else {
             s += static_cast<u16>(Layout::region_height[i]) + 2;
         }
@@ -73,30 +74,42 @@ constexpr u16 display_list_capacity() {
     return s;
 }
 
-// Worst-case total LMS count: a scroll region emits one LMS per visible line; a
-// normal region emits one plus its potential 4K crossings.
+// Worst-case total LMS count: a scroll region emits one LMS per visible line
+// plus one for its exit buffer line; a normal region emits one plus its
+// potential 4K crossings.
 template <typename Layout>
 constexpr u16 max_lms_count() {
     u16 n = 0;
     for (u8 i = 0; i < Layout::region_count; ++i) {
         if (Layout::region_is_overlay[i]) continue;   // overlays emit no LMS
         n += Layout::region_is_scroll[i]
-                 ? static_cast<u16>(Layout::region_height[i])
+                 ? static_cast<u16>(Layout::region_height[i] + 1)
                  : static_cast<u16>(1 + lms_crossings_max(Layout::region_ram[i]));
     }
     // Min 1 so a pure-overlay layout never declares a zero-length lms_pos[] array.
     return n < 1 ? 1 : n;
 }
 
-// Total scroll LMS (one per visible line of every scroll region). Sized at least
-// 1 so DisplayProgram::scroll_lms_pos[] is never a zero-length array.
+// Total scroll LMS (one per visible line of every scroll region, plus one per
+// region for its exit buffer line). Sized at least 1 so
+// DisplayProgram::scroll_lms_pos[] is never a zero-length array.
 template <typename Layout>
 constexpr u16 max_scroll_lms_count() {
     u16 n = 0;
     for (u8 i = 0; i < Layout::region_count; ++i) {
-        if (Layout::region_is_scroll[i]) n += Layout::region_height[i];
+        if (Layout::region_is_scroll[i]) n += static_cast<u16>(Layout::region_height[i] + 1);
     }
     return n < 1 ? 1 : n;
+}
+
+// Map height (rows) of the first scroll region, or 0 if the layout has none.
+// patch_scroll() uses it to clamp the buffer line's LMS at the bottom map edge.
+template <typename Layout>
+constexpr u16 scroll_map_height() {
+    for (u8 i = 0; i < Layout::region_count; ++i) {
+        if (Layout::region_is_scroll[i]) return Layout::region_map_height[i];
+    }
+    return 0;
 }
 
 } // namespace detail
@@ -209,7 +222,26 @@ struct DisplayProgram {
                 // (each line reloads the full address anyway). The addresses here
                 // are placeholders against `screen_base`; scroll_map() repoints
                 // them at the bound map via patch_scroll().
+                //
+                // The display hardware's vertical-scroll contract makes the first
+                // line AFTER the flagged zone the zone's exit line: it displays at
+                // a height that varies with the fine-scroll phase (complementing
+                // the first zone line's top truncation). If that exit line were
+                // whatever mode line follows the region, a following region's
+                // first line would shrink and grow with the phase (Altirra-
+                // measured: it displays only its top VSCROL+1 scanlines). So the
+                // region terminates ITSELF with one extra buffer line, VSCROLL
+                // clear, whose LMS points one map-row stride past the last visible
+                // line: the variable-height exit line then shows the top of the
+                // row scrolling in at the window's bottom edge (mirroring the top
+                // edge) and every following mode line displays at full height at
+                // every phase. The buffer line keeps DL_HSCROLL: it displays map
+                // content, so it must match the zone's widened fetch and hold the
+                // same horizontal phase as the lines above it. Cost: the region
+                // occupies a constant 8*height+1 scanlines (for an 8-scanline
+                // mode) instead of a phase-dependent 8*height - VSCROL.
                 const u8  op     = static_cast<u8>(mode | DL_LMS | DL_HSCROLL | DL_VSCROLL);
+                const u8  buf_op = static_cast<u8>(mode | DL_LMS | DL_HSCROLL);
                 const u16 stride = Layout::region_map_width[r];
                 u16 line_start   = static_cast<u16>(screen_base + Layout::offset(r));
                 for (u8 i = 0; i < Layout::region_height[r]; ++i) {
@@ -218,6 +250,7 @@ struct DisplayProgram {
                     if (i == 0) region_lms_pos[r] = pos;
                     line_start = static_cast<u16>(line_start + stride);
                 }
+                scroll_lms_pos[scroll_lms_count++] = emit_load(p, buf_op, line_start);
                 continue;
             }
 
@@ -288,11 +321,28 @@ struct DisplayProgram {
         // frame rate (it runs every frame); the incremental form keeps it inside one
         // frame. Result is byte-identical to `map_base + (coarse_row+i)*map_width +
         // coarse_col` for every i.
-        u16 a = static_cast<u16>(map_base + coarse_row * map_width + coarse_col);
-        for (u16 i = 0; i < scroll_lms_count; ++i) {
-            dst[scroll_lms_pos[i]]     = lo(a);
-            dst[scroll_lms_pos[i] + 1] = hi(a);
-            a = static_cast<u16>(a + map_width);
+        //
+        // The final entry is the region's buffer line (see build()): it strides one
+        // further row so the variable-height exit line shows the row scrolling in.
+        // At the bottom stop (coarse_row == map_height - height, the ScrollManager's
+        // clamp) that row is one past the map, so its LMS is clamped to the map's
+        // last row instead — the exit line then repeats up to one scanline of the
+        // last visible row rather than fetching out-of-map RAM, keeping the engine's
+        // no-legal-camera-position-fetches-out-of-map invariant. (Single scroll
+        // region per layout, like the rest of the scroll binding.)
+        if (scroll_lms_count != 0) {
+            constexpr u16 map_h = detail::scroll_map_height<Layout>();
+            const u16 buf = static_cast<u16>(scroll_lms_count - 1);
+            u16 a = static_cast<u16>(map_base + coarse_row * map_width + coarse_col);
+            for (u16 i = 0; i < buf; ++i) {
+                dst[scroll_lms_pos[i]]     = lo(a);
+                dst[scroll_lms_pos[i] + 1] = hi(a);
+                a = static_cast<u16>(a + map_width);
+            }
+            if (static_cast<u16>(coarse_row + buf) >= map_h)
+                a = static_cast<u16>(a - map_width);
+            dst[scroll_lms_pos[buf]]     = lo(a);
+            dst[scroll_lms_pos[buf] + 1] = hi(a);
         }
         if constexpr (double_buffered) front_b = static_cast<u8>(!front_b);
 #ifdef EDGE_SCROLL_RASTERBAR

--- a/engine/version.h
+++ b/engine/version.h
@@ -10,8 +10,8 @@
 // EDGE follows Semantic Versioning (https://semver.org/): MAJOR.MINOR.PATCH.
 
 #define EDGE_VERSION_MAJOR 0
-#define EDGE_VERSION_MINOR 9
+#define EDGE_VERSION_MINOR 10
 #define EDGE_VERSION_PATCH 0
-#define EDGE_VERSION_STRING "0.9.0"
+#define EDGE_VERSION_STRING "0.10.0"
 
 #endif // ENGINE_VERSION_H

--- a/tests/backends/atari/test_atari_scroll.cpp
+++ b/tests/backends/atari/test_atari_scroll.cpp
@@ -5,10 +5,13 @@
 //
 // The portable split math lives in tests/generic/test_scroll.cpp. Here we test
 // the ANTIC-specific half: that atari::DisplayProgram emits one LMS per visible
-// scroll line (with the HSCROLL/VSCROLL bits) striding by the map width, that
-// patch_scroll() rewrites those addresses for a coarse offset, and that
-// ScreenManager::apply_scroll() drives it end-to-end (including suspend gating)
-// while a non-scroll region in the same layout still emits a single LMS.
+// scroll line (with the HSCROLL/VSCROLL bits) striding by the map width plus a
+// VSCROLL-clear buffer line terminating the zone (so the variable-height exit
+// line never lands on a following region), that patch_scroll() rewrites those
+// addresses for a coarse offset (clamping the buffer line at the bottom map
+// edge), and that ScreenManager::apply_scroll() drives it end-to-end (including
+// suspend gating) while a non-scroll region in the same layout still emits a
+// single LMS with no scroll bits.
 
 #include <stdint.h>
 #include <stdio.h>
@@ -82,6 +85,11 @@ using Layout = ScrollScreen::display;
 // Scroll-line opcode: Mode 2 | LMS | HSCROLL | VSCROLL.
 static constexpr u8 SCROLL_OP =
     static_cast<u8>(0x02 | M::DL_LMS | M::DL_HSCROLL | M::DL_VSCROLL);
+// Buffer-line opcode (the zone's self-terminating exit line): VSCROLL clear so
+// the variable-height exit falls on it, HSCROLL kept so it matches the zone's
+// widened fetch and horizontal phase.
+static constexpr u8 BUFFER_OP =
+    static_cast<u8>(0x02 | M::DL_LMS | M::DL_HSCROLL);
 
 // ── Runtime harness ────────────────────────────────────────────────────
 
@@ -117,15 +125,22 @@ static atari::DisplayProgram<Layout> g_dl;   // ~80 bytes -> static, not stack
 static void test_scroll_build() {
     g_dl.build(0x4000, 0x4000);
 
-    // 22 scroll LMS + 1 for the HUD region = 23 total (no 4K crossing here).
-    CHECK(g_dl.scroll_lms_count == VIS);
-    CHECK(g_dl.lms_count == VIS + 1);
+    // 22 zone lines + 1 buffer line, + 1 for the HUD region (no 4K crossing here).
+    CHECK(g_dl.scroll_lms_count == VIS + 1);
+    CHECK(g_dl.lms_count == VIS + 2);
 
-    // Every scroll line carries LMS | HSCROLL | VSCROLL.
-    for (u16 i = 0; i < g_dl.scroll_lms_count; ++i) {
+    // Every visible zone line carries LMS | HSCROLL | VSCROLL.
+    for (u16 i = 0; i < VIS; ++i) {
         const u16 pos = g_dl.scroll_lms_pos[i];
         CHECK(g_dl.bytes[pos - 1] == SCROLL_OP);
     }
+    // The trailing buffer line terminates the zone: VSCROLL clear, HSCROLL kept,
+    // LMS one map-row stride past the last visible line.
+    const u16 bpos = g_dl.scroll_lms_pos[VIS];
+    CHECK(g_dl.bytes[bpos - 1] == BUFFER_OP);
+    CHECK((g_dl.bytes[bpos - 1] & M::DL_VSCROLL) == 0);
+    CHECK(read16(g_dl.bytes, bpos) ==
+          static_cast<u16>(read16(g_dl.bytes, g_dl.scroll_lms_pos[VIS - 1]) + MAP_W));
     // The scroll region's first LMS is recorded as its region LMS.
     CHECK(g_dl.region_lms_pos[1] == g_dl.scroll_lms_pos[0]);
 
@@ -171,6 +186,56 @@ static void test_patch_scroll() {
         const u16 expect = static_cast<u16>(0x8000 + (2 + i) * MAP_W + 4);
         CHECK(read16(front, g_dl.scroll_lms_pos[i]) == expect);
     }
+
+    // Bottom stop: coarse_row = MAP_H - VIS (the ScrollManager's clamp) puts the
+    // buffer line's natural row one past the map, so its LMS clamps to the map's
+    // last row — same address as the last zone line, never an out-of-map fetch.
+    front = g_dl.patch_scroll(0x8000, MAP_W, /*col*/ 0, /*row*/ MAP_H - VIS);
+    const u16 last_zone = read16(front, g_dl.scroll_lms_pos[VIS - 1]);
+    CHECK(last_zone == static_cast<u16>(0x8000 + (MAP_H - 1) * MAP_W));
+    CHECK(read16(front, g_dl.scroll_lms_pos[VIS]) == last_zone);
+
+    // One row above the stop the buffer line is unclamped (last in-map row).
+    front = g_dl.patch_scroll(0x8000, MAP_W, /*col*/ 0, /*row*/ MAP_H - VIS - 1);
+    CHECK(read16(front, g_dl.scroll_lms_pos[VIS]) ==
+          static_cast<u16>(0x8000 + (MAP_H - 1) * MAP_W));
+}
+
+// ── Split layout: a region BELOW the scroll region is never truncated ──
+//
+// The layout shape that exposed the exit-line defect: the scrolled viewport
+// sits ABOVE fixed text rows. The zone must terminate inside the region (the
+// buffer line), so the following region's mode lines carry no scroll bits and
+// display at full height at every fine-scroll phase.
+
+struct SplitScreen {
+    using display = DisplayLayout<
+        ScrollRegion<TextRegion<M::Mode::MODE_2, VIS>, MAP_W, MAP_H>,
+        TextRegion<M::Mode::MODE_2, 2>>;
+};
+
+static atari::DisplayProgram<SplitScreen::display> g_split_dl;
+
+static void test_split_layout_build() {
+    g_split_dl.build(0x4000, 0x4000);
+
+    CHECK(g_split_dl.scroll_lms_count == VIS + 1);
+    CHECK(g_split_dl.lms_count == VIS + 2);
+
+    // Zone lines flagged; the buffer line ends the zone before the HUD.
+    for (u16 i = 0; i < VIS; ++i)
+        CHECK(g_split_dl.bytes[g_split_dl.scroll_lms_pos[i] - 1] == SCROLL_OP);
+    const u16 bpos = g_split_dl.scroll_lms_pos[VIS];
+    CHECK(g_split_dl.bytes[bpos - 1] == BUFFER_OP);
+
+    // The HUD below is untouched: its LMS is the instruction immediately after
+    // the buffer line, carries no scroll bits, and its second line is a plain
+    // full-height mode byte.
+    const u16 hud = g_split_dl.region_lms_pos[1];
+    CHECK(hud == bpos + 3);
+    CHECK(g_split_dl.bytes[hud - 1] == (0x02 | M::DL_LMS));
+    CHECK((g_split_dl.bytes[hud - 1] & (M::DL_VSCROLL | M::DL_HSCROLL)) == 0);
+    CHECK(g_split_dl.bytes[hud + 2] == 0x02);
 }
 
 // ── ScreenManager.apply_scroll drives the live list + suspend gating ───
@@ -225,6 +290,7 @@ static void test_apply_scroll() {
 int main() {
     test_scroll_build();
     test_patch_scroll();
+    test_split_layout_build();
     test_apply_scroll();
 
     if (g_failures == 0) {


### PR DESCRIPTION
This pull request introduces EDGE v0.10.0, focusing on a major fix for vertical fine-scroll regions on Atari platforms and related documentation updates. The most significant change is that scroll regions now self-terminate with a buffer line, addressing a display bug when fixed text rows appear below a scrolled viewport. This release also adds a regression demo and updates documentation to reflect the new version and behavior.

**Vertical fine-scroll region fixes and validation:**
- Scroll regions now terminate with a buffer line to prevent the first line of the region below from being truncated or bobbing with the scroll phase. This ensures that layouts with regions below a scroll region render correctly at all scroll phases. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL33-R52) [[2]](diffhunk://#diff-76c8ad7e7848cedc2c34d0329338565fe969ae6eb3b2aadefc2e8173e1e43014L39-R40) [[3]](diffhunk://#diff-76c8ad7e7848cedc2c34d0329338565fe969ae6eb3b2aadefc2e8173e1e43014L48-R49)
- Added a new regression demo, `atari_vscroll_split_test.cpp`, and corresponding CMake target to validate and demonstrate the buffer line behavior and prevent regressions. [[1]](diffhunk://#diff-5df0730e3949c5191c0392e9a49135eb88804fd4ec7a92ee8f1a74113f001b40R1-R123) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR910-R932)

**Documentation and versioning:**
- Bumped documentation and readme version references to v0.10.0 across all docs and changelogs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-ddbd72c00fdf2bf68dc455453bc81a1ad80be9018af263c28b367985a40dc98cL3-R3) [[3]](diffhunk://#diff-0237b3d7fe1c8fa8e17881af69a003519f78956a5040d9e04bdbc9017125e042L3-R3) [[4]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L3-R3) [[5]](diffhunk://#diff-5aa90ada9e14c6a3188620b196900b68fed5edc6e4e8f192a6e29d0384fd3c6dL3-R3) [[6]](diffhunk://#diff-1ea199fcea0d29740c9df691b542888c877d1c76a4fda36b130b92c9039f5433L3-R3) [[7]](diffhunk://#diff-06902fedfd31968a421d08fc272d3a331dbd2987f514d4b96429943b4ab5f33cL3-R3) [[8]](diffhunk://#diff-38612f5904fb8c3dc3283d855aa486c7bc5ce02c15edd6b90be1e8424fcf0b99L3-R3) [[9]](diffhunk://#diff-b1b484de02794082600e79848bdf85fed4c26408fc1b36fb451beb48866d64d7L3-R3) [[10]](diffhunk://#diff-48492ab448322dc75b3414244c16ea64f9498bb9185bff4a0cb5c1d26c991306L3-R3)
- Added a detailed changelog entry for the vertical fine-scroll fix and the new buffer line behavior.
- Documented the technical rationale and consequences of the buffer line fix in a new architecture decision record (ADR-036).
- Expanded the Atari platform guide with a section explaining the scanline budget and buffer line for vertical scroll regions, referencing the new demo and ADR.